### PR TITLE
feat: CI 텔레그램 알림 추가 및 CD 배포 메시지 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -120,16 +120,25 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
+          # 머지 커밋이면 PR 제목 추출, 아니면 커밋 메시지 그대로 사용
+          if echo "$COMMIT_MSG" | grep -q "^Merge pull request"; then
+            # "Merge pull request #N from ..." 에서 두 번째 줄(PR 제목) 추출
+            DISPLAY_MSG="$(echo "$COMMIT_MSG" | sed -n '2p' | sed 's/^[[:space:]]*//')"
+            [ -z "$DISPLAY_MSG" ] && DISPLAY_MSG="$COMMIT_MSG"
+          else
+            DISPLAY_MSG="$(echo "$COMMIT_MSG" | head -1)"
+          fi
+
           if [ "$BACKEND_STATUS" = "success" ] && [ "$FRONTEND_STATUS" = "success" ]; then
             KST_TIME="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M KST')"
-            MESSAGE="$(printf '✅ podo-budget 배포 완료\n📝 %s\n🔗 %s\n🕐 %s' \
-              "${COMMIT_MSG}" \
-              "https://github.com/${REPO}/actions/runs/${RUN_ID}" \
+            MESSAGE="$(printf '✅ podo-budget 배포 완료\n📝 %s\n🕐 %s' \
+              "${DISPLAY_MSG}" \
               "${KST_TIME}")"
           else
             MESSAGE="❌ podo-budget 배포 실패 (backend: ${BACKEND_STATUS}, frontend: ${FRONTEND_STATUS})"
             [ -n "$BACKEND_FAILURE" ] && MESSAGE="${MESSAGE}"$'\n'"🔴 Backend: ${BACKEND_FAILURE}"
             [ -n "$FRONTEND_FAILURE" ] && MESSAGE="${MESSAGE}"$'\n'"🔴 Frontend: ${FRONTEND_FAILURE}"
+            MESSAGE="${MESSAGE}"$'\n'"🔗 https://github.com/${REPO}/actions/runs/${RUN_ID}"
           fi
 
           curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,37 @@ jobs:
     uses: ./.github/workflows/ci-test.yml
     with:
       frontend_build_check: true
+
+  # ── CI 결과 알림 ──────────────────────────────────
+  notify-ci-result:
+    name: Notify CI Result
+    needs: [test]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Send Telegram notification
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TEST_STATUS: ${{ needs.test.result }}
+          PR_TITLE: ${{ github.event.pull_request.title || 'Manual trigger' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if [ "$TEST_STATUS" = "success" ]; then
+            MESSAGE="$(printf '✅ podo-budget CI 통과\n📝 #%s %s' \
+              "${PR_NUMBER}" \
+              "${PR_TITLE}")"
+          else
+            MESSAGE="$(printf '❌ podo-budget CI 실패\n📝 #%s %s\n🔗 https://github.com/%s/actions/runs/%s' \
+              "${PR_NUMBER}" \
+              "${PR_TITLE}" \
+              "${REPO}" \
+              "${RUN_ID}")"
+          fi
+
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" || true


### PR DESCRIPTION
## Summary
- CI 테스트 통과/실패 시 텔레그램 알림 추가 (기존에는 CD만 알림)
- CI/CD 실패 시에만 GitHub Actions 링크 포함
- CD 배포 완료 메시지에서 "Merge pull request #N" 대신 실제 PR 제목 표시

## 알림 예시

**CI 통과:**
```
✅ podo-budget CI 통과
📝 #25 feat: PWA 아이콘 및 파비콘 리디자인
```

**CI 실패:**
```
❌ podo-budget CI 실패
📝 #25 feat: PWA 아이콘 및 파비콘 리디자인
🔗 https://github.com/.../actions/runs/...
```

**CD 배포 완료:**
```
✅ podo-budget 배포 완료
📝 feat: PWA 아이콘 및 파비콘 리디자인
🕐 2026-03-13 15:30 KST
```

**CD 배포 실패:**
```
❌ podo-budget 배포 실패 (backend: failure, frontend: success)
🔴 Backend: ...
🔗 https://github.com/.../actions/runs/...
```

## Test plan
- [ ] PR 생성 시 CI 알림 텔레그램으로 수신 확인
- [ ] 머지 후 CD 배포 메시지에서 PR 제목 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)