### PR TITLE
fix: 모바일 거래내역 날짜 필터 UI overflow 수정

### DIFF
--- a/frontend/src/pages/ExpenseList.tsx
+++ b/frontend/src/pages/ExpenseList.tsx
@@ -282,26 +282,26 @@ export default function ExpenseList() {
             )
           })}
         </div>
-        <div className={`grid grid-cols-1 sm:grid-cols-2 ${showMemberFilter ? 'lg:grid-cols-5' : 'lg:grid-cols-4'} gap-4`}>
-          <div>
+        <div className={`grid grid-cols-2 ${showMemberFilter ? 'lg:grid-cols-5' : 'lg:grid-cols-4'} gap-3`}>
+          <div className="min-w-0">
             <label className="block text-xs text-warm-400 mb-1">시작일</label>
             <input
               type="date"
               value={startDate}
               onChange={(e) => setStartDate(e.target.value)}
-              className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+              className="w-full min-w-0 border border-warm-300 rounded-xl px-2 sm:px-3 py-2 text-xs sm:text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
             />
           </div>
-          <div>
+          <div className="min-w-0">
             <label className="block text-xs text-warm-400 mb-1">종료일</label>
             <input
               type="date"
               value={endDate}
               onChange={(e) => setEndDate(e.target.value)}
-              className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+              className="w-full min-w-0 border border-warm-300 rounded-xl px-2 sm:px-3 py-2 text-xs sm:text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
             />
           </div>
-          <div>
+          <div className="min-w-0 col-span-2 sm:col-span-1">
             <label className="block text-xs text-warm-400 mb-1">카테고리</label>
             <div className="relative">
               <select
@@ -319,7 +319,7 @@ export default function ExpenseList() {
           </div>
           {/* 멤버 필터 (가구 활성 + 멤버 2명 이상) */}
           {showMemberFilter && (
-            <div>
+            <div className="min-w-0 col-span-2 sm:col-span-1">
               <label className="block text-xs text-warm-400 mb-1">멤버</label>
               <div className="relative">
                 <select
@@ -336,7 +336,7 @@ export default function ExpenseList() {
               </div>
             </div>
           )}
-          <div className="flex items-end">
+          <div className="flex items-end col-span-2 lg:col-span-1">
             <button
               onClick={() => setParams({ start: null, end: null, cat: null, member: null, page: null })}
               className="w-full sm:w-auto px-4 py-2 text-sm text-warm-500 hover:text-warm-600 underline"

--- a/frontend/src/pages/IncomeList.tsx
+++ b/frontend/src/pages/IncomeList.tsx
@@ -248,27 +248,27 @@ export default function IncomeList() {
           })}
         </div>
         <div
-          className={`grid grid-cols-1 sm:grid-cols-2 ${showMemberFilter ? 'lg:grid-cols-5' : 'lg:grid-cols-4'} gap-4`}
+          className={`grid grid-cols-2 ${showMemberFilter ? 'lg:grid-cols-5' : 'lg:grid-cols-4'} gap-3`}
         >
-          <div>
+          <div className="min-w-0">
             <label className="block text-xs text-warm-400 mb-1">시작일</label>
             <input
               type="date"
               value={startDate}
               onChange={(e) => setStartDate(e.target.value)}
-              className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-leaf-500/30 focus:border-leaf-500"
+              className="w-full min-w-0 border border-warm-300 rounded-xl px-2 sm:px-3 py-2 text-xs sm:text-sm focus:ring-2 focus:ring-leaf-500/30 focus:border-leaf-500"
             />
           </div>
-          <div>
+          <div className="min-w-0">
             <label className="block text-xs text-warm-400 mb-1">종료일</label>
             <input
               type="date"
               value={endDate}
               onChange={(e) => setEndDate(e.target.value)}
-              className="w-full border border-warm-300 rounded-xl px-3 py-2 text-sm focus:ring-2 focus:ring-leaf-500/30 focus:border-leaf-500"
+              className="w-full min-w-0 border border-warm-300 rounded-xl px-2 sm:px-3 py-2 text-xs sm:text-sm focus:ring-2 focus:ring-leaf-500/30 focus:border-leaf-500"
             />
           </div>
-          <div>
+          <div className="min-w-0 col-span-2 sm:col-span-1">
             <label className="block text-xs text-warm-400 mb-1">카테고리</label>
             <div className="relative">
               <select
@@ -287,7 +287,7 @@ export default function IncomeList() {
             </div>
           </div>
           {showMemberFilter && (
-            <div>
+            <div className="min-w-0 col-span-2 sm:col-span-1">
               <label className="block text-xs text-warm-400 mb-1">멤버</label>
               <div className="relative">
                 <select
@@ -306,7 +306,7 @@ export default function IncomeList() {
               </div>
             </div>
           )}
-          <div className="flex items-end">
+          <div className="flex items-end col-span-2 lg:col-span-1">
             <button
               onClick={() => setParams({ start: null, end: null, cat: null, member: null, page: null })}
               className="w-full sm:w-auto px-4 py-2 text-sm text-warm-500 hover:text-warm-600 underline"


### PR DESCRIPTION
- 시작일/종료일을 모바일에서도 2열 나란히 배치 (grid-cols-2)
- 날짜 input에 min-w-0 추가로 overflow 방지
- 모바일 날짜 input 폰트/패딩 축소 (text-xs, px-2)
- 카테고리/멤버 필터는 모바일 full-width 유지 (col-span-2 sm:col-span-1)
- ExpenseList, IncomeList 동일하게 적용