### PR TITLE
refactor: 대시보드 제거, 가계부를 첫 화면으로 변경 (#36)

### DIFF
--- a/backend/tests/integration/test_api_accounts.py
+++ b/backend/tests/integration/test_api_accounts.py
@@ -1,0 +1,163 @@
+"""계좌 API 통합 테스트"""
+
+import pytest
+
+from app.models.user import User
+
+# --- Helper ---
+
+
+def _account_payload(**overrides):
+    """계좌 생성 페이로드"""
+    base = {
+        "name": "KB국민은행",
+        "type": "bank",
+        "institution": "국민은행",
+        "memo": "급여 계좌",
+    }
+    base.update(overrides)
+    return base
+
+
+# --- CRUD ---
+
+
+@pytest.mark.asyncio
+async def test_create_account(authenticated_client, test_user: User):
+    """계좌 등록 성공"""
+    response = await authenticated_client.post("/api/accounts", json=_account_payload())
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["name"] == "KB국민은행"
+    assert data["type"] == "bank"
+    assert data["institution"] == "국민은행"
+    assert data["memo"] == "급여 계좌"
+    assert data["created_by"] == test_user.id
+
+
+@pytest.mark.asyncio
+async def test_create_brokerage_account(authenticated_client):
+    """증권 계좌 등록"""
+    response = await authenticated_client.post(
+        "/api/accounts",
+        json=_account_payload(name="키움증권", type="brokerage", institution="키움"),
+    )
+    assert response.status_code == 201
+    assert response.json()["type"] == "brokerage"
+
+
+@pytest.mark.asyncio
+async def test_create_account_invalid_type(authenticated_client):
+    """유효하지 않은 계좌 타입으로 생성 시 422"""
+    response = await authenticated_client.post(
+        "/api/accounts",
+        json=_account_payload(type="invalid_type"),
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_accounts(authenticated_client, test_user: User):
+    """계좌 목록 조회"""
+    # 계좌 2개 생성
+    await authenticated_client.post("/api/accounts", json=_account_payload())
+    await authenticated_client.post(
+        "/api/accounts",
+        json=_account_payload(name="키움증권", type="brokerage"),
+    )
+
+    response = await authenticated_client.get("/api/accounts")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_account_by_id(authenticated_client):
+    """계좌 단건 조회"""
+    create_res = await authenticated_client.post("/api/accounts", json=_account_payload())
+    account_id = create_res.json()["id"]
+
+    response = await authenticated_client.get(f"/api/accounts/{account_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == account_id
+    assert response.json()["name"] == "KB국민은행"
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent_account(authenticated_client):
+    """존재하지 않는 계좌 조회 시 404"""
+    response = await authenticated_client.get("/api/accounts/99999")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_account(authenticated_client):
+    """계좌 수정"""
+    create_res = await authenticated_client.post("/api/accounts", json=_account_payload())
+    account_id = create_res.json()["id"]
+
+    response = await authenticated_client.put(
+        f"/api/accounts/{account_id}",
+        json={"name": "KB국민은행 수정", "memo": "수정된 메모"},
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "KB국민은행 수정"
+    assert response.json()["memo"] == "수정된 메모"
+
+
+@pytest.mark.asyncio
+async def test_update_nonexistent_account(authenticated_client):
+    """존재하지 않는 계좌 수정 시 404"""
+    response = await authenticated_client.put(
+        "/api/accounts/99999",
+        json={"name": "없는 계좌"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_account(authenticated_client):
+    """계좌 삭제"""
+    create_res = await authenticated_client.post("/api/accounts", json=_account_payload())
+    account_id = create_res.json()["id"]
+
+    response = await authenticated_client.delete(f"/api/accounts/{account_id}")
+    assert response.status_code == 204
+
+    # 삭제 후 조회하면 404
+    get_res = await authenticated_client.get(f"/api/accounts/{account_id}")
+    assert get_res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_account(authenticated_client):
+    """존재하지 않는 계좌 삭제 시 404"""
+    response = await authenticated_client.delete("/api/accounts/99999")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_other_user_cannot_modify_account(
+    authenticated_client,
+    authenticated_client2,
+    test_user: User,
+    test_user2: User,
+):
+    """다른 사용자의 계좌를 수정/삭제할 수 없다"""
+    # user1이 계좌 생성
+    create_res = await authenticated_client.post("/api/accounts", json=_account_payload())
+    account_id = create_res.json()["id"]
+
+    # user2가 수정 시도 → 404 (권한 없음)
+    put_res = await authenticated_client2.put(
+        f"/api/accounts/{account_id}",
+        json={"name": "해킹 시도"},
+    )
+    assert put_res.status_code == 404
+
+    # user2가 삭제 시도 → 404 (권한 없음)
+    del_res = await authenticated_client2.delete(f"/api/accounts/{account_id}")
+    assert del_res.status_code == 404

--- a/backend/tests/integration/test_api_feedback.py
+++ b/backend/tests/integration/test_api_feedback.py
@@ -1,0 +1,199 @@
+"""피드백 API 통합 테스트"""
+
+import pytest
+
+from app.models.user import User
+
+# --- Helper ---
+
+
+def _feedback_payload(**overrides):
+    """피드백 생성 페이로드"""
+    base = {
+        "type": "feature",
+        "title": "다크모드 추가",
+        "content": "다크모드를 추가해주세요. 밤에 눈이 피로합니다.",
+    }
+    base.update(overrides)
+    return base
+
+
+# --- 피드백 제출 ---
+
+
+@pytest.mark.asyncio
+async def test_create_feedback(authenticated_client, test_user: User):
+    """피드백 제출 성공"""
+    response = await authenticated_client.post("/api/feedback", json=_feedback_payload())
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["title"] == "다크모드 추가"
+    assert data["type"] == "feature"
+    assert data["content"] == "다크모드를 추가해주세요. 밤에 눈이 피로합니다."
+    assert data["status"] == "new"
+    assert data["user_id"] == test_user.id
+
+
+@pytest.mark.asyncio
+async def test_create_bug_feedback(authenticated_client, test_user: User):
+    """버그 신고 제출"""
+    response = await authenticated_client.post(
+        "/api/feedback",
+        json=_feedback_payload(type="bug", title="카테고리 에러", content="카테고리가 표시되지 않습니다"),
+    )
+    assert response.status_code == 201
+    assert response.json()["type"] == "bug"
+
+
+@pytest.mark.asyncio
+async def test_create_feedback_validation(authenticated_client):
+    """필수 필드 누락 시 422 에러"""
+    response = await authenticated_client.post("/api/feedback", json={"type": "feature"})
+    assert response.status_code == 422
+
+
+# --- 내 피드백 조회 ---
+
+
+@pytest.mark.asyncio
+async def test_get_my_feedbacks(authenticated_client, test_user: User):
+    """내 피드백 목록 조회"""
+    # 피드백 2개 생성
+    await authenticated_client.post("/api/feedback", json=_feedback_payload())
+    await authenticated_client.post(
+        "/api/feedback",
+        json=_feedback_payload(type="bug", title="버그 보고", content="버그입니다"),
+    )
+
+    response = await authenticated_client.get("/api/feedback/mine")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 2
+    # 두 피드백 모두 포함되어 있는지 확인
+    titles = {d["title"] for d in data}
+    assert titles == {"다크모드 추가", "버그 보고"}
+
+
+@pytest.mark.asyncio
+async def test_get_my_feedbacks_empty(authenticated_client):
+    """피드백이 없을 때 빈 목록 반환"""
+    response = await authenticated_client.get("/api/feedback/mine")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+# --- 관리자 전체 조회 ---
+
+
+@pytest.mark.asyncio
+async def test_admin_get_all_feedbacks(authenticated_client, test_user: User, db_session):
+    """관리자: 전체 피드백 조회"""
+    # test_user.id를 ADMIN_USER_ID로 설정
+    from app.core.config import settings
+
+    original_admin_id = settings.ADMIN_USER_ID
+    settings.ADMIN_USER_ID = test_user.id
+    try:
+        # 피드백 생성
+        await authenticated_client.post("/api/feedback", json=_feedback_payload())
+
+        response = await authenticated_client.get("/api/feedback")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert len(data) >= 1
+        # username이 포함되어야 함
+        assert data[0]["username"] is not None
+    finally:
+        settings.ADMIN_USER_ID = original_admin_id
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_get_all_feedbacks(authenticated_client, test_user: User):
+    """비관리자: 전체 피드백 조회 시 403"""
+    from app.core.config import settings
+
+    # ADMIN_USER_ID를 test_user가 아닌 다른 ID로 설정
+    original_admin_id = settings.ADMIN_USER_ID
+    settings.ADMIN_USER_ID = test_user.id + 9999
+    try:
+        response = await authenticated_client.get("/api/feedback")
+        assert response.status_code == 403
+    finally:
+        settings.ADMIN_USER_ID = original_admin_id
+
+
+# --- 상태 변경 ---
+
+
+@pytest.mark.asyncio
+async def test_admin_update_feedback_status(authenticated_client, test_user: User):
+    """관리자: 피드백 상태 변경"""
+    from app.core.config import settings
+
+    original_admin_id = settings.ADMIN_USER_ID
+    settings.ADMIN_USER_ID = test_user.id
+    try:
+        # 피드백 생성
+        create_res = await authenticated_client.post("/api/feedback", json=_feedback_payload())
+        feedback_id = create_res.json()["id"]
+
+        # 상태 변경: new → read
+        response = await authenticated_client.patch(
+            f"/api/feedback/{feedback_id}",
+            json={"status": "read"},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "read"
+
+        # 상태 변경: read → done
+        response = await authenticated_client.patch(
+            f"/api/feedback/{feedback_id}",
+            json={"status": "done"},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "done"
+    finally:
+        settings.ADMIN_USER_ID = original_admin_id
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_update_status(authenticated_client, test_user: User):
+    """비관리자: 상태 변경 시 403"""
+    from app.core.config import settings
+
+    original_admin_id = settings.ADMIN_USER_ID
+    settings.ADMIN_USER_ID = test_user.id
+    try:
+        create_res = await authenticated_client.post("/api/feedback", json=_feedback_payload())
+        feedback_id = create_res.json()["id"]
+    finally:
+        settings.ADMIN_USER_ID = test_user.id + 9999
+
+    try:
+        response = await authenticated_client.patch(
+            f"/api/feedback/{feedback_id}",
+            json={"status": "read"},
+        )
+        assert response.status_code == 403
+    finally:
+        settings.ADMIN_USER_ID = original_admin_id
+
+
+@pytest.mark.asyncio
+async def test_update_nonexistent_feedback(authenticated_client, test_user: User):
+    """존재하지 않는 피드백 상태 변경 시 404"""
+    from app.core.config import settings
+
+    original_admin_id = settings.ADMIN_USER_ID
+    settings.ADMIN_USER_ID = test_user.id
+    try:
+        response = await authenticated_client.patch(
+            "/api/feedback/99999",
+            json={"status": "read"},
+        )
+        assert response.status_code == 404
+    finally:
+        settings.ADMIN_USER_ID = original_admin_id

--- a/frontend/src/api/__tests__/admin.test.ts
+++ b/frontend/src/api/__tests__/admin.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @file admin.test.ts
+ * @description 관리자 API 단위 테스트
+ */
+
+import { describe, it, expect } from 'vitest'
+import { adminApi } from '../admin'
+import { mockDashboardStats } from '../../mocks/fixtures'
+
+describe('adminApi', () => {
+  describe('getDashboardStats', () => {
+    it('대시보드 통계를 조회한다', async () => {
+      const response = await adminApi.getDashboardStats()
+      expect(response.data).toEqual(mockDashboardStats)
+      expect(response.data.total_users).toBeGreaterThan(0)
+    })
+  })
+
+  describe('getUserList', () => {
+    it('사용자 목록을 조회한다', async () => {
+      const response = await adminApi.getUserList()
+      expect(response.data.users).toBeDefined()
+      expect(Array.isArray(response.data.users)).toBe(true)
+      expect(response.data.total).toBeGreaterThan(0)
+    })
+
+    it('페이지네이션 파라미터를 전달한다', async () => {
+      const response = await adminApi.getUserList(2, 10)
+      expect(response.data.page).toBe(2)
+      expect(response.data.page_size).toBe(10)
+    })
+  })
+
+  describe('getUserDetail', () => {
+    it('사용자 상세 정보를 조회한다', async () => {
+      const response = await adminApi.getUserDetail(1)
+      expect(response.data.id).toBe(1)
+      expect(response.data.username).toBeDefined()
+    })
+  })
+
+  describe('updateUser', () => {
+    it('사용자 정보를 수정한다', async () => {
+      const response = await adminApi.updateUser(1, { is_active: false })
+      expect(response.data.is_active).toBe(false)
+    })
+  })
+})

--- a/frontend/src/api/__tests__/assets.test.ts
+++ b/frontend/src/api/__tests__/assets.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @file assets.test.ts
+ * @description 자산 관리 API 단위 테스트
+ */
+
+import { describe, it, expect } from 'vitest'
+import { assetApi } from '../assets'
+import {
+  mockAssets,
+  mockAssetSummary,
+  mockAssetSnapshots,
+  mockAssetGoal,
+  mockMonthlySavings,
+} from '../../mocks/fixtures'
+
+describe('assetApi', () => {
+  describe('getAll', () => {
+    it('모든 자산 목록을 조회한다', async () => {
+      const response = await assetApi.getAll()
+      expect(response.data).toEqual(mockAssets)
+      expect(Array.isArray(response.data)).toBe(true)
+    })
+  })
+
+  describe('getById', () => {
+    it('ID로 단일 자산을 조회한다', async () => {
+      const response = await assetApi.getById(1)
+      expect(response.data).toEqual(mockAssets[0])
+    })
+
+    it('존재하지 않는 ID로 조회 시 에러를 반환한다', async () => {
+      await expect(assetApi.getById(999)).rejects.toThrow()
+    })
+  })
+
+  describe('create', () => {
+    it('새로운 자산을 생성한다', async () => {
+      const newAsset = {
+        name: '카카오',
+        type: 'stock_kr',
+        purchase_price: 50000,
+        current_price: 55000,
+      }
+      const response = await assetApi.create(newAsset)
+      expect(response.data).toMatchObject({ name: '카카오', type: 'stock_kr' })
+      expect(response.data.id).toBeDefined()
+    })
+  })
+
+  describe('update', () => {
+    it('자산을 수정한다', async () => {
+      const response = await assetApi.update(1, { name: '삼성전자 수정' })
+      expect(response.data.name).toBe('삼성전자 수정')
+    })
+
+    it('존재하지 않는 ID로 수정 시 에러를 반환한다', async () => {
+      await expect(assetApi.update(999, { name: 'x' })).rejects.toThrow()
+    })
+  })
+
+  describe('delete', () => {
+    it('자산을 삭제한다', async () => {
+      const response = await assetApi.delete(1)
+      expect(response.status).toBe(204)
+    })
+
+    it('존재하지 않는 ID로 삭제 시 에러를 반환한다', async () => {
+      await expect(assetApi.delete(999)).rejects.toThrow()
+    })
+  })
+
+  describe('getSummary', () => {
+    it('자산 요약을 조회한다', async () => {
+      const response = await assetApi.getSummary()
+      expect(response.data).toEqual(mockAssetSummary)
+      expect(response.data.net_worth).toBeDefined()
+    })
+  })
+
+  describe('getSnapshots', () => {
+    it('자산 스냅샷을 조회한다', async () => {
+      const response = await assetApi.getSnapshots()
+      expect(response.data).toEqual(mockAssetSnapshots)
+      expect(Array.isArray(response.data)).toBe(true)
+    })
+  })
+
+  describe('search', () => {
+    it('자산을 검색한다', async () => {
+      const response = await assetApi.search('삼성')
+      expect(Array.isArray(response.data)).toBe(true)
+    })
+  })
+
+  describe('parse', () => {
+    it('자연어로 자산을 파싱한다', async () => {
+      const response = await assetApi.parse('비상금 통장 100만원')
+      expect(response.data.items).toBeDefined()
+      expect(response.data.items.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('goal', () => {
+    it('자산 목표를 조회한다', async () => {
+      const response = await assetApi.getGoal()
+      expect(response.data).toEqual(mockAssetGoal)
+      expect(response.data!.target_net_worth).toBeDefined()
+    })
+
+    it('자산 목표를 설정한다', async () => {
+      const response = await assetApi.setGoal({
+        target_net_worth: 200000000,
+        target_date: '2028-12-31',
+      })
+      expect(response.data.target_net_worth).toBe(200000000)
+    })
+
+    it('자산 목표를 삭제한다', async () => {
+      const response = await assetApi.deleteGoal()
+      expect(response.status).toBe(204)
+    })
+  })
+
+  describe('getMonthlySavings', () => {
+    it('월별 저축 추이를 조회한다', async () => {
+      const response = await assetApi.getMonthlySavings()
+      expect(response.data).toEqual(mockMonthlySavings)
+      expect(Array.isArray(response.data)).toBe(true)
+    })
+  })
+})

--- a/frontend/src/api/__tests__/chat.test.ts
+++ b/frontend/src/api/__tests__/chat.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @file chat.test.ts
+ * @description 자연어 채팅 API 단위 테스트
+ */
+
+import { describe, it, expect } from 'vitest'
+import { chatApi } from '../chat'
+import { mockChatResponse } from '../../mocks/fixtures'
+
+describe('chatApi', () => {
+  describe('sendMessage', () => {
+    it('자연어 메시지를 전송하여 지출을 저장한다', async () => {
+      const response = await chatApi.sendMessage('오늘 점심에 김치찌개 8000원 먹었어')
+      expect(response.data.message).toBe(mockChatResponse.message)
+      expect(response.data.expenses_created).toHaveLength(1)
+      expect(response.data.expenses_created![0].amount).toBe(8000)
+    })
+
+    it('preview 모드에서 파싱 결과만 반환한다', async () => {
+      const response = await chatApi.sendMessage('점심 8000원', undefined, true)
+      expect(response.data.expenses_created).toBeNull()
+      expect(response.data.parsed_items).toBeDefined()
+      expect(response.data.parsed_items!.length).toBeGreaterThan(0)
+    })
+
+    it('householdId를 포함하여 전송한다', async () => {
+      const response = await chatApi.sendMessage('점심 8000원', 1)
+      expect(response.data.message).toBeDefined()
+    })
+
+    it('preview와 householdId를 함께 전송한다', async () => {
+      const response = await chatApi.sendMessage('점심 8000원', 1, true)
+      expect(response.data.parsed_items).toBeDefined()
+    })
+  })
+})

--- a/frontend/src/api/__tests__/feedback.test.ts
+++ b/frontend/src/api/__tests__/feedback.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @file feedback.test.ts
+ * @description 피드백 API 단위 테스트
+ */
+
+import { describe, it, expect } from 'vitest'
+import { feedbackApi } from '../feedback'
+import { mockFeedbacks } from '../../mocks/fixtures'
+
+describe('feedbackApi', () => {
+  describe('create', () => {
+    it('피드백을 제출한다', async () => {
+      const response = await feedbackApi.create({
+        type: 'feature',
+        title: '다크모드',
+        content: '다크모드 추가 부탁드립니다',
+      })
+      expect(response.data).toMatchObject({
+        type: 'feature',
+        title: '다크모드',
+        content: '다크모드 추가 부탁드립니다',
+        status: 'new',
+      })
+      expect(response.data.id).toBeDefined()
+    })
+
+    it('버그 신고를 제출한다', async () => {
+      const response = await feedbackApi.create({
+        type: 'bug',
+        title: '버그 발견',
+        content: '특정 상황에서 에러가 발생합니다',
+      })
+      expect(response.data.type).toBe('bug')
+    })
+  })
+
+  describe('getMine', () => {
+    it('내 피드백 목록을 조회한다', async () => {
+      const response = await feedbackApi.getMine()
+      expect(response.data).toEqual(mockFeedbacks)
+      expect(Array.isArray(response.data)).toBe(true)
+    })
+  })
+
+  describe('getAll', () => {
+    it('전체 피드백 목록을 조회한다 (관리자)', async () => {
+      const response = await feedbackApi.getAll()
+      expect(response.data).toEqual(mockFeedbacks)
+      expect(Array.isArray(response.data)).toBe(true)
+    })
+  })
+
+  describe('updateStatus', () => {
+    it('피드백 상태를 변경한다', async () => {
+      const response = await feedbackApi.updateStatus(1, 'done')
+      expect(response.data.status).toBe('done')
+    })
+  })
+})

--- a/frontend/src/api/__tests__/income.test.ts
+++ b/frontend/src/api/__tests__/income.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @file income.test.ts
+ * @description 수입 API 단위 테스트
+ */
+
+import { describe, it, expect } from 'vitest'
+import { incomeApi } from '../income'
+import { mockIncomes, mockIncomeStats } from '../../mocks/fixtures'
+
+describe('incomeApi', () => {
+  describe('getAll', () => {
+    it('모든 수입 목록을 조회한다', async () => {
+      const response = await incomeApi.getAll()
+      expect(response.data).toEqual(mockIncomes)
+      expect(Array.isArray(response.data)).toBe(true)
+    })
+
+    it('limit 파라미터를 전달하여 수입 목록을 조회한다', async () => {
+      const response = await incomeApi.getAll({ limit: 1 })
+      expect(response.data).toHaveLength(1)
+    })
+
+    it('skip 파라미터를 전달하여 페이지네이션을 처리한다', async () => {
+      const response = await incomeApi.getAll({ skip: 1, limit: 1 })
+      expect(response.data).toHaveLength(1)
+      expect(response.data[0].id).toBe(mockIncomes[1].id)
+    })
+
+    it('start_date 필터로 특정 날짜 이후의 수입만 조회한다', async () => {
+      const response = await incomeApi.getAll({ start_date: '2026-02-05T00:00:00Z' })
+      expect(response.data.every((i) => i.date >= '2026-02-05T00:00:00Z')).toBe(true)
+    })
+
+    it('end_date 필터로 특정 날짜 이전의 수입만 조회한다', async () => {
+      const response = await incomeApi.getAll({ end_date: '2026-02-05T00:00:00Z' })
+      expect(response.data.every((i) => i.date <= '2026-02-05T00:00:00Z')).toBe(true)
+    })
+  })
+
+  describe('getById', () => {
+    it('ID로 단일 수입을 조회한다', async () => {
+      const response = await incomeApi.getById(1)
+      expect(response.data).toEqual(mockIncomes[0])
+      expect(response.data.id).toBe(1)
+    })
+
+    it('존재하지 않는 ID로 조회 시 에러를 반환한다', async () => {
+      await expect(incomeApi.getById(999)).rejects.toThrow()
+    })
+  })
+
+  describe('create', () => {
+    it('새로운 수입을 생성한다', async () => {
+      const newIncome = {
+        amount: 2000000,
+        description: '보너스',
+        date: '2026-03-01T09:00:00Z',
+      }
+      const response = await incomeApi.create(newIncome)
+      expect(response.data).toMatchObject({
+        amount: 2000000,
+        description: '보너스',
+      })
+      expect(response.data.id).toBeGreaterThan(0)
+    })
+  })
+
+  describe('update', () => {
+    it('기존 수입을 수정한다', async () => {
+      const updates = { amount: 4000000, description: '월급 수정' }
+      const response = await incomeApi.update(1, updates)
+      expect(response.data.amount).toBe(4000000)
+      expect(response.data.description).toBe('월급 수정')
+    })
+
+    it('존재하지 않는 ID로 수정 시 에러를 반환한다', async () => {
+      await expect(incomeApi.update(999, { amount: 1000 })).rejects.toThrow()
+    })
+  })
+
+  describe('delete', () => {
+    it('수입을 삭제한다', async () => {
+      const response = await incomeApi.delete(1)
+      expect(response.status).toBe(204)
+    })
+
+    it('존재하지 않는 ID로 삭제 시 에러를 반환한다', async () => {
+      await expect(incomeApi.delete(999)).rejects.toThrow()
+    })
+  })
+
+  describe('getStats', () => {
+    it('기간별 수입 통계를 조회한다', async () => {
+      const response = await incomeApi.getStats('monthly')
+      expect(response.data).toEqual(mockIncomeStats)
+      expect(response.data.period).toBe('monthly')
+      expect(response.data.total).toBeGreaterThan(0)
+    })
+  })
+})

--- a/frontend/src/api/__tests__/recurring.test.ts
+++ b/frontend/src/api/__tests__/recurring.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @file recurring.test.ts
+ * @description 정기 거래 API 단위 테스트
+ */
+
+import { describe, it, expect } from 'vitest'
+import { recurringApi } from '../recurring'
+import { mockRecurringTransactions } from '../../mocks/fixtures'
+
+describe('recurringApi', () => {
+  describe('getAll', () => {
+    it('모든 정기 거래 목록을 조회한다', async () => {
+      const response = await recurringApi.getAll()
+      expect(response.data).toEqual(mockRecurringTransactions)
+      expect(Array.isArray(response.data)).toBe(true)
+    })
+
+    it('타입별 필터로 지출만 조회한다', async () => {
+      const response = await recurringApi.getAll({ type: 'expense' })
+      expect(response.data.every((r) => r.type === 'expense')).toBe(true)
+    })
+
+    it('타입별 필터로 수입만 조회한다', async () => {
+      const response = await recurringApi.getAll({ type: 'income' })
+      expect(response.data.every((r) => r.type === 'income')).toBe(true)
+    })
+  })
+
+  describe('getPending', () => {
+    it('대기 중인 정기 거래 목록을 조회한다', async () => {
+      const response = await recurringApi.getPending()
+      expect(Array.isArray(response.data)).toBe(true)
+      expect(response.data.every((r) => r.is_active)).toBe(true)
+    })
+  })
+
+  describe('getById', () => {
+    it('ID로 단일 정기 거래를 조회한다', async () => {
+      const response = await recurringApi.getById(1)
+      expect(response.data).toEqual(mockRecurringTransactions[0])
+    })
+
+    it('존재하지 않는 ID로 조회 시 에러를 반환한다', async () => {
+      await expect(recurringApi.getById(999)).rejects.toThrow()
+    })
+  })
+
+  describe('create', () => {
+    it('새로운 정기 거래를 생성한다', async () => {
+      const newRecurring = {
+        type: 'expense' as const,
+        amount: 10000,
+        description: '구독료',
+        frequency: 'monthly' as const,
+        day_of_month: 15,
+        start_date: '2026-03-01',
+      }
+      const response = await recurringApi.create(newRecurring)
+      expect(response.data).toMatchObject({
+        description: '구독료',
+        amount: 10000,
+        frequency: 'monthly',
+      })
+      expect(response.data.id).toBeDefined()
+    })
+  })
+
+  describe('update', () => {
+    it('정기 거래를 수정한다', async () => {
+      const updates = { amount: 20000, description: '수정된 구독료' }
+      const response = await recurringApi.update(1, updates)
+      expect(response.data.amount).toBe(20000)
+      expect(response.data.description).toBe('수정된 구독료')
+    })
+
+    it('존재하지 않는 ID로 수정 시 에러를 반환한다', async () => {
+      await expect(recurringApi.update(999, { amount: 1000 })).rejects.toThrow()
+    })
+  })
+
+  describe('delete', () => {
+    it('정기 거래를 삭제한다', async () => {
+      const response = await recurringApi.delete(1)
+      expect(response.status).toBe(204)
+    })
+
+    it('존재하지 않는 ID로 삭제 시 에러를 반환한다', async () => {
+      await expect(recurringApi.delete(999)).rejects.toThrow()
+    })
+  })
+
+  describe('execute', () => {
+    it('정기 거래를 실행한다', async () => {
+      const response = await recurringApi.execute(1)
+      expect(response.data.message).toBeDefined()
+      expect(response.data.created_id).toBeGreaterThan(0)
+      expect(response.data.next_due_date).toBeDefined()
+    })
+
+    it('존재하지 않는 ID로 실행 시 에러를 반환한다', async () => {
+      await expect(recurringApi.execute(999)).rejects.toThrow()
+    })
+  })
+
+  describe('skip', () => {
+    it('정기 거래를 건너뛴다', async () => {
+      const response = await recurringApi.skip(1)
+      expect(response.data.next_due_date).toBeDefined()
+    })
+
+    it('존재하지 않는 ID로 건너뛰기 시 에러를 반환한다', async () => {
+      await expect(recurringApi.skip(999)).rejects.toThrow()
+    })
+  })
+})

--- a/frontend/src/components/__tests__/MiniCalendar.test.tsx
+++ b/frontend/src/components/__tests__/MiniCalendar.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @file MiniCalendar.test.tsx
+ * @description 미니 캘린더 컴포넌트 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MiniCalendar from '../MiniCalendar'
+
+const daySummaries = new Map([
+  ['2026-03-01', { expense: 50000, income: 0 }],
+  ['2026-03-14', { expense: 8000, income: 3500000 }],
+])
+
+function renderCalendar(props: Partial<React.ComponentProps<typeof MiniCalendar>> = {}) {
+  const defaultProps = {
+    year: 2026,
+    month: 2, // 0-indexed, 3월
+    daySummaries,
+    onDateClick: vi.fn(),
+    today: '2026-03-14',
+    ...props,
+  }
+  return { ...render(<MiniCalendar {...defaultProps} />), props: defaultProps }
+}
+
+describe('MiniCalendar', () => {
+  it('요일 헤더를 표시한다', () => {
+    renderCalendar()
+    const weekdays = ['일', '월', '화', '수', '목', '금', '토']
+    weekdays.forEach((day) => {
+      expect(screen.getByText(day)).toBeInTheDocument()
+    })
+  })
+
+  it('현재 월의 날짜를 표시한다', () => {
+    renderCalendar()
+    // 3월은 1~31일
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('15')).toBeInTheDocument()
+    expect(screen.getByText('31')).toBeInTheDocument()
+  })
+
+  it('오늘 날짜에 강조 스타일을 적용한다', () => {
+    renderCalendar()
+    const todayEl = screen.getByText('14')
+    // 오늘 날짜는 bg-grape-600 클래스가 적용됨
+    expect(todayEl.className).toContain('bg-grape-600')
+  })
+
+  it('날짜 클릭 시 onDateClick을 호출한다', async () => {
+    const user = userEvent.setup()
+    const { props } = renderCalendar()
+    await user.click(screen.getByText('14'))
+    expect(props.onDateClick).toHaveBeenCalledWith('2026-03-14')
+  })
+
+  it('지출이 있는 날짜에 지출 금액을 표시한다', () => {
+    renderCalendar()
+    // daySummaries에 3월 1일 50000원 지출이 있음
+    expect(screen.getByText(/-5만/)).toBeInTheDocument()
+  })
+
+  it('수입이 있는 날짜에 수입 금액을 표시한다', () => {
+    renderCalendar()
+    // daySummaries에 3월 14일 350만원 수입이 있음
+    expect(screen.getByText(/\+350만/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/PullToRefresh.test.tsx
+++ b/frontend/src/components/__tests__/PullToRefresh.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @file PullToRefresh.test.tsx
+ * @description 당겨서 새로고침 컴포넌트 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import PullToRefresh from '../PullToRefresh'
+
+describe('PullToRefresh', () => {
+  it('children을 렌더링한다', () => {
+    render(
+      <PullToRefresh onRefresh={vi.fn()}>
+        <div>테스트 콘텐츠</div>
+      </PullToRefresh>,
+    )
+    expect(screen.getByText('테스트 콘텐츠')).toBeInTheDocument()
+  })
+
+  it('기본 상태에서 새로고침 인디케이터가 높이 0으로 숨겨져 있다', () => {
+    const { container } = render(
+      <PullToRefresh onRefresh={vi.fn()}>
+        <div>콘텐츠</div>
+      </PullToRefresh>,
+    )
+    // 인디케이터 컨테이너의 높이가 0
+    const indicator = container.querySelector('.overflow-hidden') as HTMLElement
+    expect(indicator).toBeTruthy()
+    expect(indicator.style.height).toBe('0px')
+  })
+
+  it('컨테이너 ref가 설정된다', () => {
+    const { container } = render(
+      <PullToRefresh onRefresh={vi.fn()}>
+        <div>콘텐츠</div>
+      </PullToRefresh>,
+    )
+    // relative 포지셔닝을 가진 컨테이너가 있어야 함
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).toContain('relative')
+  })
+})

--- a/frontend/src/components/__tests__/RegisterRecurringModal.test.tsx
+++ b/frontend/src/components/__tests__/RegisterRecurringModal.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @file RegisterRecurringModal.test.tsx
+ * @description 반복 거래 등록 모달 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import RegisterRecurringModal from '../RegisterRecurringModal'
+import { mockCategories } from '../../mocks/fixtures'
+
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}))
+
+vi.mock('../../stores/useHouseholdStore', () => ({
+  useHouseholdStore: (selector: (s: { activeHouseholdId: null }) => unknown) =>
+    selector({ activeHouseholdId: null }),
+}))
+
+function renderModal(props: Partial<React.ComponentProps<typeof RegisterRecurringModal>> = {}) {
+  const defaultProps = {
+    type: 'expense' as const,
+    amount: 17000,
+    description: '넷플릭스',
+    category_id: 1,
+    categories: mockCategories,
+    initialDate: '2026-03-14T00:00:00Z',
+    onClose: vi.fn(),
+    onSuccess: vi.fn(),
+    ...props,
+  }
+  return { ...render(<RegisterRecurringModal {...defaultProps} />), props: defaultProps }
+}
+
+describe('RegisterRecurringModal', () => {
+  it('모달 제목을 렌더링한다', () => {
+    renderModal()
+    // 제목과 버튼 모두 "반복 거래 등록" 텍스트를 가짐
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('반복 거래 등록')
+  })
+
+  it('미리 채워진 거래 정보를 표시한다', () => {
+    renderModal()
+    expect(screen.getByText('지출')).toBeInTheDocument()
+    expect(screen.getByText('넷플릭스')).toBeInTheDocument()
+    expect(screen.getByText('₩17,000')).toBeInTheDocument()
+  })
+
+  it('수입 타입을 올바르게 표시한다', () => {
+    renderModal({ type: 'income' })
+    expect(screen.getByText('수입')).toBeInTheDocument()
+  })
+
+  it('반복 빈도 셀렉트를 렌더링한다', () => {
+    renderModal()
+    expect(screen.getByText('반복 빈도')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('매월')).toBeInTheDocument()
+  })
+
+  it('월별 빈도에서 반복 날짜 필드를 표시한다', () => {
+    renderModal()
+    expect(screen.getByText('반복 날짜')).toBeInTheDocument()
+  })
+
+  it('닫기 버튼 클릭 시 onClose를 호출한다', async () => {
+    const user = userEvent.setup()
+    const { props } = renderModal()
+    // X 버튼 클릭
+    const closeButtons = screen.getAllByRole('button')
+    const closeBtn = closeButtons.find((b) => b.querySelector('svg'))!
+    await user.click(closeBtn)
+    expect(props.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('등록 버튼이 렌더링된다', () => {
+    renderModal()
+    expect(screen.getByRole('button', { name: '반복 거래 등록' })).toBeInTheDocument()
+  })
+
+  it('폼 제출 시 API를 호출하고 성공 콜백을 실행한다', async () => {
+    const user = userEvent.setup()
+    const { props } = renderModal()
+    const submitBtn = screen.getByRole('button', { name: '반복 거래 등록' })
+    await user.click(submitBtn)
+    await waitFor(() => {
+      expect(props.onSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('시작일과 종료일 필드를 렌더링한다', () => {
+    renderModal()
+    expect(screen.getByText('시작일')).toBeInTheDocument()
+    expect(screen.getByText('종료일 (선택)')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/TransactionItem.test.tsx
+++ b/frontend/src/components/__tests__/TransactionItem.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @file TransactionItem.test.tsx
+ * @description 거래 항목 컴포넌트 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import TransactionItem from '../TransactionItem'
+import { mockCategories } from '../../mocks/fixtures'
+
+function renderItem(props: Partial<React.ComponentProps<typeof TransactionItem>> = {}) {
+  const defaultProps = {
+    id: 1,
+    type: 'expense' as const,
+    description: '김치찌개',
+    amount: 8000,
+    categoryId: 1,
+    categories: mockCategories,
+    onCategoryClick: vi.fn(),
+    ...props,
+  }
+  return render(
+    <MemoryRouter>
+      <TransactionItem {...defaultProps} />
+    </MemoryRouter>,
+  )
+}
+
+describe('TransactionItem', () => {
+  it('지출 항목의 설명과 금액을 렌더링한다', () => {
+    renderItem()
+    expect(screen.getByText('김치찌개')).toBeInTheDocument()
+    // 금액은 '-' + formatAmount(8000) → '-₩8,000' 형태로 렌더링됨
+    expect(screen.getByText(/-₩8,000/)).toBeInTheDocument()
+  })
+
+  it('수입 항목은 + 부호와 함께 표시한다', () => {
+    renderItem({ type: 'income', description: '월급', amount: 3000000 })
+    expect(screen.getByText('월급')).toBeInTheDocument()
+    expect(screen.getByText(/\+₩3,000,000/)).toBeInTheDocument()
+  })
+
+  it('카테고리 이름을 표시한다', () => {
+    renderItem({ categoryId: 1 })
+    expect(screen.getByText('식비')).toBeInTheDocument()
+  })
+
+  it('카테고리가 없으면 미분류를 표시한다', () => {
+    renderItem({ categoryId: null })
+    expect(screen.getByText('미분류')).toBeInTheDocument()
+  })
+
+  it('지출은 /expenses/:id 링크를 렌더링한다', () => {
+    renderItem({ id: 5, type: 'expense' })
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/expenses/5')
+  })
+
+  it('수입은 /income/:id 링크를 렌더링한다', () => {
+    renderItem({ id: 3, type: 'income' })
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/income/3')
+  })
+
+  it('카테고리 버튼 클릭 시 onCategoryClick을 호출한다', async () => {
+    const user = userEvent.setup()
+    const onCategoryClick = vi.fn()
+    renderItem({ onCategoryClick })
+    await user.click(screen.getByText('식비'))
+    expect(onCategoryClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('정기 거래는 "정기" 뱃지를 표시한다', () => {
+    renderItem({ rawInput: '[정기] 넷플릭스' })
+    expect(screen.getByText('정기')).toBeInTheDocument()
+  })
+
+  it('통계 제외 항목은 "통계제외" 뱃지를 표시한다', () => {
+    renderItem({ excludeFromStats: true })
+    expect(screen.getByText('통계제외')).toBeInTheDocument()
+  })
+
+  it('통계 제외 항목은 opacity가 적용된다', () => {
+    renderItem({ excludeFromStats: true })
+    const link = screen.getByRole('link')
+    expect(link.className).toContain('opacity-50')
+  })
+})

--- a/frontend/src/mocks/fixtures.ts
+++ b/frontend/src/mocks/fixtures.ts
@@ -327,6 +327,140 @@ export const mockAssetSnapshots: AssetSnapshot[] = [
 /**
  * 테스트용 구조화된 인사이트
  */
+/**
+ * 테스트용 자산 목록
+ */
+export const mockAssets = [
+  {
+    id: 1,
+    name: '삼성전자',
+    type: 'stock_kr',
+    is_liability: false,
+    ticker: '005930.KS',
+    quantity: 10,
+    purchase_price: 70000,
+    current_price: 72000,
+    currency: 'KRW',
+    memo: null,
+    household_id: null,
+    user_id: 1,
+    account_id: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-03-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    name: '비상금 통장',
+    type: 'deposit',
+    is_liability: false,
+    ticker: null,
+    quantity: null,
+    purchase_price: 5000000,
+    current_price: 5000000,
+    currency: 'KRW',
+    memo: null,
+    household_id: null,
+    user_id: 1,
+    account_id: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-03-01T00:00:00Z',
+  },
+]
+
+/**
+ * 테스트용 자산 목표
+ */
+export const mockAssetGoal = {
+  id: 1,
+  target_net_worth: 100000000,
+  target_date: '2027-12-31',
+  household_id: null,
+  user_id: 1,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  pace_analysis: {
+    current_net_worth: 85000000,
+    monthly_required: 1250000,
+    months_remaining: 12,
+    on_track: true,
+  },
+}
+
+/**
+ * 테스트용 월별 저축 추이
+ */
+export const mockMonthlySavings = [
+  { month: '2026-01', total_income: 4000000, total_expense: 2500000, net_savings: 1500000 },
+  { month: '2026-02', total_income: 4000000, total_expense: 2800000, net_savings: 1200000 },
+]
+
+/**
+ * 테스트용 자연어 채팅 응답
+ */
+export const mockChatResponse = {
+  message: '김치찌개 8,000원을 식비로 저장했습니다.',
+  expenses_created: [
+    {
+      id: 10,
+      amount: 8000,
+      description: '김치찌개',
+      category_id: 1,
+      raw_input: '오늘 점심에 김치찌개 8000원 먹었어',
+      memo: null,
+      household_id: null,
+      user_id: 1,
+      exclude_from_stats: false,
+      date: '2026-03-14T12:00:00Z',
+      created_at: '2026-03-14T12:00:00Z',
+      updated_at: '2026-03-14T12:00:00Z',
+    },
+  ],
+  incomes_created: null,
+  parsed_items: null,
+  parsed_expenses: null,
+}
+
+/**
+ * 테스트용 피드백 목록
+ */
+export const mockFeedbacks = [
+  {
+    id: 1,
+    user_id: 1,
+    type: 'feature' as const,
+    title: '다크모드 추가',
+    content: '다크모드를 추가해주세요',
+    status: 'new' as const,
+    username: 'testuser',
+    created_at: '2026-03-01T00:00:00Z',
+    updated_at: '2026-03-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    user_id: 1,
+    type: 'bug' as const,
+    title: '카테고리 안 보임',
+    content: '카테고리가 표시되지 않습니다',
+    status: 'read' as const,
+    username: 'testuser',
+    created_at: '2026-03-02T00:00:00Z',
+    updated_at: '2026-03-02T00:00:00Z',
+  },
+]
+
+/**
+ * 테스트용 관리자 대시보드 통계
+ */
+export const mockDashboardStats = {
+  total_users: 150,
+  active_users: 80,
+  telegram_linked_count: 30,
+  total_households: 20,
+  today_active_users: 15,
+  total_expenses_count: 5000,
+  total_income_count: 1500,
+}
+
 export const mockStructuredInsights: StructuredInsights = {
   findings: [
     {

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -15,8 +15,14 @@ import {
   mockRecurringTransactions,
   mockStats,
   mockComparison,
+  mockAssets,
   mockAssetSummary,
   mockAssetSnapshots,
+  mockAssetGoal,
+  mockMonthlySavings,
+  mockChatResponse,
+  mockFeedbacks,
+  mockDashboardStats,
   mockStructuredInsights,
 } from './fixtures'
 
@@ -364,7 +370,30 @@ export const handlers = [
     })
   }),
 
+  // ==================== 자연어 채팅 API ====================
+
+  http.post(`${BASE_URL}/chat`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>
+    if (body.preview) {
+      return HttpResponse.json({
+        ...mockChatResponse,
+        expenses_created: null,
+        parsed_items: [
+          { amount: 8000, category: '식비', description: '김치찌개', date: '2026-03-14', memo: '' },
+        ],
+        parsed_expenses: [
+          { amount: 8000, category: '식비', description: '김치찌개', date: '2026-03-14', memo: '' },
+        ],
+      })
+    }
+    return HttpResponse.json(mockChatResponse)
+  }),
+
   // ==================== 자산 API ====================
+
+  http.get(`${BASE_URL}/assets`, () => {
+    return HttpResponse.json(mockAssets)
+  }),
 
   http.get(`${BASE_URL}/assets/summary`, () => {
     return HttpResponse.json(mockAssetSummary)
@@ -372,6 +401,78 @@ export const handlers = [
 
   http.get(`${BASE_URL}/assets/snapshots`, () => {
     return HttpResponse.json(mockAssetSnapshots)
+  }),
+
+  http.get(`${BASE_URL}/assets/search`, ({ request }) => {
+    const url = new URL(request.url)
+    const q = url.searchParams.get('q') || ''
+    const results = mockAssets.filter((a) => a.name.includes(q)).map((a) => ({
+      name: a.name,
+      ticker: a.ticker,
+      type: a.type,
+      market: 'KR',
+    }))
+    return HttpResponse.json(results)
+  }),
+
+  http.get(`${BASE_URL}/assets/goal`, () => {
+    return HttpResponse.json(mockAssetGoal)
+  }),
+
+  http.post(`${BASE_URL}/assets/goal`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>
+    return HttpResponse.json({
+      ...mockAssetGoal,
+      target_net_worth: body.target_net_worth ?? mockAssetGoal.target_net_worth,
+      target_date: body.target_date ?? mockAssetGoal.target_date,
+    }, { status: 201 })
+  }),
+
+  http.delete(`${BASE_URL}/assets/goal`, () => {
+    return HttpResponse.json(null, { status: 204 })
+  }),
+
+  http.get(`${BASE_URL}/assets/monthly-savings`, () => {
+    return HttpResponse.json(mockMonthlySavings)
+  }),
+
+  http.post(`${BASE_URL}/assets/parse`, async ({ request }) => {
+    const body = (await request.json()) as { text: string }
+    return HttpResponse.json({
+      items: [{ name: body.text, type: 'deposit', purchase_price: 1000000, current_price: 1000000 }],
+    })
+  }),
+
+  http.get(`${BASE_URL}/assets/:id`, ({ params }) => {
+    const asset = mockAssets.find((a) => a.id === Number(params.id))
+    if (!asset) return HttpResponse.json({ detail: 'Not found' }, { status: 404 })
+    return HttpResponse.json(asset)
+  }),
+
+  http.post(`${BASE_URL}/assets`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>
+    return HttpResponse.json({
+      id: 99,
+      ...body,
+      user_id: 1,
+      household_id: null,
+      account_id: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }, { status: 201 })
+  }),
+
+  http.put(`${BASE_URL}/assets/:id`, async ({ params, request }) => {
+    const asset = mockAssets.find((a) => a.id === Number(params.id))
+    if (!asset) return HttpResponse.json({ detail: 'Not found' }, { status: 404 })
+    const body = (await request.json()) as Record<string, unknown>
+    return HttpResponse.json({ ...asset, ...body, updated_at: new Date().toISOString() })
+  }),
+
+  http.delete(`${BASE_URL}/assets/:id`, ({ params }) => {
+    const asset = mockAssets.find((a) => a.id === Number(params.id))
+    if (!asset) return HttpResponse.json({ detail: 'Not found' }, { status: 404 })
+    return HttpResponse.json(null, { status: 204 })
   }),
 
   // ==================== 인사이트 API ====================
@@ -396,6 +497,83 @@ export const handlers = [
     return HttpResponse.json({
       month: '2026-03',
       insights: mockStructuredInsights,
+    })
+  }),
+
+  // ==================== 피드백 API ====================
+
+  http.post(`${BASE_URL}/feedback`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>
+    return HttpResponse.json({
+      id: 99,
+      user_id: 1,
+      type: body.type ?? 'feature',
+      title: body.title ?? '',
+      content: body.content ?? '',
+      status: 'new',
+      username: 'testuser',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }, { status: 201 })
+  }),
+
+  http.get(`${BASE_URL}/feedback/mine`, () => {
+    return HttpResponse.json(mockFeedbacks)
+  }),
+
+  http.get(`${BASE_URL}/feedback`, () => {
+    return HttpResponse.json(mockFeedbacks)
+  }),
+
+  http.patch(`${BASE_URL}/feedback/:id`, async ({ params, request }) => {
+    const fb = mockFeedbacks.find((f) => f.id === Number(params.id))
+    if (!fb) return HttpResponse.json({ detail: 'Not found' }, { status: 404 })
+    const body = (await request.json()) as { status: string }
+    return HttpResponse.json({ ...fb, status: body.status, updated_at: new Date().toISOString() })
+  }),
+
+  // ==================== 관리자 API ====================
+
+  http.get(`${BASE_URL}/admin/stats/dashboard`, () => {
+    return HttpResponse.json(mockDashboardStats)
+  }),
+
+  http.get(`${BASE_URL}/admin/users`, ({ request }) => {
+    const url = new URL(request.url)
+    const page = Number(url.searchParams.get('page')) || 1
+    const pageSize = Number(url.searchParams.get('page_size')) || 20
+    return HttpResponse.json({
+      users: [
+        { id: 1, username: 'testuser', email: 'test@example.com', is_active: true, created_at: '2026-01-01T00:00:00Z', expense_count: 100, income_count: 50 },
+      ],
+      total: 1,
+      page,
+      page_size: pageSize,
+    })
+  }),
+
+  http.get(`${BASE_URL}/admin/users/:userId`, ({ params }) => {
+    return HttpResponse.json({
+      id: Number(params.userId),
+      username: 'testuser',
+      email: 'test@example.com',
+      is_active: true,
+      created_at: '2026-01-01T00:00:00Z',
+      expense_count: 100,
+      income_count: 50,
+    })
+  }),
+
+  http.patch(`${BASE_URL}/admin/users/:userId`, async ({ params, request }) => {
+    const body = (await request.json()) as Record<string, unknown>
+    return HttpResponse.json({
+      id: Number(params.userId),
+      username: 'testuser',
+      email: 'test@example.com',
+      is_active: body.is_active ?? true,
+      created_at: '2026-01-01T00:00:00Z',
+      expense_count: 100,
+      income_count: 50,
     })
   }),
 ]

--- a/frontend/src/pages/__tests__/FeedbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/FeedbackPage.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @file FeedbackPage.test.tsx
+ * @description 피드백 페이지 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import FeedbackPage from '../FeedbackPage'
+
+// react-hot-toast 모킹
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <FeedbackPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('FeedbackPage', () => {
+  it('피드백 폼을 렌더링한다', async () => {
+    renderPage()
+    expect(screen.getByText('피드백 보내기')).toBeInTheDocument()
+    expect(screen.getByText('기능 요청')).toBeInTheDocument()
+    expect(screen.getByText('버그 신고')).toBeInTheDocument()
+  })
+
+  it('제목과 내용 입력 필드를 렌더링한다', () => {
+    renderPage()
+    expect(screen.getByPlaceholderText('제목')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('자세한 내용을 적어주세요')).toBeInTheDocument()
+  })
+
+  it('보내기 버튼이 비활성화 상태로 시작한다', () => {
+    renderPage()
+    const submitBtn = screen.getByRole('button', { name: /보내기/ })
+    expect(submitBtn).toBeDisabled()
+  })
+
+  it('제목과 내용을 입력하면 보내기 버튼이 활성화된다', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.type(screen.getByPlaceholderText('제목'), '다크모드 추가 요청')
+    await user.type(screen.getByPlaceholderText('자세한 내용을 적어주세요'), '다크모드를 추가해주세요')
+
+    const submitBtn = screen.getByRole('button', { name: /보내기/ })
+    expect(submitBtn).not.toBeDisabled()
+  })
+
+  it('버그 신고 타입을 선택할 수 있다', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    const bugBtn = screen.getByText('버그 신고')
+    await user.click(bugBtn)
+    // 버그 타입 버튼이 활성화 스타일을 가져야 함 (bg-red-600)
+    expect(bugBtn.closest('button')!.className).toContain('bg-red-600')
+  })
+
+  it('제출 후 폼이 초기화된다', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.type(screen.getByPlaceholderText('제목'), '테스트 제목')
+    await user.type(screen.getByPlaceholderText('자세한 내용을 적어주세요'), '테스트 내용')
+
+    const submitBtn = screen.getByRole('button', { name: /보내기/ })
+    await user.click(submitBtn)
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('제목')).toHaveValue('')
+    })
+  })
+
+  it('내 피드백 목록을 로드하여 표시한다', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('내 피드백')).toBeInTheDocument()
+    })
+    // 내 피드백 + 관리자 피드백 모두 같은 데이터를 표시하므로 여러 개 존재
+    expect(screen.getAllByText('다크모드 추가').length).toBeGreaterThan(0)
+  })
+
+  it('뒤로가기 링크가 설정 페이지로 이동한다', () => {
+    renderPage()
+    const backLink = screen.getByRole('link', { name: '뒤로가기' })
+    expect(backLink).toHaveAttribute('href', '/settings')
+  })
+})

--- a/frontend/src/pages/__tests__/HouseholdDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/HouseholdDetailPage.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @file HouseholdDetailPage.test.tsx
+ * @description 공유 가계부 상세 페이지 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import HouseholdDetailPage from '../HouseholdDetailPage'
+
+const mockHousehold = {
+  id: 1,
+  name: '우리집',
+  description: '가족 가계부',
+  my_role: 'owner',
+  members: [
+    {
+      user_id: 1,
+      username: '홍길동',
+      email: 'hong@example.com',
+      role: 'owner',
+      joined_at: '2026-01-01T00:00:00Z',
+    },
+    {
+      user_id: 2,
+      username: '김철수',
+      email: 'kim@example.com',
+      role: 'member',
+      joined_at: '2026-02-01T00:00:00Z',
+    },
+  ],
+}
+
+const fetchHouseholdDetail = vi.fn().mockResolvedValue(mockHousehold)
+const clearCurrentHousehold = vi.fn()
+const clearError = vi.fn()
+
+vi.mock('../../stores/useHouseholdStore', () => ({
+  useHouseholdStore: () => ({
+    currentHousehold: mockHousehold,
+    isLoading: false,
+    error: null,
+    fetchHouseholdDetail,
+    updateHousehold: vi.fn(),
+    deleteHousehold: vi.fn(),
+    inviteMember: vi.fn(),
+    updateMemberRole: vi.fn(),
+    removeMember: vi.fn(),
+    leaveHousehold: vi.fn(),
+    clearError,
+    clearCurrentHousehold,
+  }),
+}))
+
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}))
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 1, username: '홍길동' } }),
+}))
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/households/1']}>
+      <Routes>
+        <Route path="/households/:id" element={<HouseholdDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('HouseholdDetailPage', () => {
+  it('가구 역할 뱃지를 표시한다', async () => {
+    renderPage()
+    // 헤더의 역할 뱃지 + 테이블의 역할 뱃지 모두 표시됨
+    expect(screen.getAllByText('소유자').length).toBeGreaterThan(0)
+  })
+
+  it('가구 설명을 표시한다', () => {
+    renderPage()
+    expect(screen.getByText('가족 가계부')).toBeInTheDocument()
+  })
+
+  it('멤버 탭이 기본 선택되어 있다', () => {
+    renderPage()
+    // "멤버" 텍스트는 탭 + 테이블 역할 드롭다운에 모두 존재
+    expect(screen.getAllByText('멤버').length).toBeGreaterThan(0)
+  })
+
+  it('멤버 목록을 표시한다', () => {
+    renderPage()
+    expect(screen.getByText('홍길동')).toBeInTheDocument()
+    expect(screen.getByText('김철수')).toBeInTheDocument()
+  })
+
+  it('멤버의 이메일을 표시한다', () => {
+    renderPage()
+    expect(screen.getByText('hong@example.com')).toBeInTheDocument()
+    expect(screen.getByText('kim@example.com')).toBeInTheDocument()
+  })
+
+  it('소유자에게 멤버 초대 버튼을 표시한다', () => {
+    renderPage()
+    expect(screen.getByText('+ 멤버 초대')).toBeInTheDocument()
+  })
+
+  it('소유자에게 설정 탭을 표시한다', () => {
+    renderPage()
+    expect(screen.getByText('설정')).toBeInTheDocument()
+  })
+
+  it('소유자는 다른 멤버에 대해 추방 버튼을 볼 수 있다', () => {
+    renderPage()
+    expect(screen.getByText('추방')).toBeInTheDocument()
+  })
+
+  it('자기 자신은 (나) 표시가 된다', () => {
+    renderPage()
+    expect(screen.getByText('(나)')).toBeInTheDocument()
+  })
+
+  it('가구 정보 로드를 요청한다', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(fetchHouseholdDetail).toHaveBeenCalledWith(1)
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/TransactionList.test.tsx
+++ b/frontend/src/pages/__tests__/TransactionList.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @file TransactionList.test.tsx
+ * @description 통합 거래 목록 페이지 (홈 화면) 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import TransactionList from '../TransactionList'
+
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}))
+
+vi.mock('../../stores/useHouseholdStore', () => ({
+  useHouseholdStore: (selector: (s: { activeHouseholdId: null }) => unknown) =>
+    selector({ activeHouseholdId: null }),
+}))
+
+function renderPage(initialRoute = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <TransactionList />
+    </MemoryRouter>,
+  )
+}
+
+describe('TransactionList', () => {
+  it('월 네비게이션 헤더를 표시한다', async () => {
+    renderPage()
+    // 현재 월이 표시되어야 함
+    const now = new Date()
+    const monthLabel = `${now.getFullYear()}년 ${now.getMonth() + 1}월`
+    expect(screen.getByText(monthLabel)).toBeInTheDocument()
+  })
+
+  it('지출/수입 요약 영역을 표시한다', async () => {
+    renderPage()
+    expect(screen.getByText('지출')).toBeInTheDocument()
+    expect(screen.getByText('수입')).toBeInTheDocument()
+  })
+
+  it('데이터 로드 후 거래 목록을 표시한다', async () => {
+    renderPage()
+    // MSW가 반환하는 mockExpenses, mockIncomes의 데이터가 표시되어야 함
+    await waitFor(() => {
+      // 빈 상태 또는 거래 목록이 표시됨
+      const hasTransactions = screen.queryByText('거래 내역이 없습니다') !== null
+        || screen.queryByRole('link') !== null
+      expect(hasTransactions).toBe(true)
+    })
+  })
+
+  it('지출 필터 버튼을 클릭하면 필터가 적용된다', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    // 지출 버튼 클릭
+    const expenseBtn = screen.getByText('지출')
+    await user.click(expenseBtn)
+    // 필터가 적용되어도 페이지는 정상 렌더링
+    expect(screen.getByText('지출')).toBeInTheDocument()
+  })
+
+  it('수입 필터 버튼을 클릭하면 필터가 적용된다', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const incomeBtn = screen.getByText('수입')
+    await user.click(incomeBtn)
+    expect(screen.getByText('수입')).toBeInTheDocument()
+  })
+
+  it('이전 월 버튼을 클릭하면 월이 변경된다', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const now = new Date()
+    const currentLabel = `${now.getFullYear()}년 ${now.getMonth() + 1}월`
+    expect(screen.getByText(currentLabel)).toBeInTheDocument()
+
+    // 이전 월 버튼 클릭 (첫 번째 네비게이션 버튼)
+    const navButtons = screen.getAllByRole('button')
+    const prevBtn = navButtons[0]
+    await user.click(prevBtn)
+
+    // 이전 월이 표시되어야 함
+    const prevMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+    const prevLabel = `${prevMonth.getFullYear()}년 ${prevMonth.getMonth() + 1}월`
+    await waitFor(() => {
+      expect(screen.getByText(prevLabel)).toBeInTheDocument()
+    })
+  })
+
+  it('요일 헤더가 캘린더에 표시된다', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('일')).toBeInTheDocument()
+      expect(screen.getByText('토')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 대시보드 페이지를 제거하고 TransactionList(가계부)를 앱의 첫 화면(`/`)으로 설정
- 대시보드의 반복 거래 알림을 PendingRecurring 독립 컴포넌트로 추출하여 가계부 상단에 배치
- 네비게이션을 5탭(대시보드/가계부/리포트/자산/설정) → 4탭(가계부/리포트/자산/설정)으로 축소
- Dashboard.tsx, GrapeProgress.tsx 및 관련 테스트 삭제 (1,031줄 제거)
- `/transactions` → `/` 쿼리 보존 리다이렉트, 내부 링크 정리
- GuidePage, changelogs, CLAUDE.md 문서 업데이트, PWA cacheId v11

## Test plan
- [x] PendingRecurring 컴포넌트 테스트 4개 통과
- [x] Layout 테스트 4탭 구조 반영 (9개 통과)
- [x] 프론트엔드 전체 테스트 42 files, 404 tests 통과
- [x] 프론트엔드 빌드 성공
- [x] 백엔드 테스트 443 passed
- [ ] `/` 접속 시 가계부(TransactionList) 표시 확인
- [ ] `/transactions` 접속 시 `/`로 리다이렉트 확인
- [ ] 반복 거래 알림 등록/건너뛰기 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>