### PR TITLE
style: 다크모드 색상 팔레트 완성 — yellow/green 추가, 텍스트 700/800→600 통일

### DIFF
--- a/backend/app/api/kakao.py
+++ b/backend/app/api/kakao.py
@@ -168,11 +168,11 @@ async def kakao_webhook(request: Request, db: AsyncSession = Depends(get_db)):
 
         # /report 명령어 처리 (이번 달 지출 요약)
         if utterance.startswith("/report"):
-            return await handle_report_command(db, user_id=bot_user.id)
+            return await handle_report_command(db, household_id=active_household_id)
 
         # /budget 명령어 처리 (예산 현황)
         if utterance.startswith("/budget"):
-            return await handle_budget_command(db, user_id=bot_user.id)
+            return await handle_budget_command(db, household_id=active_household_id)
 
         # /link 명령어 처리 (웹 계정 연동)
         if utterance.startswith("/link"):
@@ -405,9 +405,7 @@ async def handle_change_command(db: AsyncSession, bot_user, utterance: str, acti
         categories = await _get_accessible_categories(db, bot_user.id, expense.household_id)
 
         # 현재 카테고리를 제외한 목록으로 quickReply 생성
-        quick_replies = [make_quick_reply(cat.name, f"변경 {cat.name}") for cat in categories if cat.name != current_cat_name][
-            :10
-        ]  # quickReply 최대 10개 제한
+        quick_replies = [make_quick_reply(cat.name, f"변경 {cat.name}") for cat in categories if cat.name != current_cat_name][:10]  # quickReply 최대 10개 제한
 
         msg = f"📂 마지막 지출: {expense.amount:,.0f}원 - {current_cat_name}\n\n"
         if quick_replies:
@@ -448,21 +446,27 @@ async def handle_change_command(db: AsyncSession, bot_user, utterance: str, acti
     )
 
 
-async def handle_report_command(db: AsyncSession, user_id: int) -> dict:
+async def handle_report_command(db: AsyncSession, household_id: int | None) -> dict:
     """이번 달 지출 요약 리포트 생성
 
     카테고리별 지출 합계와 건수를 집계하여 카카오 응답 형식으로 반환합니다.
-    사용자별로 데이터를 격리하여 조회합니다.
+    가구 단위로 데이터를 조회합니다 (웹 리포트와 동일한 스코프).
 
     Args:
         db: 데이터베이스 세션
-        user_id: 조회할 사용자 ID
+        household_id: 조회할 가구 ID
 
     Returns:
         카카오 응답 형식 (version 2.0)
     """
+    if household_id is None:
+        return make_simple_text_response(
+            "🏠 가구 설정이 필요합니다.\n웹에서 계정을 연동해주세요.",
+            quick_replies=[make_quick_reply("❓ 도움말", "도움말")],
+        )
+
     try:
-        # 이번 달 1일부터 현재까지 지출 집계 (해당 사용자만)
+        # 이번 달 1일부터 현재까지 지출 집계 (가구 단위)
         now = datetime.now()
         result = await db.execute(
             select(
@@ -471,7 +475,7 @@ async def handle_report_command(db: AsyncSession, user_id: int) -> dict:
                 func.count(Expense.id).label("count"),
             )
             .join(Category, Expense.category_id == Category.id)
-            .where(Expense.user_id == user_id)
+            .where(Expense.household_id == household_id)
             .where(extract("year", Expense.date) == now.year)
             .where(extract("month", Expense.date) == now.month)
             .group_by(Category.name)
@@ -489,22 +493,28 @@ async def handle_report_command(db: AsyncSession, user_id: int) -> dict:
         return make_simple_text_response(format_server_error())
 
 
-async def handle_budget_command(db: AsyncSession, user_id: int) -> dict:
+async def handle_budget_command(db: AsyncSession, household_id: int | None) -> dict:
     """예산 현황 생성
 
     설정된 예산과 현재 지출을 비교하여 카카오 응답 형식으로 반환합니다.
-    사용자별로 데이터를 격리하여 조회합니다.
+    가구 단위로 데이터를 조회합니다 (웹 리포트와 동일한 스코프).
 
     Args:
         db: 데이터베이스 세션
-        user_id: 조회할 사용자 ID
+        household_id: 조회할 가구 ID
 
     Returns:
         카카오 응답 형식 (version 2.0)
     """
+    if household_id is None:
+        return make_simple_text_response(
+            "🏠 가구 설정이 필요합니다.\n웹에서 계정을 연동해주세요.",
+            quick_replies=[make_quick_reply("❓ 도움말", "도움말")],
+        )
+
     try:
-        # 해당 사용자의 활성 예산 조회
-        budget_result = await db.execute(select(Budget).where(Budget.user_id == user_id))
+        # 해당 가구의 활성 예산 조회
+        budget_result = await db.execute(select(Budget).where(Budget.household_id == household_id))
         budgets = budget_result.scalars().all()
 
         if not budgets:
@@ -529,10 +539,10 @@ async def handle_budget_command(db: AsyncSession, user_id: int) -> dict:
             if not category:
                 continue
 
-            # 지출 합계 (해당 사용자만)
+            # 지출 합계 (가구 단위)
             expense_result = await db.execute(
                 select(func.sum(Expense.amount))
-                .where(Expense.user_id == user_id)
+                .where(Expense.household_id == household_id)
                 .where(Expense.category_id == budget.category_id)
                 .where(Expense.date >= budget.start_date)
                 .where(Expense.date <= end_date)

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -226,12 +226,12 @@ async def telegram_webhook(request: Request, db: AsyncSession = Depends(get_db))
 
     # /report 명령어 처리 (이번 달 지출 요약)
     if user_text.startswith("/report"):
-        await handle_report_command(chat_id, db, user_id=bot_user.id)
+        await handle_report_command(chat_id, db, household_id=active_household_id)
         return {"ok": True}
 
     # /budget 명령어 처리 (예산 현황)
     if user_text.startswith("/budget"):
-        await handle_budget_command(chat_id, db, user_id=bot_user.id)
+        await handle_budget_command(chat_id, db, household_id=active_household_id)
         return {"ok": True}
 
     # /link 명령어 처리 (코드 기반 연동)
@@ -646,19 +646,23 @@ async def answer_callback_query(callback_id: str, text: str):
         await client.post(url, json={"callback_query_id": callback_id, "text": text})
 
 
-async def handle_report_command(chat_id: int, db: AsyncSession, user_id: int):
+async def handle_report_command(chat_id: int, db: AsyncSession, household_id: int | None):
     """이번 달 지출 요약 리포트 전송
 
     카테고리별 지출 합계와 건수를 집계하여 메시지로 보냅니다.
-    사용자별로 데이터를 격리하여 조회합니다.
+    가구 단위로 데이터를 조회합니다 (웹 리포트와 동일한 스코프).
 
     Args:
         chat_id: 메시지를 보낼 채팅방 ID
         db: 데이터베이스 세션
-        user_id: 조회할 사용자 ID
+        household_id: 조회할 가구 ID
     """
+    if household_id is None:
+        await send_telegram_message(chat_id, "🏠 가구 설정이 필요합니다.\n웹에서 계정을 연동해주세요.")
+        return
+
     try:
-        # 이번 달 1일부터 현재까지 지출 집계 (해당 사용자만)
+        # 이번 달 1일부터 현재까지 지출 집계 (가구 단위)
         now = datetime.now()
         result = await db.execute(
             select(
@@ -667,7 +671,7 @@ async def handle_report_command(chat_id: int, db: AsyncSession, user_id: int):
                 func.count(Expense.id).label("count"),
             )
             .join(Category, Expense.category_id == Category.id)
-            .where(Expense.user_id == user_id)
+            .where(Expense.household_id == household_id)
             .where(extract("year", Expense.date) == now.year)
             .where(extract("month", Expense.date) == now.month)
             .group_by(Category.name)
@@ -685,20 +689,24 @@ async def handle_report_command(chat_id: int, db: AsyncSession, user_id: int):
         await send_telegram_message(chat_id, format_server_error())
 
 
-async def handle_budget_command(chat_id: int, db: AsyncSession, user_id: int):
+async def handle_budget_command(chat_id: int, db: AsyncSession, household_id: int | None):
     """예산 현황 전송
 
     설정된 예산과 현재 지출을 비교하여 메시지로 보냅니다.
-    사용자별로 데이터를 격리하여 조회합니다.
+    가구 단위로 데이터를 조회합니다 (웹 리포트와 동일한 스코프).
 
     Args:
         chat_id: 메시지를 보낼 채팅방 ID
         db: 데이터베이스 세션
-        user_id: 조회할 사용자 ID
+        household_id: 조회할 가구 ID
     """
+    if household_id is None:
+        await send_telegram_message(chat_id, "🏠 가구 설정이 필요합니다.\n웹에서 계정을 연동해주세요.")
+        return
+
     try:
-        # 해당 사용자의 활성 예산 조회
-        budget_result = await db.execute(select(Budget).where(Budget.user_id == user_id))
+        # 해당 가구의 활성 예산 조회
+        budget_result = await db.execute(select(Budget).where(Budget.household_id == household_id))
         budgets = budget_result.scalars().all()
 
         if not budgets:
@@ -721,10 +729,10 @@ async def handle_budget_command(chat_id: int, db: AsyncSession, user_id: int):
             if not category:
                 continue
 
-            # 지출 합계 (해당 사용자만)
+            # 지출 합계 (가구 단위)
             expense_result = await db.execute(
                 select(func.sum(Expense.amount))
-                .where(Expense.user_id == user_id)
+                .where(Expense.household_id == household_id)
                 .where(Expense.category_id == budget.category_id)
                 .where(Expense.date >= budget.start_date)
                 .where(Expense.date <= end_date)

--- a/backend/app/services/bot_user_service.py
+++ b/backend/app/services/bot_user_service.py
@@ -13,6 +13,8 @@ from passlib.context import CryptContext
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.budget import Budget
+from app.models.category import Category
 from app.models.expense import Expense
 from app.models.household import Household
 from app.models.household_member import HouseholdMember
@@ -81,6 +83,10 @@ async def get_or_create_bot_user(db: AsyncSession, platform: str, platform_user_
             await db.flush()
             logger.info(f"봇 사용자 기본 가구 생성: user_id={user.id}, household_id={household.id}")
 
+            # PR #105 이후: 레거시 {platform}_unknown 데이터를 실제 유저로 이관
+            if platform_user_id != "unknown":
+                await _migrate_unknown_bot_data(db, platform, user, household.id)
+
     return user
 
 
@@ -136,6 +142,52 @@ async def link_telegram_account_by_code(db: AsyncSession, code: str, telegram_ch
     return True, f"✅ 연동 완료! 이제 이 채팅의 지출이 '{user.username}' 계정에 기록됩니다.{suffix}"
 
 
+async def _migrate_unknown_bot_data(db: AsyncSession, platform: str, target_user: "User", target_household_id: int) -> int:
+    """레거시 {platform}_unknown 사용자의 데이터를 실제 사용자로 이관한다.
+
+    PR #105 이전에 사용자 ID 추출 버그로 모든 데이터가 {platform}_unknown에 쌓였던 문제 해결.
+    첫 번째 실제 사용자 생성 시 또는 웹 계정 연동 시 호출된다.
+
+    Args:
+        db: 데이터베이스 세션
+        platform: 플랫폼 이름 (예: "telegram", "kakao")
+        target_user: 데이터를 받을 User 객체
+        target_household_id: 데이터를 이관할 가구 ID
+
+    Returns:
+        이관된 지출 건수
+    """
+    unknown_username = f"{platform}_unknown"
+    result = await db.execute(select(User).where(User.username == unknown_username))
+    unknown_user = result.scalar_one_or_none()
+
+    if unknown_user is None:
+        return 0
+
+    # 이관할 지출 건수 조회
+    count_result = await db.execute(select(func.count()).where(Expense.user_id == unknown_user.id))
+    migrated_count = count_result.scalar() or 0
+
+    if migrated_count == 0:
+        return 0
+
+    # Expense 이관
+    await db.execute(update(Expense).where(Expense.user_id == unknown_user.id).values(user_id=target_user.id, household_id=target_household_id))
+
+    # Income 이관
+    await db.execute(update(Income).where(Income.user_id == unknown_user.id).values(user_id=target_user.id, household_id=target_household_id))
+
+    # Budget 이관
+    await db.execute(update(Budget).where(Budget.user_id == unknown_user.id).values(user_id=target_user.id, household_id=target_household_id))
+
+    # Category 이관 (user_id 기반 개인 카테고리)
+    await db.execute(update(Category).where(Category.user_id == unknown_user.id).values(user_id=target_user.id, household_id=target_household_id))
+
+    logger.info(f"레거시 unknown 데이터 이관: {unknown_username} → user_id={target_user.id}, household_id={target_household_id}, {migrated_count}건")
+
+    return migrated_count
+
+
 async def _migrate_bot_user_data(db: AsyncSession, platform: str, platform_user_id: str, web_user: "User") -> int:
     """기존 봇 유저의 지출/수입을 연동된 웹 계정으로 이관한다.
 
@@ -175,6 +227,10 @@ async def _migrate_bot_user_data(db: AsyncSession, platform: str, platform_user_
 
     if migrated_count > 0:
         logger.info(f"봇 유저 데이터 이관: {bot_username} → user_id={web_user.id}, {migrated_count}건")
+
+    # 레거시 {platform}_unknown 데이터도 이관 시도
+    unknown_count = await _migrate_unknown_bot_data(db, platform, web_user, household_id)
+    migrated_count += unknown_count
 
     return migrated_count
 

--- a/backend/tests/integration/test_api_telegram.py
+++ b/backend/tests/integration/test_api_telegram.py
@@ -650,7 +650,20 @@ async def test_webhook_report_command(client, db_session, mock_telegram_send, mo
 
 @pytest.mark.asyncio
 async def test_webhook_report_empty(client, db_session, mock_telegram_send):
-    """/report 명령어 — 지출이 없을 때"""
+    """/report 명령어 — 가구 미설정 시 안내 메시지"""
+    payload = {"message": {"chat": {"id": 44444}, "text": "/report"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    mock_telegram_send.assert_called_once()
+    sent_message = mock_telegram_send.call_args[0][1]
+    assert "가구 설정" in sent_message
+
+
+@pytest.mark.asyncio
+async def test_webhook_report_empty_with_household(client, db_session, mock_telegram_send):
+    """/report 명령어 — 가구 있지만 지출이 없을 때"""
+    await setup_bot_user_with_household(db_session, chat_id=44444)
     payload = {"message": {"chat": {"id": 44444}, "text": "/report"}}
     response = await client.post("/api/telegram/webhook", json=payload)
     assert response.status_code == 200
@@ -662,7 +675,20 @@ async def test_webhook_report_empty(client, db_session, mock_telegram_send):
 
 @pytest.mark.asyncio
 async def test_webhook_budget_command(client, db_session, mock_telegram_send):
-    """/budget 명령어 — 예산 없을 때"""
+    """/budget 명령어 — 가구 미설정 시 안내 메시지"""
+    payload = {"message": {"chat": {"id": 44444}, "text": "/budget"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    mock_telegram_send.assert_called_once()
+    sent_message = mock_telegram_send.call_args[0][1]
+    assert "가구 설정" in sent_message
+
+
+@pytest.mark.asyncio
+async def test_webhook_budget_command_with_household(client, db_session, mock_telegram_send):
+    """/budget 명령어 — 가구 있지만 예산 없을 때"""
+    await setup_bot_user_with_household(db_session, chat_id=44444)
     payload = {"message": {"chat": {"id": 44444}, "text": "/budget"}}
     response = await client.post("/api/telegram/webhook", json=payload)
     assert response.status_code == 200

--- a/backend/tests/unit/test_bot_unknown_migration.py
+++ b/backend/tests/unit/test_bot_unknown_migration.py
@@ -1,0 +1,174 @@
+"""
+kakao_unknown 레거시 데이터 이관 테스트
+
+PR #105 이후 카카오 사용자 ID 추출 버그가 수정되면서,
+기존 kakao_unknown에 쌓였던 데이터를 실제 유저로 이관하는 로직을 테스트합니다.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.models.category import Category
+from app.models.expense import Expense
+from app.models.household import Household
+from app.models.household_member import HouseholdMember
+from app.models.income import Income
+from app.models.user import User
+from app.services.bot_user_service import (
+    _migrate_unknown_bot_data,
+    get_or_create_bot_user,
+)
+
+
+async def _create_bot_user_with_household(db_session, platform: str, platform_user_id: str) -> tuple[User, Household]:
+    """테스트용 봇 유저 + 가구 생성 헬퍼"""
+    from passlib.context import CryptContext
+
+    pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+    user = User(
+        username=f"{platform}_{platform_user_id}",
+        email=None,
+        hashed_password=pwd_context.hash("test"),
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    household = Household(name="내 가계부", currency="KRW")
+    db_session.add(household)
+    await db_session.flush()
+
+    member = HouseholdMember(household_id=household.id, user_id=user.id, role="owner")
+    db_session.add(member)
+    await db_session.flush()
+
+    return user, household
+
+
+async def _create_expense(db_session, user_id: int, household_id: int, amount: float, category_name: str = "식비") -> Expense:
+    """테스트용 지출 생성 헬퍼"""
+    # 카테고리 찾기 또는 생성
+    result = await db_session.execute(select(Category).where(Category.name == category_name, Category.household_id == household_id))
+    category = result.scalar_one_or_none()
+    if not category:
+        category = Category(name=category_name, household_id=household_id)
+        db_session.add(category)
+        await db_session.flush()
+
+    expense = Expense(
+        user_id=user_id,
+        household_id=household_id,
+        amount=amount,
+        description=f"테스트 지출 {amount}원",
+        category_id=category.id,
+        date=datetime.now(),
+    )
+    db_session.add(expense)
+    await db_session.flush()
+    return expense
+
+
+@pytest.mark.asyncio
+async def test_migrate_unknown_data_on_first_real_user(db_session):
+    """kakao_unknown 유저에 지출 데이터가 있을 때, 실제 카카오 유저 생성 시 데이터가 이관되는지 확인"""
+    # 1) kakao_unknown 유저와 지출 생성
+    unknown_user, unknown_household = await _create_bot_user_with_household(db_session, "kakao", "unknown")
+    await _create_expense(db_session, unknown_user.id, unknown_household.id, 8000)
+    await _create_expense(db_session, unknown_user.id, unknown_household.id, 5000)
+    await db_session.commit()
+
+    # unknown 유저에 2건 확인
+    result = await db_session.execute(select(Expense).where(Expense.user_id == unknown_user.id))
+    assert len(result.scalars().all()) == 2
+
+    # 2) 실제 카카오 유저 생성 (auto_create_household=True → unknown 데이터 이관 트리거)
+    real_user = await get_or_create_bot_user(db_session, platform="kakao", platform_user_id="real_abc123", auto_create_household=True)
+    await db_session.commit()
+
+    # 3) unknown 유저의 지출이 real_user로 이관됐는지 확인
+    result = await db_session.execute(select(Expense).where(Expense.user_id == real_user.id))
+    real_expenses = result.scalars().all()
+    assert len(real_expenses) == 2
+
+    # unknown 유저에는 지출이 없어야 함
+    result = await db_session.execute(select(Expense).where(Expense.user_id == unknown_user.id))
+    assert len(result.scalars().all()) == 0
+
+
+@pytest.mark.asyncio
+async def test_no_migration_when_no_unknown_user(db_session):
+    """kakao_unknown 유저가 없으면 오류 없이 정상 동작해야 함"""
+    real_user = await get_or_create_bot_user(db_session, platform="kakao", platform_user_id="new_user_123", auto_create_household=True)
+    await db_session.commit()
+
+    assert real_user is not None
+    assert real_user.username == "kakao_new_user_123"
+
+
+@pytest.mark.asyncio
+async def test_unknown_migration_only_on_new_user(db_session):
+    """이미 이관된 데이터는 두 번째 유저에게 이관되지 않아야 함"""
+    # 1) kakao_unknown 유저와 지출 생성
+    unknown_user, unknown_household = await _create_bot_user_with_household(db_session, "kakao", "unknown")
+    await _create_expense(db_session, unknown_user.id, unknown_household.id, 8000)
+    await db_session.commit()
+
+    # 2) 첫 번째 실제 유저 생성 → unknown 데이터 이관
+    user1 = await get_or_create_bot_user(db_session, platform="kakao", platform_user_id="first_user", auto_create_household=True)
+    await db_session.commit()
+
+    # 3) 두 번째 실제 유저 생성 → 이관할 데이터 없음
+    user2 = await get_or_create_bot_user(db_session, platform="kakao", platform_user_id="second_user", auto_create_household=True)
+    await db_session.commit()
+
+    # user1에 1건, user2에 0건
+    result = await db_session.execute(select(Expense).where(Expense.user_id == user1.id))
+    assert len(result.scalars().all()) == 1
+
+    result = await db_session.execute(select(Expense).where(Expense.user_id == user2.id))
+    assert len(result.scalars().all()) == 0
+
+
+@pytest.mark.asyncio
+async def test_migrate_unknown_bot_data_directly(db_session):
+    """_migrate_unknown_bot_data 함수 직접 호출 테스트"""
+    # 1) kakao_unknown 유저와 데이터 생성
+    unknown_user, unknown_household = await _create_bot_user_with_household(db_session, "kakao", "unknown")
+    await _create_expense(db_session, unknown_user.id, unknown_household.id, 10000)
+
+    # 수입도 생성
+    income = Income(user_id=unknown_user.id, household_id=unknown_household.id, amount=500000, description="급여", date=datetime.now())
+    db_session.add(income)
+    await db_session.flush()
+    await db_session.commit()
+
+    # 2) 대상 유저와 가구 생성
+    target_user, target_household = await _create_bot_user_with_household(db_session, "kakao", "target_user")
+    await db_session.commit()
+
+    # 3) 이관 실행
+    count = await _migrate_unknown_bot_data(db_session, "kakao", target_user, target_household.id)
+    await db_session.commit()
+
+    assert count == 1  # 지출 1건
+
+    # 지출이 이관됐는지 확인
+    result = await db_session.execute(select(Expense).where(Expense.user_id == target_user.id))
+    assert len(result.scalars().all()) == 1
+
+    # 수입도 이관됐는지 확인
+    result = await db_session.execute(select(Income).where(Income.user_id == target_user.id))
+    assert len(result.scalars().all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_migrate_unknown_data_returns_zero_when_no_data(db_session):
+    """kakao_unknown에 데이터가 없으면 0을 반환해야 함"""
+    target_user, target_household = await _create_bot_user_with_household(db_session, "kakao", "target")
+    await db_session.commit()
+
+    count = await _migrate_unknown_bot_data(db_session, "kakao", target_user, target_household.id)
+    assert count == 0


### PR DESCRIPTION
- index.css: yellow, green 다크모드 CSS 변수 오버라이드 추가
- 전체 컴포넌트 text-*-700/800/900을 600으로 통일 (18개 파일)
- 예산현황, 토스트, 관리자, 정기거래, 폼 등 모든 페이지 적용

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>