### PR TITLE
fix: 배포 완료 텔레그램 알림에 PR 링크 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -122,11 +122,18 @@ jobs:
         run: |
           DISPLAY_MSG="$(echo "$COMMIT_MSG" | head -1)"
 
+          # 커밋 메시지에서 PR 번호 추출 (예: (#38) → 38)
+          PR_NUM="$(echo "$DISPLAY_MSG" | grep -oE '#[0-9]+' | tail -1 | tr -d '#')"
+          if [ -n "$PR_NUM" ]; then
+            PR_LINK="https://github.com/${REPO}/pull/${PR_NUM}"
+          fi
+
           if [ "$BACKEND_STATUS" = "success" ] && [ "$FRONTEND_STATUS" = "success" ]; then
             KST_TIME="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M KST')"
             MESSAGE="$(printf '[PROD] ✅ podo-budget 배포 완료\n📝 %s\n🕐 %s' \
               "${DISPLAY_MSG}" \
               "${KST_TIME}")"
+            [ -n "$PR_LINK" ] && MESSAGE="${MESSAGE}"$'\n'"🔗 ${PR_LINK}"
           else
             MESSAGE="[PROD] ❌ podo-budget 배포 실패 (backend: ${BACKEND_STATUS}, frontend: ${FRONTEND_STATUS})"
             [ -n "$BACKEND_FAILURE" ] && MESSAGE="${MESSAGE}"$'\n'"🔴 Backend: ${BACKEND_FAILURE}"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -121,11 +121,18 @@ jobs:
         run: |
           DISPLAY_MSG="$(echo "$COMMIT_MSG" | head -1)"
 
+          # 커밋 메시지에서 PR 번호 추출 (예: (#38) → 38)
+          PR_NUM="$(echo "$DISPLAY_MSG" | grep -oE '#[0-9]+' | tail -1 | tr -d '#')"
+          if [ -n "$PR_NUM" ]; then
+            PR_LINK="https://github.com/${REPO}/pull/${PR_NUM}"
+          fi
+
           if [ "$BACKEND_STATUS" = "success" ] && [ "$FRONTEND_STATUS" = "success" ]; then
             KST_TIME="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M KST')"
             MESSAGE="$(printf '[DEV] ✅ podo-budget 배포 완료\n📝 %s\n🕐 %s' \
               "${DISPLAY_MSG}" \
               "${KST_TIME}")"
+            [ -n "$PR_LINK" ] && MESSAGE="${MESSAGE}"$'\n'"🔗 ${PR_LINK}"
           else
             MESSAGE="[DEV] ❌ podo-budget 배포 실패 (backend: ${BACKEND_STATUS}, frontend: ${FRONTEND_STATUS})"
             [ -n "$BACKEND_FAILURE" ] && MESSAGE="${MESSAGE}"$'\n'"🔴 Backend: ${BACKEND_FAILURE}"


### PR DESCRIPTION
## Summary
- 배포 성공 텔레그램 메시지에 커밋 메시지에서 PR 번호를 추출하여 GitHub PR 링크 추가
- DEV/PROD 워크플로우 모두 적용
- PR 번호가 없는 경우(수동 트리거 등)에는 링크 없이 기존대로 전송

🤖 Generated with [Claude Code](https://claude.com/claude-code)