### PR TITLE
refactor: 대시보드 제거, 가계부를 첫 화면으로 변경 (#36)

### DIFF
--- a/frontend/src/components/RegisterRecurringModal.tsx
+++ b/frontend/src/components/RegisterRecurringModal.tsx
@@ -129,13 +129,13 @@ export default function RegisterRecurringModal({
 
           {/* 반복 빈도 */}
           <div>
-            <label className="block text-sm font-medium text-warm-700 mb-1">반복 빈도</label>
+            <label className="block text-sm font-medium text-warm-700 mb-2">반복 빈도</label>
             <select
               value={formData.frequency}
               onChange={(e) =>
                 setFormData({ ...formData, frequency: e.target.value as typeof formData.frequency })
               }
-              className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+              className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
             >
               <option value="monthly">매월</option>
               <option value="weekly">매주</option>
@@ -147,7 +147,7 @@ export default function RegisterRecurringModal({
           {/* 빈도별 추가 필드 */}
           {(formData.frequency === 'monthly' || formData.frequency === 'yearly') && (
             <div>
-              <label className="block text-sm font-medium text-warm-700 mb-1">반복 날짜</label>
+              <label className="block text-sm font-medium text-warm-700 mb-2">반복 날짜</label>
               <div className="flex items-center gap-2">
                 <input
                   type="number"
@@ -155,7 +155,7 @@ export default function RegisterRecurringModal({
                   onChange={(e) => setFormData({ ...formData, day_of_month: e.target.value })}
                   min="1"
                   max="31"
-                  className="w-24 px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                  className="w-24 px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                 />
                 <span className="text-sm text-warm-600">일</span>
               </div>
@@ -164,11 +164,11 @@ export default function RegisterRecurringModal({
 
           {formData.frequency === 'weekly' && (
             <div>
-              <label className="block text-sm font-medium text-warm-700 mb-1">요일</label>
+              <label className="block text-sm font-medium text-warm-700 mb-2">요일</label>
               <select
                 value={formData.day_of_week}
                 onChange={(e) => setFormData({ ...formData, day_of_week: e.target.value })}
-                className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
               >
                 {['월', '화', '수', '목', '금', '토', '일'].map((d, i) => (
                   <option key={i} value={i}>{d}요일</option>
@@ -179,11 +179,11 @@ export default function RegisterRecurringModal({
 
           {formData.frequency === 'yearly' && (
             <div>
-              <label className="block text-sm font-medium text-warm-700 mb-1">반복 월</label>
+              <label className="block text-sm font-medium text-warm-700 mb-2">반복 월</label>
               <select
                 value={formData.month_of_year}
                 onChange={(e) => setFormData({ ...formData, month_of_year: e.target.value })}
-                className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
               >
                 {Array.from({ length: 12 }, (_, i) => (
                   <option key={i + 1} value={i + 1}>{i + 1}월</option>
@@ -194,14 +194,14 @@ export default function RegisterRecurringModal({
 
           {formData.frequency === 'custom' && (
             <div>
-              <label className="block text-sm font-medium text-warm-700 mb-1">반복 주기</label>
+              <label className="block text-sm font-medium text-warm-700 mb-2">반복 주기</label>
               <div className="flex items-center gap-2">
                 <input
                   type="number"
                   value={formData.interval}
                   onChange={(e) => setFormData({ ...formData, interval: e.target.value })}
                   min="1"
-                  className="w-24 px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                  className="w-24 px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                 />
                 <span className="text-sm text-warm-600">일마다</span>
               </div>
@@ -210,30 +210,30 @@ export default function RegisterRecurringModal({
 
           {/* 시작일 */}
           <div>
-            <label className="block text-sm font-medium text-warm-700 mb-1">시작일</label>
+            <label className="block text-sm font-medium text-warm-700 mb-2">시작일</label>
             <input
               type="date"
               value={formData.start_date}
               onChange={(e) => setFormData({ ...formData, start_date: e.target.value })}
-              className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+              className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
             />
           </div>
 
           {/* 종료일 */}
           <div>
-            <label className="block text-sm font-medium text-warm-700 mb-1">종료일 (선택)</label>
+            <label className="block text-sm font-medium text-warm-700 mb-2">종료일 (선택)</label>
             <input
               type="date"
               value={formData.end_date}
               onChange={(e) => setFormData({ ...formData, end_date: e.target.value })}
-              className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+              className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
             />
           </div>
 
           <button
             type="submit"
             disabled={submitting}
-            className="w-full py-2.5 bg-grape-600 text-white rounded-xl text-sm font-medium shadow-sm hover:bg-grape-700 transition-colors disabled:opacity-50"
+            className="w-full py-3 bg-grape-600 text-white rounded-xl text-sm font-medium shadow-sm hover:bg-grape-700 transition-colors disabled:opacity-50"
           >
             {submitting ? '등록 중...' : '반복 거래 등록'}
           </button>

--- a/frontend/src/data/changelogs.ts
+++ b/frontend/src/data/changelogs.ts
@@ -18,6 +18,16 @@ export interface Changelog {
 
 export const changelogs: Changelog[] = [
   {
+    version: '1.9.1',
+    date: '2026-03-15',
+    title: 'UI 일관성 개선',
+    items: [
+      { tag: '개선', text: '전체 페이지의 입력 필드, 버튼, 간격 스타일이 통일되었습니다' },
+      { tag: '수정', text: '모바일에서 자산 입력 날짜 선택이 잘리던 문제를 수정했습니다' },
+      { tag: '개선', text: '뒤로가기 버튼 터치 영역이 커져 모바일에서 더 쉽게 누를 수 있습니다' },
+    ],
+  },
+  {
     version: '1.9.0',
     date: '2026-03-14',
     title: '카카오톡 채널 봇 연동',

--- a/frontend/src/pages/AssetForm.tsx
+++ b/frontend/src/pages/AssetForm.tsx
@@ -315,7 +315,7 @@ export default function AssetForm() {
       {/* 자연어 모드 */}
       {mode === 'natural' && !isEdit && (
         <div className="space-y-4">
-          <div className="bg-white rounded-2xl border border-warm-200/60 shadow-sm p-5 space-y-3">
+          <div className="bg-white rounded-2xl border border-warm-200/60 shadow-sm p-6 space-y-3">
             <p className="text-sm text-warm-500">
               보유 자산을 자유롭게 입력하면 자동으로 분석해드립니다.
             </p>
@@ -327,12 +327,12 @@ export default function AssetForm() {
               onChange={e => setNaturalInput(e.target.value)}
               placeholder="보유 자산을 입력하세요..."
               rows={4}
-              className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300 resize-none"
+              className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500 resize-none"
             />
             <button
               onClick={handleNaturalParse}
               disabled={loading || !naturalInput.trim()}
-              className="w-full py-2.5 bg-grape-600 text-white rounded-lg text-sm font-medium hover:bg-grape-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+              className="w-full py-3 bg-grape-600 text-white rounded-xl text-sm font-medium hover:bg-grape-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
             >
               {loading && !previewItems ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
               분석하기
@@ -341,7 +341,7 @@ export default function AssetForm() {
 
           {/* 프리뷰 */}
           {previewItems && (
-            <div className="bg-white rounded-2xl border border-warm-200/60 shadow-sm p-5 space-y-3">
+            <div className="bg-white rounded-2xl border border-warm-200/60 shadow-sm p-6 space-y-3">
               <h3 className="text-sm font-semibold text-warm-700">분석 결과 ({previewItems.length}건)</h3>
               <div className="space-y-2">
                 {previewItems.map((item, i) => (
@@ -362,7 +362,7 @@ export default function AssetForm() {
               <button
                 onClick={handleNaturalSave}
                 disabled={loading}
-                className="w-full py-2.5 bg-grape-600 text-white rounded-lg text-sm font-medium hover:bg-grape-700 disabled:opacity-50 transition-colors flex items-center justify-center gap-2"
+                className="w-full py-3 bg-grape-600 text-white rounded-xl text-sm font-medium hover:bg-grape-700 disabled:opacity-50 transition-colors flex items-center justify-center gap-2"
               >
                 {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
                 저장하기
@@ -374,10 +374,10 @@ export default function AssetForm() {
 
       {/* 직접 입력 모드 */}
       {(mode === 'direct' || isEdit) && (
-        <form onSubmit={handleDirectSave} className="bg-white rounded-2xl border border-warm-200/60 shadow-sm p-5 space-y-4">
+        <form onSubmit={handleDirectSave} className="bg-white rounded-2xl border border-warm-200/60 shadow-sm p-6 space-y-5">
           {/* 자산 유형 선택 */}
           <div>
-            <label className="block text-sm font-medium text-warm-700 mb-1.5">자산 유형</label>
+            <label className="block text-sm font-medium text-warm-700 mb-2">자산 유형</label>
             <select
               value={assetType}
               onChange={e => {
@@ -385,7 +385,7 @@ export default function AssetForm() {
                 setAssetType(t)
                 if (isEdit) setForm(f => ({ ...f, type: t, is_liability: isLiabilityType(t) }))
               }}
-              className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+              className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
             >
               {(Object.entries(TYPE_LABELS) as [AssetType, string][]).map(([v, label]) => (
                 <option key={v} value={v}>{label}</option>
@@ -396,13 +396,13 @@ export default function AssetForm() {
           {/* 자산명 (수동형에서만) */}
           {!isInvestmentType && (
             <div>
-              <label className="block text-sm font-medium text-warm-700 mb-1.5">자산명</label>
+              <label className="block text-sm font-medium text-warm-700 mb-2">자산명</label>
               <input
                 type="text"
                 value={form.name ?? ''}
                 onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
                 placeholder="예) 내 적금, 주택담보대출"
-                className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                 required
               />
             </div>
@@ -412,7 +412,7 @@ export default function AssetForm() {
           {isInvestmentType && (
             <>
               <div className="relative" ref={dropdownRef}>
-                <label className="block text-sm font-medium text-warm-700 mb-1.5">종목명</label>
+                <label className="block text-sm font-medium text-warm-700 mb-2">종목명</label>
                 {form.ticker && !manualMode ? (
                   /* 선택된 상태 */
                   <div className="flex items-center gap-2 p-2.5 border border-grape-200 bg-grape-50 rounded-lg">
@@ -440,7 +440,7 @@ export default function AssetForm() {
                       value={form.name ?? ''}
                       onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
                       placeholder="종목명 (예: 삼성전자)"
-                      className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                      className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                       required
                     />
                     <input
@@ -448,7 +448,7 @@ export default function AssetForm() {
                       value={form.ticker ?? ''}
                       onChange={e => setForm(f => ({ ...f, ticker: e.target.value || undefined }))}
                       placeholder="티커/코드 (선택, 예: 005930)"
-                      className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                      className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                     />
                     <button
                       type="button"
@@ -477,10 +477,10 @@ export default function AssetForm() {
                       onFocus={() => { if (searchResults.length > 0 || searchError) setShowDropdown(true) }}
                       onKeyDown={e => { if (e.key === 'Enter') e.preventDefault() }}
                       placeholder={assetType === 'crypto' ? 'BTC, 비트코인...' : '종목명 또는 코드 검색'}
-                      className="w-full border border-warm-200 rounded-lg pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                      className="w-full border border-warm-300 rounded-xl pl-9 pr-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                     />
                     {showDropdown && (
-                      <div className="absolute z-10 left-0 right-0 top-full mt-1 bg-white border border-warm-200 rounded-lg shadow-lg py-1 max-h-48 overflow-y-auto">
+                      <div className="absolute z-10 left-0 right-0 top-full mt-1 bg-white border border-warm-300 rounded-xl shadow-lg py-1 max-h-48 overflow-y-auto">
                         {searchError ? (
                           /* 에러 상태 */
                           <div className="px-3 py-4 text-center">
@@ -529,27 +529,27 @@ export default function AssetForm() {
                 )}
               </div>
 
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-warm-700 mb-1.5">수량</label>
+                  <label className="block text-sm font-medium text-warm-700 mb-2">수량</label>
                   <input
                     type="number"
                     step="any"
                     value={form.quantity ?? ''}
                     onChange={e => setForm(f => ({ ...f, quantity: e.target.value ? Number(e.target.value) : null }))}
                     placeholder="0"
-                    className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                    className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-warm-700 mb-1.5">매입 평균가 (원)</label>
+                  <label className="block text-sm font-medium text-warm-700 mb-2">매입 평균가 (원)</label>
                   <input
                     type="number"
                     step="any"
                     value={form.avg_buy_price ?? ''}
                     onChange={e => setForm(f => ({ ...f, avg_buy_price: e.target.value ? Number(e.target.value) : null }))}
                     placeholder="0"
-                    className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                    className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                   />
                 </div>
               </div>
@@ -560,7 +560,7 @@ export default function AssetForm() {
           {isManualType && (
             <>
               <div>
-                <label className="block text-sm font-medium text-warm-700 mb-1.5">
+                <label className="block text-sm font-medium text-warm-700 mb-2">
                   {assetType === 'loan' ? '대출 잔액 (원)' : '금액 (원)'}
                 </label>
                 <input
@@ -569,39 +569,39 @@ export default function AssetForm() {
                   value={form.manual_value ?? ''}
                   onChange={e => setForm(f => ({ ...f, manual_value: e.target.value ? Number(e.target.value) : null }))}
                   placeholder="0"
-                  className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                  className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                 />
               </div>
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-warm-700 mb-1.5">이율 (%)</label>
+                  <label className="block text-sm font-medium text-warm-700 mb-2">이율 (%)</label>
                   <input
                     type="number"
                     step="0.01"
                     value={form.interest_rate ?? ''}
                     onChange={e => setForm(f => ({ ...f, interest_rate: e.target.value ? Number(e.target.value) : null }))}
                     placeholder="연 이율"
-                    className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                    className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-warm-700 mb-1.5">만기일</label>
+                  <label className="block text-sm font-medium text-warm-700 mb-2">만기일</label>
                   <input
                     type="date"
                     value={form.maturity_date ?? ''}
                     onChange={e => setForm(f => ({ ...f, maturity_date: e.target.value || null }))}
-                    className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                    className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                   />
                 </div>
               </div>
               {assetType === 'loan' && (
-                <div className="grid grid-cols-2 gap-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
-                    <label className="block text-sm font-medium text-warm-700 mb-1.5">상환방식</label>
+                    <label className="block text-sm font-medium text-warm-700 mb-2">상환방식</label>
                     <select
                       value={form.repayment_type ?? ''}
                       onChange={e => setForm(f => ({ ...f, repayment_type: e.target.value || null }))}
-                      className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                      className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                     >
                       <option value="">선택</option>
                       <option value="equal_principal_interest">원리금균등</option>
@@ -610,14 +610,14 @@ export default function AssetForm() {
                     </select>
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-warm-700 mb-1.5">월 상환액 (원)</label>
+                    <label className="block text-sm font-medium text-warm-700 mb-2">월 상환액 (원)</label>
                     <input
                       type="number"
                       step="any"
                       value={form.monthly_payment ?? ''}
                       onChange={e => setForm(f => ({ ...f, monthly_payment: e.target.value ? Number(e.target.value) : null }))}
                       placeholder="0"
-                      className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                      className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                     />
                   </div>
                 </div>
@@ -628,11 +628,11 @@ export default function AssetForm() {
           {/* 계좌 선택 (선택) */}
           {accounts.length > 0 && (
             <div>
-              <label className="block text-sm font-medium text-warm-700 mb-1.5">계좌 (선택)</label>
+              <label className="block text-sm font-medium text-warm-700 mb-2">계좌 (선택)</label>
               <select
                 value={form.account_id ?? ''}
                 onChange={e => setForm(f => ({ ...f, account_id: e.target.value ? Number(e.target.value) : null }))}
-                className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+                className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
               >
                 <option value="">계좌 미지정</option>
                 {accounts.map(acc => (
@@ -644,20 +644,20 @@ export default function AssetForm() {
 
           {/* 메모 */}
           <div>
-            <label className="block text-sm font-medium text-warm-700 mb-1.5">메모 (선택)</label>
+            <label className="block text-sm font-medium text-warm-700 mb-2">메모 (선택)</label>
             <input
               type="text"
               value={form.memo ?? ''}
               onChange={e => setForm(f => ({ ...f, memo: e.target.value || null }))}
               placeholder="메모"
-              className="w-full border border-warm-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+              className="w-full border border-warm-300 rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
             />
           </div>
 
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-2.5 bg-grape-600 text-white rounded-lg text-sm font-medium hover:bg-grape-700 disabled:opacity-50 transition-colors flex items-center justify-center gap-2"
+            className="w-full py-3 bg-grape-600 text-white rounded-xl text-sm font-medium hover:bg-grape-700 disabled:opacity-50 transition-colors flex items-center justify-center gap-2"
           >
             {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
             {isEdit ? '수정하기' : '저장하기'}

--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -221,12 +221,12 @@ export default function BudgetManager() {
 
   return (
     <div className="space-y-6">
-      <button onClick={() => navigate('/settings')} className="p-1.5 -ml-1.5 rounded-lg hover:bg-warm-100 transition-colors">
+      <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-warm-100 transition-colors">
         <ArrowLeft className="w-5 h-5 text-warm-600" />
       </button>
 
       {/* 월 총 예산 카드 */}
-      <div className="bg-white rounded-2xl shadow-sm border border-warm-200 p-5">
+      <div className="bg-white rounded-2xl shadow-sm border border-warm-200/60 p-5">
         <div className="flex items-center gap-2 mb-4">
           <Wallet className="w-5 h-5 text-grape-600" />
           <h2 className="text-lg font-semibold text-warm-900">월 총 예산</h2>
@@ -278,7 +278,7 @@ export default function BudgetManager() {
 
       {/* 예산 현황 카드 */}
       {alerts.length > 0 && (
-        <div className="bg-white rounded-2xl shadow-sm border border-warm-200 p-5">
+        <div className="bg-white rounded-2xl shadow-sm border border-warm-200/60 p-5">
           <div className="flex items-center gap-2 mb-4">
             <BarChart3 className="w-5 h-5 text-grape-600" />
             <h2 className="text-lg font-semibold text-warm-900">예산 현황</h2>
@@ -346,7 +346,7 @@ export default function BudgetManager() {
           description="카테고리 관리 페이지에서 카테고리를 먼저 추가해주세요"
         />
       ) : (
-        <div className="bg-white rounded-2xl shadow-sm border border-warm-200 overflow-hidden">
+        <div className="bg-white rounded-2xl shadow-sm border border-warm-200/60 overflow-hidden">
           <div className="px-5 py-4 border-b border-warm-100">
             <h2 className="text-base font-semibold text-warm-900">카테고리별 예산</h2>
             <p className="text-xs text-warm-400 mt-0.5">

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, Plus } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { categoryApi } from '../api/categories'
 import EmptyState from '../components/EmptyState'
@@ -166,7 +166,7 @@ export default function CategoryManager() {
   if (error) {
     return (
       <div className="space-y-6">
-        <button onClick={() => navigate('/settings')} className="p-1.5 -ml-1.5 rounded-lg hover:bg-warm-100 transition-colors">
+        <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-warm-100 transition-colors">
           <ArrowLeft className="w-5 h-5 text-warm-600" />
         </button>
         <div className="bg-white rounded-2xl shadow-sm border border-warm-200">
@@ -179,19 +179,20 @@ export default function CategoryManager() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <button onClick={() => navigate('/settings')} className="p-1.5 -ml-1.5 rounded-lg hover:bg-warm-100 transition-colors">
+        <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-warm-100 transition-colors">
           <ArrowLeft className="w-5 h-5 text-warm-600" />
         </button>
         <button
           onClick={() => setIsAdding(true)}
-          className="w-full sm:w-auto px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
+          className="flex items-center gap-1.5 px-4 py-2 bg-grape-600 text-white rounded-xl text-sm font-medium shadow-sm hover:bg-grape-700 transition-colors"
         >
-          + 추가
+          <Plus className="w-4 h-4" />
+          추가
         </button>
       </div>
 
       {/* 카테고리 목록 */}
-      <div className="bg-white rounded-2xl shadow-sm border border-warm-200 overflow-hidden">
+      <div className="bg-white rounded-2xl shadow-sm border border-warm-200/60 overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full">
             <thead>

--- a/frontend/src/pages/HouseholdDetailPage.tsx
+++ b/frontend/src/pages/HouseholdDetailPage.tsx
@@ -244,7 +244,7 @@ export default function HouseholdDetailPage() {
   if (error && !currentHousehold) {
     return (
       <div className="space-y-6">
-        <button onClick={() => navigate('/households')} className="p-1.5 -ml-1.5 rounded-lg hover:bg-warm-100 transition-colors">
+        <button onClick={() => navigate('/households')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-warm-100 transition-colors">
           <ArrowLeft className="w-5 h-5 text-warm-600" />
         </button>
         <div className="bg-white rounded-2xl shadow-sm border border-warm-200">

--- a/frontend/src/pages/HouseholdListPage.tsx
+++ b/frontend/src/pages/HouseholdListPage.tsx
@@ -125,7 +125,7 @@ export default function HouseholdListPage() {
   if (error && households.length === 0) {
     return (
       <div className="space-y-6">
-        <button onClick={() => navigate('/settings')} className="p-1.5 -ml-1.5 rounded-lg hover:bg-warm-100 transition-colors">
+        <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-warm-100 transition-colors">
           <ArrowLeft className="w-5 h-5 text-warm-600" />
         </button>
         <div className="bg-white rounded-2xl shadow-sm border border-warm-200">
@@ -140,7 +140,7 @@ export default function HouseholdListPage() {
       {/* 헤더 */}
       <div className="flex items-center justify-between">
         <div>
-          <button onClick={() => navigate('/settings')} className="p-1.5 -ml-1.5 rounded-lg hover:bg-warm-100 transition-colors">
+          <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-warm-100 transition-colors">
           <ArrowLeft className="w-5 h-5 text-warm-600" />
         </button>
           <p className="text-sm text-warm-500 mt-1">

--- a/frontend/src/pages/IncomeForm.tsx
+++ b/frontend/src/pages/IncomeForm.tsx
@@ -270,7 +270,7 @@ export default function IncomeForm() {
         <button
           onClick={() => { setMode('natural'); setPreviewItems(null) }}
           className={`
-            flex-1 px-4 py-3 text-sm font-medium rounded-lg transition-all
+            flex-1 px-3 py-2.5 text-sm font-medium rounded-lg transition-all
             ${mode === 'natural'
               ? 'bg-leaf-600 text-white shadow-sm shadow-leaf-200'
               : 'text-warm-600 hover:bg-warm-50'
@@ -282,7 +282,7 @@ export default function IncomeForm() {
         <button
           onClick={() => { setMode('form'); setPreviewItems(null) }}
           className={`
-            flex-1 px-4 py-3 text-sm font-medium rounded-lg transition-all
+            flex-1 px-3 py-2.5 text-sm font-medium rounded-lg transition-all
             ${mode === 'form'
               ? 'bg-leaf-600 text-white shadow-sm shadow-leaf-200'
               : 'text-warm-600 hover:bg-warm-50'

--- a/frontend/src/pages/InvitationListPage.tsx
+++ b/frontend/src/pages/InvitationListPage.tsx
@@ -170,7 +170,7 @@ export default function InvitationListPage() {
   if (error && myInvitations.length === 0) {
     return (
       <div className="space-y-6">
-        <button onClick={() => navigate('/households')} className="p-1.5 -ml-1.5 rounded-lg hover:bg-warm-100 transition-colors">
+        <button onClick={() => navigate('/households')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-warm-100 transition-colors">
           <ArrowLeft className="w-5 h-5 text-warm-600" />
         </button>
         <div className="bg-white rounded-2xl shadow-sm border border-warm-200">

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -219,7 +219,7 @@ export default function RecurringList() {
   if (error) {
     return (
       <div className="space-y-6">
-        <button onClick={() => navigate('/settings')} className="p-1.5 -ml-1.5 rounded-lg hover:bg-warm-100 transition-colors">
+        <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-warm-100 transition-colors">
           <ArrowLeft className="w-5 h-5 text-warm-600" />
         </button>
         <div className="bg-white rounded-2xl shadow-sm border border-warm-200/60">
@@ -233,7 +233,7 @@ export default function RecurringList() {
     <div className="space-y-6">
       {/* 헤더 */}
       <div className="flex items-center justify-between">
-        <button onClick={() => navigate('/settings')} className="p-1.5 -ml-1.5 rounded-lg hover:bg-warm-100 transition-colors">
+        <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-warm-100 transition-colors">
           <ArrowLeft className="w-5 h-5 text-warm-600" />
         </button>
         <button
@@ -392,12 +392,12 @@ export default function RecurringList() {
               {/* 타입 선택 (추가 시에만) */}
               {!editingId && (
                 <div>
-                  <label className="block text-sm font-medium text-warm-700 mb-1">유형</label>
+                  <label className="block text-sm font-medium text-warm-700 mb-2">유형</label>
                   <div className="flex gap-2">
                     <button
                       type="button"
                       onClick={() => setFormData({ ...formData, type: 'expense', category_id: '' })}
-                      className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
+                      className={`flex-1 py-2 rounded-xl text-sm font-medium transition-colors ${
                         formData.type === 'expense' ? 'bg-grape-100 text-grape-800' : 'bg-warm-100 text-warm-600'
                       }`}
                     >
@@ -406,7 +406,7 @@ export default function RecurringList() {
                     <button
                       type="button"
                       onClick={() => setFormData({ ...formData, type: 'income', category_id: '' })}
-                      className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
+                      className={`flex-1 py-2 rounded-xl text-sm font-medium transition-colors ${
                         formData.type === 'income' ? 'bg-leaf-100 text-leaf-800' : 'bg-warm-100 text-warm-600'
                       }`}
                     >
@@ -418,36 +418,36 @@ export default function RecurringList() {
 
               {/* 설명 */}
               <div>
-                <label className="block text-sm font-medium text-warm-700 mb-1">설명</label>
+                <label className="block text-sm font-medium text-warm-700 mb-2">설명</label>
                 <input
                   type="text"
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                   placeholder="예: 넷플릭스, 월급"
-                  className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                  className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                 />
               </div>
 
               {/* 금액 */}
               <div>
-                <label className="block text-sm font-medium text-warm-700 mb-1">금액</label>
+                <label className="block text-sm font-medium text-warm-700 mb-2">금액</label>
                 <input
                   type="number"
                   value={formData.amount}
                   onChange={(e) => setFormData({ ...formData, amount: e.target.value })}
                   placeholder="0"
                   min="1"
-                  className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                  className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                 />
               </div>
 
               {/* 카테고리 */}
               <div>
-                <label className="block text-sm font-medium text-warm-700 mb-1">카테고리</label>
+                <label className="block text-sm font-medium text-warm-700 mb-2">카테고리</label>
                 <select
                   value={formData.category_id}
                   onChange={(e) => setFormData({ ...formData, category_id: e.target.value })}
-                  className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                  className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                 >
                   <option value="">선택 안 함</option>
                   {filteredCategories.map((c) => (
@@ -460,11 +460,11 @@ export default function RecurringList() {
               {!editingId && (
                 <>
                   <div>
-                    <label className="block text-sm font-medium text-warm-700 mb-1">반복 빈도</label>
+                    <label className="block text-sm font-medium text-warm-700 mb-2">반복 빈도</label>
                     <select
                       value={formData.frequency}
                       onChange={(e) => setFormData({ ...formData, frequency: e.target.value as typeof formData.frequency })}
-                      className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                      className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                     >
                       <option value="monthly">매월</option>
                       <option value="weekly">매주</option>
@@ -476,25 +476,25 @@ export default function RecurringList() {
                   {/* 빈도별 추가 필드 */}
                   {(formData.frequency === 'monthly' || formData.frequency === 'yearly') && (
                     <div>
-                      <label className="block text-sm font-medium text-warm-700 mb-1">반복일</label>
+                      <label className="block text-sm font-medium text-warm-700 mb-2">반복일</label>
                       <input
                         type="number"
                         value={formData.day_of_month}
                         onChange={(e) => setFormData({ ...formData, day_of_month: e.target.value })}
                         min="1"
                         max="31"
-                        className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                        className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                       />
                     </div>
                   )}
 
                   {formData.frequency === 'weekly' && (
                     <div>
-                      <label className="block text-sm font-medium text-warm-700 mb-1">요일</label>
+                      <label className="block text-sm font-medium text-warm-700 mb-2">요일</label>
                       <select
                         value={formData.day_of_week}
                         onChange={(e) => setFormData({ ...formData, day_of_week: e.target.value })}
-                        className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                        className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                       >
                         {['월', '화', '수', '목', '금', '토', '일'].map((d, i) => (
                           <option key={i} value={i}>{d}요일</option>
@@ -505,11 +505,11 @@ export default function RecurringList() {
 
                   {formData.frequency === 'yearly' && (
                     <div>
-                      <label className="block text-sm font-medium text-warm-700 mb-1">반복 월</label>
+                      <label className="block text-sm font-medium text-warm-700 mb-2">반복 월</label>
                       <select
                         value={formData.month_of_year}
                         onChange={(e) => setFormData({ ...formData, month_of_year: e.target.value })}
-                        className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                        className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                       >
                         {Array.from({ length: 12 }, (_, i) => (
                           <option key={i + 1} value={i + 1}>{i + 1}월</option>
@@ -520,25 +520,25 @@ export default function RecurringList() {
 
                   {formData.frequency === 'custom' && (
                     <div>
-                      <label className="block text-sm font-medium text-warm-700 mb-1">반복 주기 (일)</label>
+                      <label className="block text-sm font-medium text-warm-700 mb-2">반복 주기 (일)</label>
                       <input
                         type="number"
                         value={formData.interval}
                         onChange={(e) => setFormData({ ...formData, interval: e.target.value })}
                         min="1"
-                        className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                        className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                       />
                     </div>
                   )}
 
                   {/* 시작일 */}
                   <div>
-                    <label className="block text-sm font-medium text-warm-700 mb-1">시작일</label>
+                    <label className="block text-sm font-medium text-warm-700 mb-2">시작일</label>
                     <input
                       type="date"
                       value={formData.start_date}
                       onChange={(e) => setFormData({ ...formData, start_date: e.target.value })}
-                      className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                      className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                     />
                   </div>
                 </>
@@ -546,12 +546,12 @@ export default function RecurringList() {
 
               {/* 종료일 (항상 표시) */}
               <div>
-                <label className="block text-sm font-medium text-warm-700 mb-1">종료일 (선택)</label>
+                <label className="block text-sm font-medium text-warm-700 mb-2">종료일 (선택)</label>
                 <input
                   type="date"
                   value={formData.end_date}
                   onChange={(e) => setFormData({ ...formData, end_date: e.target.value })}
-                  className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                  className="w-full px-3 py-2 rounded-xl border border-warm-300 text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                 />
               </div>
 
@@ -559,7 +559,7 @@ export default function RecurringList() {
               <button
                 type="submit"
                 disabled={submitting}
-                className="w-full py-2.5 bg-grape-600 text-white rounded-xl text-sm font-medium shadow-sm hover:bg-grape-700 transition-colors disabled:opacity-50"
+                className="w-full py-3 bg-grape-600 text-white rounded-xl text-sm font-medium shadow-sm hover:bg-grape-700 transition-colors disabled:opacity-50"
               >
                 {submitting ? '저장 중...' : editingId ? '수정하기' : '추가하기'}
               </button>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -83,7 +83,7 @@ function SubPageWrapper({ children }: { children: React.ReactNode }) {
     <div className="space-y-6">
       <button
         onClick={() => navigate('/settings')}
-        className="p-1.5 -ml-1.5 rounded-lg hover:bg-warm-100 transition-colors"
+        className="p-2.5 -ml-2.5 rounded-lg hover:bg-warm-100 transition-colors"
       >
         <ArrowLeft className="w-5 h-5 text-warm-600" />
       </button>

--- a/frontend/src/pages/TransactionList.tsx
+++ b/frontend/src/pages/TransactionList.tsx
@@ -5,7 +5,7 @@
 
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import PeriodNavigator from '../components/stats/PeriodNavigator'
 import toast from 'react-hot-toast'
 import { expenseApi } from '../api/expenses'
 import { incomeApi } from '../api/income'
@@ -232,21 +232,7 @@ export default function TransactionList() {
     <PullToRefresh onRefresh={handleRefresh}>
     <div className="space-y-4">
       {/* 월 네비게이션 */}
-      <div className="flex items-center justify-center gap-4">
-        <button
-          onClick={() => navigateMonth(-1)}
-          className="p-2 rounded-lg hover:bg-warm-100 transition-colors"
-        >
-          <ChevronLeft className="w-5 h-5 text-warm-600" />
-        </button>
-        <h1 className="text-lg font-bold text-warm-900">{monthLabel}</h1>
-        <button
-          onClick={() => navigateMonth(1)}
-          className="p-2 rounded-lg hover:bg-warm-100 transition-colors"
-        >
-          <ChevronRight className="w-5 h-5 text-warm-600" />
-        </button>
-      </div>
+      <PeriodNavigator label={monthLabel} onPrev={() => navigateMonth(-1)} onNext={() => navigateMonth(1)} />
 
       {/* 요약 + 필터 */}
       <div className="flex items-center justify-center gap-6">


### PR DESCRIPTION
## Summary
- 대시보드 페이지를 제거하고 TransactionList(가계부)를 앱의 첫 화면(`/`)으로 설정
- 대시보드의 반복 거래 알림을 PendingRecurring 독립 컴포넌트로 추출하여 가계부 상단에 배치
- 네비게이션을 5탭(대시보드/가계부/리포트/자산/설정) → 4탭(가계부/리포트/자산/설정)으로 축소
- Dashboard.tsx, GrapeProgress.tsx 및 관련 테스트 삭제 (1,031줄 제거)
- `/transactions` → `/` 쿼리 보존 리다이렉트, 내부 링크 정리
- GuidePage, changelogs, CLAUDE.md 문서 업데이트, PWA cacheId v11

## Test plan
- [x] PendingRecurring 컴포넌트 테스트 4개 통과
- [x] Layout 테스트 4탭 구조 반영 (9개 통과)
- [x] 프론트엔드 전체 테스트 42 files, 404 tests 통과
- [x] 프론트엔드 빌드 성공
- [x] 백엔드 테스트 443 passed
- [ ] `/` 접속 시 가계부(TransactionList) 표시 확인
- [ ] `/transactions` 접속 시 `/`로 리다이렉트 확인
- [ ] 반복 거래 알림 등록/건너뛰기 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---------

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>