### PR TITLE
feat: 초대 목록에서 링크 복사 버튼 추가

### DIFF
--- a/backend/app/api/households.py
+++ b/backend/app/api/households.py
@@ -683,7 +683,7 @@ async def list_invitations(
                 expires_at=inv.expires_at,
                 created_at=inv.created_at,
                 responded_at=inv.responded_at,
-                token=None,  # 목록 조회 시에는 토큰 미포함
+                token=inv.token if inv.status == "pending" else None,
             )
         )
 

--- a/backend/tests/integration/test_api_households.py
+++ b/backend/tests/integration/test_api_households.py
@@ -503,7 +503,8 @@ async def test_list_invitations_가구의_초대_목록_조회(authenticated_cli
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2
-    assert data[0]["token"] is None  # 목록 조회 시에는 토큰 미포함
+    # pending 초대는 토큰 포함 (링크 복사 기능용)
+    assert data[0]["token"] is not None
 
 
 @pytest.mark.asyncio

--- a/frontend/src/pages/HouseholdDetailPage.tsx
+++ b/frontend/src/pages/HouseholdDetailPage.tsx
@@ -7,7 +7,7 @@
 import type { } from 'react'
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, Link2 } from 'lucide-react'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
 import { useAuth } from '../contexts/AuthContext'
@@ -518,20 +518,36 @@ export default function HouseholdDetailPage() {
                         </div>
                       </div>
                       {isPending && (
-                        <button
-                          onClick={async () => {
-                            if (!confirm(`${inv.invitee_email}의 초대를 취소하시겠습니까?`)) return
-                            try {
-                              await cancelInvitation(Number(id), inv.id)
-                              addToast('success', '초대를 취소했습니다')
-                            } catch {
-                              addToast('error', '초대 취소에 실패했습니다')
-                            }
-                          }}
-                          className="ml-3 text-xs text-rose-600 hover:text-rose-700 font-medium"
-                        >
-                          취소
-                        </button>
+                        <div className="flex items-center gap-2 ml-3">
+                          {inv.token && (
+                            <button
+                              onClick={async () => {
+                                const link = `${window.location.origin}/invitations/accept?token=${inv.token}`
+                                await navigator.clipboard.writeText(link)
+                                addToast('success', '초대 링크가 복사되었습니다')
+                              }}
+                              className="text-xs text-grape-600 hover:text-grape-700 font-medium flex items-center gap-1"
+                              title="초대 링크 복사"
+                            >
+                              <Link2 className="w-3.5 h-3.5" />
+                              링크 복사
+                            </button>
+                          )}
+                          <button
+                            onClick={async () => {
+                              if (!confirm(`${inv.invitee_email}의 초대를 취소하시겠습니까?`)) return
+                              try {
+                                await cancelInvitation(Number(id), inv.id)
+                                addToast('success', '초대를 취소했습니다')
+                              } catch {
+                                addToast('error', '초대 취소에 실패했습니다')
+                              }
+                            }}
+                            className="text-xs text-rose-600 hover:text-rose-700 font-medium"
+                          >
+                            취소
+                          </button>
+                        </div>
                       )}
                     </div>
                   )


### PR DESCRIPTION
## Summary
- 초대 탭에서 pending 상태 초대에 "링크 복사" 버튼 추가
- 백엔드 초대 목록 API에서 pending 초대 시 token 포함 반환
- 클릭 시 초대 수락 링크(`/invitations/accept?token=xxx`)가 클립보드에 복사됨

## Test plan
- [ ] 초대 탭에서 pending 초대에 링크 복사 버튼 표시 확인
- [ ] 버튼 클릭 시 클립보드에 초대 링크 복사 확인
- [ ] 수락/만료된 초대에는 버튼 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)