### PR TITLE
refactor: 대시보드 제거, 가계부를 첫 화면으로 변경 (#36)

### DIFF
--- a/frontend/src/pages/ExpenseForm.tsx
+++ b/frontend/src/pages/ExpenseForm.tsx
@@ -745,7 +745,7 @@ export default function ExpenseForm() {
                 className="w-full pl-8 pr-4 py-3 border border-warm-300 rounded-xl focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                 disabled={loading}
                 min="1"
-                step="100"
+                step="any"
               />
             </div>
           </div>

--- a/frontend/src/pages/IncomeForm.tsx
+++ b/frontend/src/pages/IncomeForm.tsx
@@ -494,7 +494,7 @@ export default function IncomeForm() {
                 className="w-full pl-8 pr-4 py-3 border border-warm-300 rounded-xl focus:ring-2 focus:ring-leaf-500/30 focus:border-leaf-500"
                 disabled={loading}
                 min="1"
-                step="100"
+                step="any"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- 대시보드 페이지를 제거하고 TransactionList(가계부)를 앱의 첫 화면(`/`)으로 설정
- 대시보드의 반복 거래 알림을 PendingRecurring 독립 컴포넌트로 추출하여 가계부 상단에 배치
- 네비게이션을 5탭(대시보드/가계부/리포트/자산/설정) → 4탭(가계부/리포트/자산/설정)으로 축소
- Dashboard.tsx, GrapeProgress.tsx 및 관련 테스트 삭제 (1,031줄 제거)
- `/transactions` → `/` 쿼리 보존 리다이렉트, 내부 링크 정리
- GuidePage, changelogs, CLAUDE.md 문서 업데이트, PWA cacheId v11

## Test plan
- [x] PendingRecurring 컴포넌트 테스트 4개 통과
- [x] Layout 테스트 4탭 구조 반영 (9개 통과)
- [x] 프론트엔드 전체 테스트 42 files, 404 tests 통과
- [x] 프론트엔드 빌드 성공
- [x] 백엔드 테스트 443 passed
- [ ] `/` 접속 시 가계부(TransactionList) 표시 확인
- [ ] `/transactions` 접속 시 `/`로 리다이렉트 확인
- [ ] 반복 거래 알림 등록/건너뛰기 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>