### PR TITLE
fix: 카카오 봇 사용자 가구 자동 생성으로 지출 저장 실패 수정

### DIFF
--- a/backend/app/api/kakao.py
+++ b/backend/app/api/kakao.py
@@ -101,7 +101,7 @@ async def kakao_webhook(request: Request, db: AsyncSession = Depends(get_db)):
         kakao_user_id = user_info.get("id", "unknown")
 
         # 봇 사용자 생성 또는 조회 (데이터 격리를 위함)
-        bot_user = await get_or_create_bot_user(db, platform="kakao", platform_user_id=kakao_user_id)
+        bot_user = await get_or_create_bot_user(db, platform="kakao", platform_user_id=kakao_user_id, auto_create_household=True)
 
         # 사용자의 활성 가구 ID 조회 (봇은 미연동 사용자를 별도 처리해야 하므로 or_none 사용)
         active_household_id = await get_user_active_household_id_or_none(bot_user, db)

--- a/backend/app/services/bot_user_service.py
+++ b/backend/app/services/bot_user_service.py
@@ -14,6 +14,8 @@ from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.expense import Expense
+from app.models.household import Household
+from app.models.household_member import HouseholdMember
 from app.models.income import Income
 from app.models.user import User
 
@@ -23,7 +25,7 @@ logger = logging.getLogger(__name__)
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
-async def get_or_create_bot_user(db: AsyncSession, platform: str, platform_user_id: str) -> User:
+async def get_or_create_bot_user(db: AsyncSession, platform: str, platform_user_id: str, auto_create_household: bool = False) -> User:
     """봇 플랫폼 사용자를 찾거나 생성한다
 
     1) telegram_chat_id로 연동된 기존 계정이 있으면 해당 유저 반환
@@ -68,6 +70,16 @@ async def get_or_create_bot_user(db: AsyncSession, platform: str, platform_user_
         await db.flush()
         await db.refresh(user)
         logger.info(f"새 봇 사용자 생성: {username} (user_id={user.id})")
+
+        # 봇 유저에게 기본 가구 자동 생성 (expenses.household_id NOT NULL 제약 충족)
+        if auto_create_household:
+            household = Household(name="내 가계부", currency="KRW")
+            db.add(household)
+            await db.flush()
+            member = HouseholdMember(household_id=household.id, user_id=user.id, role="owner")
+            db.add(member)
+            await db.flush()
+            logger.info(f"봇 사용자 기본 가구 생성: user_id={user.id}, household_id={household.id}")
 
     return user
 

--- a/backend/tests/integration/test_api_kakao.py
+++ b/backend/tests/integration/test_api_kakao.py
@@ -347,17 +347,16 @@ async def test_kakao_webhook_same_user_reuses_account(client, db_session, mock_l
 
 @pytest.mark.asyncio
 async def test_kakao_webhook_expense_with_household(client, db_session, mock_llm_parse_expense):
-    """가구에 속한 사용자의 공유 키워드 지출"""
+    """가구에 속한 사용자의 공유 키워드 지출 — 자동 생성된 기본 가구에 저장"""
     from app.services.bot_user_service import get_or_create_bot_user
 
-    # 봇 사용자 생성 + 가구 가입
-    bot_user = await get_or_create_bot_user(db_session, platform="kakao", platform_user_id="kakao_hh_111")
-    household = Household(name="테스트 가구")
-    db_session.add(household)
-    await db_session.flush()
-    member = HouseholdMember(household_id=household.id, user_id=bot_user.id, role="owner")
-    db_session.add(member)
+    # 봇 사용자 생성 (기본 가구 자동 생성됨)
+    bot_user = await get_or_create_bot_user(db_session, platform="kakao", platform_user_id="kakao_hh_111", auto_create_household=True)
     await db_session.commit()
+
+    # 자동 생성된 가구 ID 조회
+    result = await db_session.execute(select(HouseholdMember.household_id).where(HouseholdMember.user_id == bot_user.id))
+    auto_household_id = result.scalar_one()
 
     payload = make_kakao_request("우리 저녁 50000원", user_id="kakao_hh_111")
     response = await client.post("/api/kakao/webhook", json=payload)
@@ -366,22 +365,21 @@ async def test_kakao_webhook_expense_with_household(client, db_session, mock_llm
     result = await db_session.execute(select(Expense))
     expenses = result.scalars().all()
     assert len(expenses) == 1
-    assert expenses[0].household_id == household.id
+    assert expenses[0].household_id == auto_household_id
 
 
 @pytest.mark.asyncio
 async def test_kakao_webhook_personal_keyword_no_household(client, db_session, mock_llm_parse_expense):
-    """가구에 속해있어도 개인 키워드 → household_id는 활성 가구로 설정됨 (household_id 필수)"""
+    """개인 키워드여도 household_id는 활성 가구로 설정됨 (household_id 필수)"""
     from app.services.bot_user_service import get_or_create_bot_user
 
-    # 봇 사용자 생성 + 가구 가입
-    bot_user = await get_or_create_bot_user(db_session, platform="kakao", platform_user_id="kakao_hh_222")
-    household = Household(name="테스트 가구2")
-    db_session.add(household)
-    await db_session.flush()
-    member = HouseholdMember(household_id=household.id, user_id=bot_user.id, role="owner")
-    db_session.add(member)
+    # 봇 사용자 생성 (기본 가구 자동 생성됨)
+    bot_user = await get_or_create_bot_user(db_session, platform="kakao", platform_user_id="kakao_hh_222", auto_create_household=True)
     await db_session.commit()
+
+    # 자동 생성된 가구 ID 조회
+    result = await db_session.execute(select(HouseholdMember.household_id).where(HouseholdMember.user_id == bot_user.id))
+    auto_household_id = result.scalar_one()
 
     payload = make_kakao_request("내 커피 5000원", user_id="kakao_hh_222")
     response = await client.post("/api/kakao/webhook", json=payload)
@@ -391,7 +389,7 @@ async def test_kakao_webhook_personal_keyword_no_household(client, db_session, m
     expenses = result.scalars().all()
     assert len(expenses) == 1
     # household_id는 필수 — 개인 키워드여도 활성 가구로 설정됨
-    assert expenses[0].household_id == household.id
+    assert expenses[0].household_id == auto_household_id
 
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- 카카오 봇 사용자가 지출 입력 시 `household_id NOT NULL` 제약으로 DB 저장이 실패하던 문제 수정
- `get_or_create_bot_user`에 `auto_create_household` 매개변수 추가 — 카카오는 True, 텔레그램은 기존대로 False
- 봇 사용자 생성 시 기본 가구("내 가계부") 자동 생성하여 즉시 지출 기록 가능

## Test plan
- [x] 카카오 통합 테스트 20개 통과
- [x] 텔레그램 통합 테스트 24개 통과 (기존 연동 필수 동작 유지)
- [x] bot_user_service 단위 테스트 8개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)