### PR TITLE
fix: 카카오 오픈빌더 사용자 ID 추출 경로 수정

### DIFF
--- a/backend/app/api/kakao.py
+++ b/backend/app/api/kakao.py
@@ -139,7 +139,8 @@ async def kakao_webhook(request: Request, db: AsyncSession = Depends(get_db)):
         # userRequest에서 utterance와 user.id 추출
         user_request = data.get("userRequest", {})
         utterance = user_request.get("utterance", "").strip()
-        user_info = data.get("user", {})
+        # 카카오 오픈빌더: user 정보는 userRequest.user에 위치
+        user_info = user_request.get("user", {}) or data.get("user", {})
         kakao_user_id = user_info.get("id", "unknown")
 
         # 봇 사용자 생성 또는 조회 (데이터 격리를 위함)

--- a/backend/tests/integration/test_api_kakao.py
+++ b/backend/tests/integration/test_api_kakao.py
@@ -32,9 +32,13 @@ def make_kakao_request(utterance: str, user_id: str = "kakao_user_123") -> dict:
     """
     return {
         "intent": {"id": "test_intent", "name": "TestIntent"},
-        "userRequest": {"utterance": utterance, "params": {}, "block": {"id": "test_block", "name": "TestBlock"}},
+        "userRequest": {
+            "utterance": utterance,
+            "params": {},
+            "block": {"id": "test_block", "name": "TestBlock"},
+            "user": {"id": user_id, "type": "botUserKey"},
+        },
         "bot": {"id": "test_bot", "name": "HomeNRich"},
-        "user": {"id": user_id, "type": "accountId"},
     }
 
 
@@ -163,9 +167,9 @@ async def test_kakao_webhook_no_utterance(client, db_session):
             "utterance": "",  # 빈 문자열
             "params": {},
             "block": {"id": "test_block", "name": "TestBlock"},
+            "user": {"id": "kakao_user_123", "type": "botUserKey"},
         },
         "bot": {"id": "test_bot", "name": "HomeNRich"},
-        "user": {"id": "kakao_user_123", "type": "accountId"},
     }
 
     response = await client.post("/api/kakao/webhook", json=payload)


### PR DESCRIPTION
## Summary
- 카카오 오픈빌더 요청에서 user 정보를 `data.user` 대신 `userRequest.user`에서 추출하도록 수정
- 기존 코드는 모든 사용자가 `kakao_unknown`으로 처리되어 데이터가 공유되는 버그가 있었음
- 테스트 페이로드도 오픈빌더 실제 형식(`userRequest.user`)으로 수정

## Test plan
- [x] 카카오 테스트 42개 전체 통과
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)