### PR TITLE
fix: SettingsPage user null 체크 누락 수정

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -532,7 +532,7 @@ export default function SettingsPage() {
       description: '기능 요청/버그 신고',
       icon: MessageSquarePlus,
     },
-    ...(user.is_admin ? [{
+    ...(user?.is_admin ? [{
       to: '/admin',
       label: '관리자',
       description: '운영 현황, 피드백 관리, 사용자 관리',


### PR DESCRIPTION
## Summary
- `user.is_admin` → `user?.is_admin`으로 optional chaining 추가
- #48에서 관리자 메뉴 추가 시 null 체크 전에 user 접근하여 빌드 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)