### PR TITLE
feat: 모바일 하단 탭 바 네비게이션 추가 (포도책방 통일 UX)

### DIFF
--- a/frontend/src/components/FloatingActionButton.tsx
+++ b/frontend/src/components/FloatingActionButton.tsx
@@ -35,7 +35,7 @@ export default function FloatingActionButton() {
   }
 
   return (
-    <div ref={ref} className="fixed bottom-6 right-6 z-40 flex flex-col items-end gap-3">
+    <div ref={ref} className="fixed bottom-20 md:bottom-6 right-6 z-40 flex flex-col items-end gap-3">
       {/* 팝오버 메뉴 */}
       {open && (
         <div className="flex flex-col gap-2 mb-1 animate-in fade-in slide-in-from-bottom-2 duration-150">

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-/* 메인 레이아웃 - 사이드바 전용 (포도책방 통일 디자인) */
+/* 메인 레이아웃 - 데스크톱 사이드바 + 모바일 하단 탭 바 (포도책방 통일 디자인) */
 
 import type { } from 'react'
 import { useState, useEffect } from 'react'
@@ -7,7 +7,7 @@ import FloatingActionButton from './FloatingActionButton'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import {
   LayoutDashboard, Receipt, TrendingUp, Settings as SettingsIcon,
-  Mail, Home, Menu, X, ChevronDown, Landmark,
+  Mail, Home, ChevronDown, Landmark,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useChangelog } from '../hooks/useChangelog'
@@ -17,12 +17,11 @@ const navItems: { path: string; label: string; icon: LucideIcon }[] = [
   { path: '/', label: '대시보드', icon: LayoutDashboard },
   { path: '/transactions', label: '가계부', icon: Receipt },
   { path: '/insights', label: '리포트', icon: TrendingUp },
-  { path: '/assets', label: '자산 관리', icon: Landmark },
+  { path: '/assets', label: '자산', icon: Landmark },
   { path: '/settings', label: '설정', icon: SettingsIcon },
 ]
 
 export default function Layout() {
-  const [sidebarOpen, setSidebarOpen] = useState(false)
   const [householdDropdownOpen, setHouseholdDropdownOpen] = useState(false)
   const location = useLocation()
   const {
@@ -42,51 +41,66 @@ export default function Layout() {
     return () => document.removeEventListener('click', handleClick)
   }, [householdDropdownOpen])
 
-  // 라우트 변경 시 모바일 사이드바 닫기
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setSidebarOpen(false)
-  }, [location.pathname])
-
   const { hasUnread: hasUnreadChangelog } = useChangelog()
   const pendingInvitationCount = myInvitations.filter(inv => inv.status === 'pending').length
   const activeHousehold = households.find(h => h.id === activeHouseholdId)
 
+  const isActive = (path: string) =>
+    path === '/' ? location.pathname === '/' : location.pathname.startsWith(path)
+
   return (
     <div className="min-h-screen bg-cream">
-      {/* 모바일 전용 미니 헤더 (48px) */}
+      {/* 모바일 전용 미니 헤더 */}
       <header className="md:hidden bg-white border-b border-warm-200 sticky top-0 z-30 h-12 flex items-center px-4 gap-3">
-        <button
-          onClick={() => setSidebarOpen(true)}
-          className="p-2 rounded-md hover:bg-warm-100"
-          aria-label="메뉴 열기"
-        >
-          <Menu className="w-5 h-5 text-warm-600" />
-        </button>
         <Link to="/" className="font-bold text-grape-700">🍇 포도가계부</Link>
+        {/* 가구 선택 (모바일 헤더) */}
+        {households.length > 1 && (
+          <div className="relative ml-auto">
+            <button
+              onClick={e => { e.stopPropagation(); setHouseholdDropdownOpen(!householdDropdownOpen) }}
+              className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs bg-grape-50 hover:bg-grape-100 text-grape-700 transition-colors"
+            >
+              <Home className="w-3.5 h-3.5" />
+              <span className="font-medium truncate max-w-[100px]">{activeHousehold?.name ?? '가구'}</span>
+              <ChevronDown className="w-3 h-3 text-warm-400" />
+            </button>
+            {householdDropdownOpen && (
+              <div className="absolute right-0 top-full mt-1 bg-white border border-warm-200 rounded-lg shadow-lg z-50 py-1 min-w-[140px]">
+                {households.map(h => (
+                  <button
+                    key={h.id}
+                    onClick={() => { setActiveHouseholdId(h.id); setHouseholdDropdownOpen(false) }}
+                    className={`w-full text-left px-3 py-2 text-sm hover:bg-warm-100 transition-colors truncate ${
+                      h.id === activeHouseholdId ? 'text-grape-700 font-medium bg-grape-50' : 'text-warm-700'
+                    }`}
+                  >
+                    {h.name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {/* 초대 배지 (모바일 헤더) */}
+        {pendingInvitationCount > 0 && (
+          <Link
+            to="/invitations"
+            className={`${households.length <= 1 ? 'ml-auto' : ''} relative p-1.5`}
+          >
+            <Mail className="w-5 h-5 text-warm-600" />
+            <span className="absolute -top-0.5 -right-0.5 bg-red-500 text-white text-[10px] px-1 py-0.5 rounded-full min-w-[16px] text-center leading-none">
+              {pendingInvitationCount}
+            </span>
+          </Link>
+        )}
       </header>
 
       <div className="flex">
-        {/* 사이드바 */}
-        <aside
-          className={`
-            fixed z-20 h-[calc(100vh-3rem)] md:h-screen
-            top-12 md:top-0 md:sticky left-0
-            w-60 bg-cream border-r border-warm-200 p-4 flex flex-col
-            transition-transform duration-200 ease-in-out
-            ${sidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}
-          `}
-        >
-          {/* 데스크톱 앱 타이틀 */}
-          <div className="hidden md:block mb-4">
+        {/* 데스크톱 사이드바 (md 이상에서만 표시) */}
+        <aside className="hidden md:flex md:sticky md:top-0 md:h-screen w-60 bg-cream border-r border-warm-200 p-4 flex-col">
+          {/* 앱 타이틀 */}
+          <div className="mb-4">
             <Link to="/" className="text-2xl font-bold text-grape-700">🍇 포도가계부</Link>
-          </div>
-
-          {/* 모바일 닫기 버튼 */}
-          <div className="md:hidden flex justify-end mb-2">
-            <button onClick={() => setSidebarOpen(false)} className="p-2 rounded-md hover:bg-warm-100">
-              <X className="w-4 h-4 text-warm-500" />
-            </button>
           </div>
 
           {/* 가구 선택 드롭다운 */}
@@ -138,19 +152,17 @@ export default function Layout() {
           {/* 네비게이션 */}
           <nav className="space-y-1 flex-1 overflow-y-auto">
             {navItems.map(item => {
-              const isActive = item.path === '/'
-                ? location.pathname === '/'
-                : location.pathname.startsWith(item.path)
+              const active = isActive(item.path)
               const Icon = item.icon
               return (
                 <Link
                   key={item.path}
                   to={item.path}
-                  aria-current={isActive ? 'page' : undefined}
+                  aria-current={active ? 'page' : undefined}
                   className={`
                     flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium
                     transition-colors relative
-                    ${isActive
+                    ${active
                       ? 'bg-grape-50 text-grape-700 border-l-3 border-grape-500'
                       : 'text-warm-600 hover:bg-warm-100 hover:text-warm-800'
                     }
@@ -186,26 +198,51 @@ export default function Layout() {
               </Link>
             )}
           </nav>
-
         </aside>
 
-        {/* 모바일 오버레이 */}
-        {sidebarOpen && (
-          <div
-            data-testid="sidebar-overlay"
-            className="fixed inset-0 bg-black/30 z-10 md:hidden"
-            onClick={() => setSidebarOpen(false)}
-          />
-        )}
-
         {/* 메인 콘텐츠 */}
-        <main className="flex-1 p-4 pb-24 md:p-6 md:pb-24 max-w-6xl mx-auto w-full">
+        <main className="flex-1 p-4 pb-28 md:p-6 md:pb-24 max-w-6xl mx-auto w-full">
           <Outlet />
         </main>
 
         {/* 플로팅 액션 버튼 */}
         <FloatingActionButton />
       </div>
+
+      {/* 모바일 하단 탭 바 */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-30 bg-white border-t border-warm-200 safe-area-bottom">
+        <div className="flex items-center justify-around h-14">
+          {navItems.map(item => {
+            const active = isActive(item.path)
+            const Icon = item.icon
+            return (
+              <Link
+                key={item.path}
+                to={item.path}
+                aria-current={active ? 'page' : undefined}
+                className={`
+                  flex flex-col items-center justify-center gap-0.5 flex-1 h-full
+                  transition-colors
+                  ${active
+                    ? 'text-grape-600'
+                    : 'text-warm-400 active:text-warm-600'
+                  }
+                `}
+              >
+                <span className="relative">
+                  <Icon className={`w-5 h-5 ${active ? 'stroke-[2.5]' : ''}`} />
+                  {item.path === '/settings' && hasUnreadChangelog && (
+                    <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
+                  )}
+                </span>
+                <span className={`text-[10px] leading-tight ${active ? 'font-semibold' : 'font-medium'}`}>
+                  {item.label}
+                </span>
+              </Link>
+            )
+          })}
+        </div>
+      </nav>
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -59,6 +59,11 @@
   }
 }
 
+/* 모바일 하단 탭 바 safe area (노치/홈바 대응) */
+.safe-area-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
 body {
   margin: 0;
   min-width: 320px;


### PR DESCRIPTION
- 모바일: 햄버거 사이드바 → 하단 5탭 바로 변경
- 데스크톱: 기존 사이드바 그대로 유지
- FAB 위치를 모바일에서 하단 바 위로 조정 (bottom-20)
- safe-area-inset-bottom 대응 (노치/홈바 기기)
- 모바일 헤더에 가구 선택/초대 배지 이동
- '자산 관리' → '자산'으로 탭 라벨 축약

https://claude.ai/code/session_014Z3DAm8hdwcavgnZQnqioc