### PR TITLE
fix: 테스트 통과 텔레그램 알림에도 PR 링크 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,14 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           ENV_PREFIX: ${{ github.base_ref == 'main' && '[PROD]' || '[DEV]' }}
         run: |
+          PR_LINK="https://github.com/${REPO}/pull/${PR_NUMBER}"
+
           if [ "$TEST_STATUS" = "success" ]; then
-            MESSAGE="$(printf '%s ✅ podo-budget 테스트 통과\n📝 #%s %s' \
+            MESSAGE="$(printf '%s ✅ podo-budget 테스트 통과\n📝 #%s %s\n🔗 %s' \
               "${ENV_PREFIX}" \
               "${PR_NUMBER}" \
-              "${PR_TITLE}")"
+              "${PR_TITLE}" \
+              "${PR_LINK}")"
           else
             MESSAGE="$(printf '%s ❌ podo-budget 테스트 실패\n📝 #%s %s\n🔗 https://github.com/%s/actions/runs/%s' \
               "${ENV_PREFIX}" \


### PR DESCRIPTION
## Summary
- CI 테스트 통과 텔레그램 알림에 PR 링크 추가 (기존에는 실패 시에만 링크 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)