### PR TITLE
refactor: 관리자 메뉴를 설정 페이지 안으로 이동

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -7,9 +7,8 @@ import FloatingActionButton from './FloatingActionButton'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import {
   Receipt, TrendingUp, Settings as SettingsIcon,
-  Mail, Home, ChevronDown, Landmark, ShieldCheck,
+  Mail, Home, ChevronDown, Landmark,
 } from 'lucide-react'
-import { useAuth } from '../contexts/AuthContext'
 import type { LucideIcon } from 'lucide-react'
 import { useChangelog } from '../hooks/useChangelog'
 
@@ -41,7 +40,6 @@ export default function Layout() {
     return () => document.removeEventListener('click', handleClick)
   }, [householdDropdownOpen])
 
-  const { user } = useAuth()
   const { hasUnread: hasUnreadChangelog } = useChangelog()
   const pendingInvitationCount = myInvitations.filter(inv => inv.status === 'pending').length
   const activeHousehold = households.find(h => h.id === activeHouseholdId)
@@ -201,22 +199,6 @@ export default function Layout() {
                 <span className="ml-auto bg-red-500 text-white text-xs px-1.5 py-0.5 rounded-full min-w-[20px] text-center">
                   {pendingInvitationCount}
                 </span>
-              </Link>
-            )}
-            {user?.is_admin && (
-              <Link
-                to="/admin"
-                className={`
-                  flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium
-                  transition-colors relative
-                  ${location.pathname === '/admin'
-                    ? 'bg-grape-50 text-grape-700 border-l-3 border-grape-500'
-                    : 'text-warm-600 hover:bg-warm-100 hover:text-warm-800'
-                  }
-                `}
-              >
-                <ShieldCheck className="w-[18px] h-[18px]" />
-                관리
               </Link>
             )}
           </nav>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,7 +8,7 @@ import { Link, useParams, useNavigate } from 'react-router-dom'
 import toast from 'react-hot-toast'
 import {
   Tags, PiggyBank, Repeat, Users, LogOut, BookOpen, MessageSquarePlus,
-  Megaphone, ChevronRight, ArrowLeft, User, Send, MessageCircle,
+  Megaphone, ChevronRight, ArrowLeft, User, Send, MessageCircle, ShieldCheck,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { generateTelegramLinkCode, unlinkTelegram } from '../api/telegram'
@@ -532,6 +532,12 @@ export default function SettingsPage() {
       description: '기능 요청/버그 신고',
       icon: MessageSquarePlus,
     },
+    ...(user.is_admin ? [{
+      to: '/admin',
+      label: '관리자',
+      description: '운영 현황, 피드백 관리, 사용자 관리',
+      icon: ShieldCheck,
+    }] : []),
   ]
 
   if (!user) return null


### PR DESCRIPTION
## Summary
- 사이드바의 별도 "관리" 탭 제거
- 설정 메뉴 최하단에 관리자 전용 항목 추가 (is_admin일 때만 표시)
- 하단 탭 4개 유지 (가계부/리포트/자산/설정)
- `/admin` 라우트는 유지 (설정에서 링크로 이동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)