### PR TITLE
fix: 지출/수입 목록 뒤로가기 시 필터·페이지 상태 복원

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ TASK.md
 # Git worktrees
 .worktrees/
 backend/scripts/reset_and_import.py
+
+# Auto Claude data directory
+.auto-claude/

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -16,19 +16,29 @@
   <!-- Leaf -->
   <path d="M 34 1 Q 44 -4 46 5 Q 40 9 35 4 Z" fill="#22c55e"/>
   <!-- Row 1 -->
-  <circle cx="24" cy="18" r="9" fill="url(#g1)" stroke="#6D28D9" stroke-width="0.5"/>
-  <circle cx="40" cy="18" r="9" fill="url(#g2)" stroke="#6D28D9" stroke-width="0.5"/>
+  <circle cx="24" cy="15" r="7" fill="url(#g1)" stroke="#6D28D9" stroke-width="0.5"/>
+  <circle cx="40" cy="15" r="7" fill="url(#g2)" stroke="#6D28D9" stroke-width="0.5"/>
   <!-- Row 2 -->
-  <circle cx="16" cy="33" r="9" fill="url(#g2)" stroke="#6D28D9" stroke-width="0.5"/>
-  <circle cx="32" cy="33" r="9" fill="url(#g1)" stroke="#6D28D9" stroke-width="0.5"/>
-  <circle cx="48" cy="33" r="9" fill="url(#g1)" stroke="#6D28D9" stroke-width="0.5"/>
+  <circle cx="16" cy="28" r="7" fill="url(#g2)" stroke="#6D28D9" stroke-width="0.5"/>
+  <circle cx="32" cy="28" r="7" fill="url(#g1)" stroke="#6D28D9" stroke-width="0.5"/>
+  <circle cx="48" cy="28" r="7" fill="url(#g1)" stroke="#6D28D9" stroke-width="0.5"/>
   <!-- Row 3 -->
-  <circle cx="24" cy="48" r="9" fill="url(#g1)" stroke="#6D28D9" stroke-width="0.5"/>
-  <circle cx="40" cy="48" r="9" fill="url(#g2)" stroke="#6D28D9" stroke-width="0.5"/>
-  <!-- Row 4 -->
-  <circle cx="32" cy="60" r="9" fill="url(#g2)" stroke="#6D28D9" stroke-width="0.5"/>
+  <circle cx="24" cy="41" r="7" fill="url(#g1)" stroke="#6D28D9" stroke-width="0.5"/>
+  <circle cx="40" cy="41" r="7" fill="url(#g2)" stroke="#6D28D9" stroke-width="0.5"/>
   <!-- Highlights -->
-  <ellipse cx="21" cy="15" rx="3" ry="2" fill="white" opacity="0.35" transform="rotate(-20 21 15)"/>
-  <ellipse cx="37" cy="15" rx="3" ry="2" fill="white" opacity="0.35" transform="rotate(-20 37 15)"/>
-  <ellipse cx="29" cy="30" rx="3" ry="2" fill="white" opacity="0.35" transform="rotate(-20 29 30)"/>
+  <ellipse cx="21" cy="12" rx="2.5" ry="1.8" fill="white" opacity="0.35" transform="rotate(-20 21 12)"/>
+  <ellipse cx="37" cy="12" rx="2.5" ry="1.8" fill="white" opacity="0.35" transform="rotate(-20 37 12)"/>
+  <ellipse cx="29" cy="25" rx="2.5" ry="1.8" fill="white" opacity="0.35" transform="rotate(-20 29 25)"/>
+  <!-- Ledger book -->
+  <!-- Cover -->
+  <rect x="4" y="50" width="56" height="13" rx="3" fill="#4C1D95"/>
+  <!-- Pages area -->
+  <rect x="11" y="51" width="49" height="11" rx="2" fill="#EDE9FE"/>
+  <!-- Spine -->
+  <rect x="4" y="50" width="8" height="13" rx="2" fill="#3B0764"/>
+  <!-- Horizontal lines (ledger) -->
+  <line x1="14" y1="55" x2="58" y2="55" stroke="#8B5CF6" stroke-width="0.8" opacity="0.6"/>
+  <line x1="14" y1="59" x2="58" y2="59" stroke="#8B5CF6" stroke-width="0.8" opacity="0.6"/>
+  <!-- Vertical column separator -->
+  <line x1="48" y1="51" x2="48" y2="61" stroke="#8B5CF6" stroke-width="0.7" opacity="0.4"/>
 </svg>

--- a/frontend/public/pwa-icon.svg
+++ b/frontend/public/pwa-icon.svg
@@ -1,4 +1,54 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
-  <rect width="512" height="512" rx="64" fill="#f59e0b"/>
-  <text x="256" y="360" font-family="system-ui, -apple-system, sans-serif" font-size="320" font-weight="700" fill="white" text-anchor="middle">H</text>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7C3AED"/>
+      <stop offset="100%" stop-color="#4C1D95"/>
+    </linearGradient>
+    <radialGradient id="g1" cx="35%" cy="35%" r="65%">
+      <stop offset="0%" stop-color="#DDD6FE"/>
+      <stop offset="50%" stop-color="#A78BFA"/>
+      <stop offset="100%" stop-color="#7C3AED"/>
+    </radialGradient>
+    <radialGradient id="g2" cx="35%" cy="35%" r="65%">
+      <stop offset="0%" stop-color="#EDE9FE"/>
+      <stop offset="50%" stop-color="#C4B5FD"/>
+      <stop offset="100%" stop-color="#8B5CF6"/>
+    </radialGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="512" height="512" rx="80" fill="url(#bg)"/>
+  <!-- Stem -->
+  <path d="M 256 75 Q 248 46 272 36" stroke="#16a34a" stroke-width="10" fill="none" stroke-linecap="round"/>
+  <!-- Leaf -->
+  <path d="M 272 36 Q 348 12 356 60 Q 304 72 272 50 Z" fill="#22c55e"/>
+  <!-- Row 1 -->
+  <circle cx="208" cy="130" r="52" fill="url(#g1)"/>
+  <circle cx="304" cy="130" r="52" fill="url(#g2)"/>
+  <!-- Row 2 -->
+  <circle cx="156" cy="234" r="52" fill="url(#g2)"/>
+  <circle cx="256" cy="234" r="52" fill="url(#g1)"/>
+  <circle cx="356" cy="234" r="52" fill="url(#g1)"/>
+  <!-- Row 3 -->
+  <circle cx="208" cy="320" r="52" fill="url(#g1)"/>
+  <circle cx="304" cy="320" r="52" fill="url(#g2)"/>
+  <!-- Highlights -->
+  <ellipse cx="188" cy="114" rx="20" ry="14" fill="white" opacity="0.35" transform="rotate(-20 188 114)"/>
+  <ellipse cx="284" cy="114" rx="20" ry="14" fill="white" opacity="0.35" transform="rotate(-20 284 114)"/>
+  <ellipse cx="236" cy="218" rx="20" ry="14" fill="white" opacity="0.35" transform="rotate(-20 236 218)"/>
+  <ellipse cx="188" cy="304" rx="20" ry="14" fill="white" opacity="0.35" transform="rotate(-20 188 304)"/>
+  <!-- Ledger book -->
+  <!-- Cover -->
+  <rect x="36" y="384" width="440" height="96" rx="18" fill="#1E0A42"/>
+  <!-- Pages area -->
+  <rect x="90" y="392" width="378" height="80" rx="12" fill="white" opacity="0.12"/>
+  <!-- Spine -->
+  <rect x="36" y="384" width="56" height="96" rx="16" fill="#150726"/>
+  <!-- Spine divider line -->
+  <line x1="64" y1="390" x2="64" y2="474" stroke="white" stroke-width="1.5" opacity="0.12"/>
+  <!-- Horizontal ledger lines -->
+  <line x1="100" y1="412" x2="468" y2="412" stroke="white" stroke-width="2" opacity="0.22"/>
+  <line x1="100" y1="434" x2="468" y2="434" stroke="white" stroke-width="2" opacity="0.22"/>
+  <line x1="100" y1="456" x2="468" y2="456" stroke="white" stroke-width="2" opacity="0.22"/>
+  <!-- Vertical column separator (debit/credit) -->
+  <line x1="394" y1="398" x2="394" y2="470" stroke="white" stroke-width="1.5" opacity="0.15"/>
 </svg>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -10,11 +10,16 @@ const apiClient = axios.create({
 })
 
 function getCookieToken(): string | null {
+  // 1. 쿠키 우선 (Chrome/Android 등)
   const match = document.cookie.match(/(?:^|; )podo_access_token=([^;]+)/)
-  return match ? match[1] : null
+  if (match) return match[1]
+  // 2. localStorage 폴백 (Safari ITP로 쿠키 공유 불가 시)
+  try { return localStorage.getItem('podo_access_token') } catch { return null }
 }
 
-// 요청 인터셉터: 쿠키에서 토큰을 읽어 Authorization 헤더에 자동 추가
+// 요청 인터셉터: 쿠키/localStorage에서 토큰을 읽어 Authorization 헤더에 자동 추가
+// 참고: AuthContext에도 동일 인터셉터가 등록되며 LIFO로 먼저 실행됨
+//       AuthContext 인터셉터는 tokenRef(in-memory)를 우선 사용 → Safari Private 모드 대응
 apiClient.interceptors.request.use(
   (config) => {
     const token = getCookieToken()

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -11,9 +11,13 @@
  * - effect body에서 동기 setState 호출 금지
  * - user/loading은 token과 loadedToken에서 파생(derived)
  * - 모든 setState는 비동기 콜백(.then, .catch) 내부에서만 호출
+ *
+ * Safari Private 모드 대응:
+ * - tokenRef: 렌더마다 동기적으로 token 미러링 → localStorage/쿠키 없어도 Authorization 헤더 설정
+ * - 401 인터셉터: Domain 쿠키 삭제 금지 → auth.podonest.com 세션 보호 (무한 루프 방지)
  */
 
-import { createContext, useContext, useMemo, useState, useEffect, useCallback } from 'react'
+import { createContext, useContext, useMemo, useState, useEffect, useCallback, useRef } from 'react'
 import type { ReactNode } from 'react'
 import type { User } from '../types'
 import authApi from '../api/auth'
@@ -82,6 +86,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return stored
   })
 
+  // tokenRef: 렌더마다 동기적으로 미러링 (useEffect 없이)
+  // Safari Private 모드에서 localStorage/쿠키 모두 차단되어도 in-memory 토큰으로 Authorization 헤더 설정
+  const tokenRef = useRef<string | null>(token)
+  tokenRef.current = token
+
   // userProfile: API에서 비동기 로드
   const [userProfile, setUserProfile] = useState<User | null>(null)
 
@@ -98,7 +107,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const requestInterceptor = apiClient.interceptors.request.use(
       (config) => {
-        const t = getCookieToken()
+        // tokenRef.current 우선: Safari Private 모드 등 cookie/localStorage 모두 차단된 환경 대응
+        const t = tokenRef.current ?? getCookieToken()
         if (t) {
           config.headers.Authorization = `Bearer ${t}`
         }
@@ -107,12 +117,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       (error) => Promise.reject(error)
     )
 
-    // 401: 토큰 클리어 → ProtectedRoute가 리다이렉트 처리 (이전: 여기서 직접 redirect)
+    // 401: 토큰 클리어 → ProtectedRoute가 리다이렉트 처리
+    // 주의: clearCookieToken()으로 .podonest.com 도메인 쿠키 삭제 금지
+    //   → budget.podonest.com에서 삭제 시 auth.podonest.com 세션까지 파괴 → 무한 루프
     const responseInterceptor = apiClient.interceptors.response.use(
       (response) => response,
       (error) => {
         if (error.response?.status === 401) {
-          clearCookieToken()
+          try { localStorage.removeItem('podo_access_token') } catch { /* 무시 */ }
           setToken(null)
           // user는 token=null 파생으로 자동 null
         }

--- a/frontend/src/pages/ExpenseList.tsx
+++ b/frontend/src/pages/ExpenseList.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useEffect, useState, useMemo } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { Loader2 } from 'lucide-react'
 import { expenseApi } from '../api/expenses'
 import { categoryApi } from '../api/categories'
@@ -85,18 +85,40 @@ export default function ExpenseList() {
   const [members, setMembers] = useState<HouseholdMember[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
-  const [page, setPage] = useState(0)
   const limit = 20
 
-  /* 필터 상태 */
-  const [startDate, setStartDate] = useState('')
-  const [endDate, setEndDate] = useState('')
-  const [categoryId, setCategoryId] = useState<number | undefined>()
-  const [memberUserId, setMemberUserId] = useState<number | undefined>()
+  /* URL 쿼리 파라미터로 필터/페이지 상태 관리 (뒤로가기 시 복원) */
+  const [searchParams, setSearchParams] = useSearchParams()
+  const page = parseInt(searchParams.get('page') ?? '0', 10)
+  const startDate = searchParams.get('start') ?? ''
+  const endDate = searchParams.get('end') ?? ''
+  const categoryId = searchParams.get('cat') ? Number(searchParams.get('cat')) : undefined
+  const memberUserId = searchParams.get('member') ? Number(searchParams.get('member')) : undefined
 
-  /* 정렬 상태 */
-  const [sortField, setSortField] = useState<SortField>('date')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+  /* 정렬 상태 (클라이언트 사이드 — URL에 반영) */
+  const sortField = (searchParams.get('sort') ?? 'date') as SortField
+  const sortDirection = (searchParams.get('dir') ?? 'desc') as SortDirection
+
+  /** URL 파라미터 업데이트 헬퍼 (기존 파라미터 유지, replace로 히스토리 오염 방지) */
+  function setParams(updates: Record<string, string | null>) {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        for (const [key, value] of Object.entries(updates)) {
+          if (value === null || value === '') next.delete(key)
+          else next.set(key, value)
+        }
+        return next
+      },
+      { replace: true }
+    )
+  }
+
+  function setPage(newPage: number) { setParams({ page: newPage === 0 ? null : String(newPage) }) }
+  function setStartDate(val: string) { setParams({ start: val || null, page: null }) }
+  function setEndDate(val: string) { setParams({ end: val || null, page: null }) }
+  function setCategoryId(val: number | undefined) { setParams({ cat: val != null ? String(val) : null, page: null }) }
+  function setMemberUserId(val: number | undefined) { setParams({ member: val != null ? String(val) : null, page: null }) }
 
   /**
    * 지출 목록 조회
@@ -127,10 +149,9 @@ export default function ExpenseList() {
    */
   const handleSort = (field: SortField) => {
     if (sortField === field) {
-      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'))
+      setParams({ dir: sortDirection === 'asc' ? 'desc' : 'asc' })
     } else {
-      setSortField(field)
-      setSortDirection('desc')
+      setParams({ sort: field, dir: 'desc' })
     }
   }
 
@@ -176,8 +197,9 @@ export default function ExpenseList() {
       fetchHouseholdDetail(activeHouseholdId).catch(() => {})
     } else {
       setMembers([])
-      setMemberUserId(undefined)
+      setParams({ member: null })
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeHouseholdId, fetchHouseholdDetail])
 
   // currentHousehold 변경 시 멤버 목록 동기화
@@ -238,7 +260,7 @@ export default function ExpenseList() {
             return (
               <button
                 key={preset.label}
-                onClick={() => { setStartDate(range.start); setEndDate(range.end); setPage(0) }}
+                onClick={() => setParams({ start: range.start, end: range.end, page: null })}
                 className={`px-3 py-1 text-xs rounded-full border transition-colors ${
                   isActive
                     ? 'bg-grape-100 text-grape-700 border-grape-300 font-medium'
@@ -256,7 +278,7 @@ export default function ExpenseList() {
             <input
               type="date"
               value={startDate}
-              onChange={(e) => { setStartDate(e.target.value); setPage(0) }}
+              onChange={(e) => setStartDate(e.target.value)}
               className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
             />
           </div>
@@ -265,7 +287,7 @@ export default function ExpenseList() {
             <input
               type="date"
               value={endDate}
-              onChange={(e) => { setEndDate(e.target.value); setPage(0) }}
+              onChange={(e) => setEndDate(e.target.value)}
               className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
             />
           </div>
@@ -273,7 +295,7 @@ export default function ExpenseList() {
             <label className="block text-xs text-warm-400 mb-1">카테고리</label>
             <select
               value={categoryId ?? ''}
-              onChange={(e) => { setCategoryId(e.target.value ? Number(e.target.value) : undefined); setPage(0) }}
+              onChange={(e) => setCategoryId(e.target.value ? Number(e.target.value) : undefined)}
               className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
             >
               <option value="">전체</option>
@@ -288,7 +310,7 @@ export default function ExpenseList() {
               <label className="block text-xs text-warm-400 mb-1">멤버</label>
               <select
                 value={memberUserId ?? ''}
-                onChange={(e) => { setMemberUserId(e.target.value ? Number(e.target.value) : undefined); setPage(0) }}
+                onChange={(e) => setMemberUserId(e.target.value ? Number(e.target.value) : undefined)}
                 className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
               >
                 <option value="">전체 멤버</option>
@@ -300,7 +322,7 @@ export default function ExpenseList() {
           )}
           <div className="flex items-end">
             <button
-              onClick={() => { setStartDate(''); setEndDate(''); setCategoryId(undefined); setMemberUserId(undefined); setPage(0) }}
+              onClick={() => setParams({ start: null, end: null, cat: null, member: null, page: null })}
               className="w-full sm:w-auto px-4 py-2 text-sm text-warm-500 hover:text-warm-600 underline"
             >
               필터 초기화
@@ -396,7 +418,7 @@ export default function ExpenseList() {
       {/* 페이지네이션 */}
       <div className="flex items-center justify-between">
         <button
-          onClick={() => setPage((p) => Math.max(0, p - 1))}
+          onClick={() => setPage(Math.max(0, page - 1))}
           disabled={page === 0}
           className="px-4 py-2 text-sm border border-warm-300 rounded-lg disabled:opacity-40 hover:bg-warm-50"
         >
@@ -404,7 +426,7 @@ export default function ExpenseList() {
         </button>
         <span className="text-sm text-warm-500">페이지 {page + 1}</span>
         <button
-          onClick={() => setPage((p) => p + 1)}
+          onClick={() => setPage(page + 1)}
           disabled={expenses.length < limit}
           className="px-4 py-2 text-sm border border-warm-300 rounded-lg disabled:opacity-40 hover:bg-warm-50"
         >

--- a/frontend/src/pages/IncomeList.tsx
+++ b/frontend/src/pages/IncomeList.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useEffect, useState, useMemo } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader2, PlusCircle } from 'lucide-react'
 import { incomeApi } from '../api/income'
 import { categoryApi } from '../api/categories'
@@ -84,16 +84,40 @@ export default function IncomeList() {
   const [members, setMembers] = useState<HouseholdMember[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
-  const [page, setPage] = useState(0)
   const limit = 20
 
-  const [startDate, setStartDate] = useState('')
-  const [endDate, setEndDate] = useState('')
-  const [categoryId, setCategoryId] = useState<number | undefined>()
-  const [memberUserId, setMemberUserId] = useState<number | undefined>()
+  /* URL 쿼리 파라미터로 필터/페이지 상태 관리 (뒤로가기 시 복원) */
+  const [searchParams, setSearchParams] = useSearchParams()
+  const page = parseInt(searchParams.get('page') ?? '0', 10)
+  const startDate = searchParams.get('start') ?? ''
+  const endDate = searchParams.get('end') ?? ''
+  const categoryId = searchParams.get('cat') ? Number(searchParams.get('cat')) : undefined
+  const memberUserId = searchParams.get('member') ? Number(searchParams.get('member')) : undefined
 
-  const [sortField, setSortField] = useState<SortField>('date')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+  /* 정렬 상태 (클라이언트 사이드 — URL에 반영) */
+  const sortField = (searchParams.get('sort') ?? 'date') as SortField
+  const sortDirection = (searchParams.get('dir') ?? 'desc') as SortDirection
+
+  /** URL 파라미터 업데이트 헬퍼 */
+  function setParams(updates: Record<string, string | null>) {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        for (const [key, value] of Object.entries(updates)) {
+          if (value === null || value === '') next.delete(key)
+          else next.set(key, value)
+        }
+        return next
+      },
+      { replace: true }
+    )
+  }
+
+  function setPage(newPage: number) { setParams({ page: newPage === 0 ? null : String(newPage) }) }
+  function setStartDate(val: string) { setParams({ start: val || null, page: null }) }
+  function setEndDate(val: string) { setParams({ end: val || null, page: null }) }
+  function setCategoryId(val: number | undefined) { setParams({ cat: val != null ? String(val) : null, page: null }) }
+  function setMemberUserId(val: number | undefined) { setParams({ member: val != null ? String(val) : null, page: null }) }
 
   async function fetchIncomes() {
     setLoading(true)
@@ -118,10 +142,9 @@ export default function IncomeList() {
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
-      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'))
+      setParams({ sort: field, dir: sortDirection === 'asc' ? 'desc' : 'asc', page: null })
     } else {
-      setSortField(field)
-      setSortDirection('desc')
+      setParams({ sort: field, dir: 'desc', page: null })
     }
   }
 
@@ -212,7 +235,7 @@ export default function IncomeList() {
             return (
               <button
                 key={preset.label}
-                onClick={() => { setStartDate(range.start); setEndDate(range.end); setPage(0) }}
+                onClick={() => setParams({ start: range.start, end: range.end, page: null })}
                 className={`px-3 py-1 text-xs rounded-full border transition-colors ${
                   isActive
                     ? 'bg-leaf-100 text-leaf-700 border-leaf-300 font-medium'
@@ -232,10 +255,7 @@ export default function IncomeList() {
             <input
               type="date"
               value={startDate}
-              onChange={(e) => {
-                setStartDate(e.target.value)
-                setPage(0)
-              }}
+              onChange={(e) => setStartDate(e.target.value)}
               className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-leaf-500/30 focus:border-leaf-500"
             />
           </div>
@@ -244,10 +264,7 @@ export default function IncomeList() {
             <input
               type="date"
               value={endDate}
-              onChange={(e) => {
-                setEndDate(e.target.value)
-                setPage(0)
-              }}
+              onChange={(e) => setEndDate(e.target.value)}
               className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-leaf-500/30 focus:border-leaf-500"
             />
           </div>
@@ -255,10 +272,7 @@ export default function IncomeList() {
             <label className="block text-xs text-warm-400 mb-1">카테고리</label>
             <select
               value={categoryId ?? ''}
-              onChange={(e) => {
-                setCategoryId(e.target.value ? Number(e.target.value) : undefined)
-                setPage(0)
-              }}
+              onChange={(e) => setCategoryId(e.target.value ? Number(e.target.value) : undefined)}
               className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-leaf-500/30 focus:border-leaf-500"
             >
               <option value="">전체</option>
@@ -274,10 +288,7 @@ export default function IncomeList() {
               <label className="block text-xs text-warm-400 mb-1">멤버</label>
               <select
                 value={memberUserId ?? ''}
-                onChange={(e) => {
-                  setMemberUserId(e.target.value ? Number(e.target.value) : undefined)
-                  setPage(0)
-                }}
+                onChange={(e) => setMemberUserId(e.target.value ? Number(e.target.value) : undefined)}
                 className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-leaf-500/30 focus:border-leaf-500"
               >
                 <option value="">전체 멤버</option>
@@ -291,13 +302,7 @@ export default function IncomeList() {
           )}
           <div className="flex items-end">
             <button
-              onClick={() => {
-                setStartDate('')
-                setEndDate('')
-                setCategoryId(undefined)
-                setMemberUserId(undefined)
-                setPage(0)
-              }}
+              onClick={() => setParams({ start: null, end: null, cat: null, member: null, page: null })}
               className="w-full sm:w-auto px-4 py-2 text-sm text-warm-500 hover:text-warm-600 underline"
             >
               필터 초기화
@@ -388,7 +393,7 @@ export default function IncomeList() {
       {/* 페이지네이션 */}
       <div className="flex items-center justify-between">
         <button
-          onClick={() => setPage((p) => Math.max(0, p - 1))}
+          onClick={() => setPage(Math.max(0, page - 1))}
           disabled={page === 0}
           className="px-4 py-2 text-sm border border-warm-300 rounded-lg disabled:opacity-40 hover:bg-warm-50"
         >
@@ -396,7 +401,7 @@ export default function IncomeList() {
         </button>
         <span className="text-sm text-warm-500">페이지 {page + 1}</span>
         <button
-          onClick={() => setPage((p) => p + 1)}
+          onClick={() => setPage(page + 1)}
           disabled={incomes.length < limit}
           className="px-4 py-2 text-sm border border-warm-300 rounded-lg disabled:opacity-40 hover:bg-warm-50"
         >


### PR DESCRIPTION
## Summary

- 지출/수입 목록에서 상세 페이지 진입 후 뒤로가기 시, 이전에 보던 페이지·필터·정렬 상태가 URL에 보존되어 정확히 복원됨
- `useState` 기반 필터/페이지/정렬 상태를 `useSearchParams`(URL 쿼리 파라미터)로 전환
- React Router `setSearchParams` 다중 호출 시 덮어쓰기 버그 수정: 여러 파라미터 변경은 단일 `setParams` 호출로 통합
- Safari ITP 환경을 위한 `localStorage` 토큰 폴백 및 Private 모드 대응 `tokenRef` 추가
- 파비콘 및 PWA 아이콘 가계부 테마 디자인으로 업데이트

## Test plan

- [ ] 지출 목록에서 페이지 이동 후 상세 진입 → 뒤로가기 → 이전 페이지로 복원되는지 확인
- [ ] 날짜 필터 적용 후 상세 진입 → 뒤로가기 → 필터 유지되는지 확인
- [ ] 카테고리 필터, 멤버 필터, 정렬 모두 동일하게 복원되는지 확인
- [ ] 날짜 프리셋 버튼 (이번주/지난주/이번달/저번달) 정상 동작 확인
- [ ] 필터 초기화 버튼 정상 동작 확인
- [ ] `npm test` 전체 통과 (408개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)