### PR TITLE
fix: 코드리뷰 그룹2 FE 버그 수정

### DIFF
--- a/backend/app/api/budget.py
+++ b/backend/app/api/budget.py
@@ -5,7 +5,7 @@ household_id가 있으면 가구 공유 예산, 없으면 개인 예산으로 �
 expenses/recurring과 동일한 household 패턴을 따릅니다.
 """
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import and_, extract, func, or_, select
@@ -485,7 +485,13 @@ async def update_budget(
     for field, value in update_data.items():
         setattr(budget, field, value)
 
-    if budget.end_date and budget.end_date < budget.start_date:
+    # DB 컬럼(DateTime)과 스키마(date) 혼용 방지: 둘 다 date로 정규화 후 비교
+    def _as_date(val: datetime | date | None) -> date | None:
+        if val is None:
+            return None
+        return val.date() if isinstance(val, datetime) else val
+
+    if budget.end_date and _as_date(budget.end_date) < _as_date(budget.start_date):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="종료일은 시작일 이후여야 합니다")
 
     await db.commit()

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -16,9 +16,14 @@ logger = logging.getLogger(__name__)
 
 
 def _verify_sentry_signature(body: bytes, signature: str, secret: str) -> bool:
-    """Sentry HMAC-SHA256 서명 검증"""
+    """Sentry HMAC-SHA256 서명 검증
+
+    Sentry는 'sha256=<hex>' 형식으로 서명을 전송하므로 prefix를 제거 후 비교한다.
+    """
+    # 'sha256=hexdigest' 형식에서 hex 값만 추출
+    hex_signature = signature.removeprefix("sha256=")
     expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, signature)
+    return hmac.compare_digest(expected, hex_signature)
 
 
 def _format_sentry_alert(payload: dict) -> str:

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -3,7 +3,7 @@
 예산 설정 및 초과 알림에 사용되는 DTO들입니다.
 """
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -26,8 +26,8 @@ class BudgetCreate(BaseModel):
     category_id: int = Field(..., description="카테고리 ID")
     amount: float = Field(..., gt=0, description="예산 금액 (양수)")
     period: Literal["monthly", "weekly", "daily"] = Field(..., description="예산 기간")
-    start_date: datetime = Field(..., description="예산 시작일")
-    end_date: datetime | None = Field(None, description="예산 종료일 (None이면 무기한)")
+    start_date: date = Field(..., description="예산 시작일")
+    end_date: date | None = Field(None, description="예산 종료일 (None이면 무기한)")
     alert_threshold: float = Field(default=0.8, ge=0.0, le=1.0, description="알림 임계값 (0~1, 기본 0.8)")
 
 
@@ -39,8 +39,8 @@ class BudgetUpdate(BaseModel):
 
     amount: float | None = Field(None, gt=0, description="예산 금액")
     period: Literal["monthly", "weekly", "daily"] | None = Field(None, description="예산 기간")
-    start_date: datetime | None = Field(None, description="예산 시작일")
-    end_date: datetime | None = Field(None, description="예산 종료일")
+    start_date: date | None = Field(None, description="예산 시작일")
+    end_date: date | None = Field(None, description="예산 종료일")
     alert_threshold: float | None = Field(None, ge=0.0, le=1.0, description="알림 임계값")
 
 

--- a/backend/tests/integration/test_api_budget.py
+++ b/backend/tests/integration/test_api_budget.py
@@ -4,7 +4,7 @@
 모든 엔드포인트는 JWT 인증이 필요합니다.
 """
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -33,14 +33,13 @@ async def test_create_budget_success(authenticated_client: AsyncClient, test_use
     await db_session.commit()
     await db_session.refresh(category)
 
-    start_date = datetime.now()
     response = await authenticated_client.post(
         "/api/budgets",
         json={
             "category_id": category.id,
             "amount": 300000,
             "period": "monthly",
-            "start_date": start_date.isoformat(),
+            "start_date": date.today().isoformat(),
             "end_date": None,
             "alert_threshold": 0.8,
         },
@@ -64,7 +63,7 @@ async def test_create_budget_nonexistent_category(authenticated_client: AsyncCli
             "category_id": 99999,
             "amount": 100000,
             "period": "monthly",
-            "start_date": datetime.now().isoformat(),
+            "start_date": date.today().isoformat(),
         },
     )
 
@@ -80,7 +79,7 @@ async def test_create_budget_invalid_dates(authenticated_client: AsyncClient, te
     await db_session.commit()
     await db_session.refresh(category)
 
-    start_date = datetime.now()
+    start_date = date.today()
     end_date = start_date - timedelta(days=1)
 
     response = await authenticated_client.post(

--- a/backend/tests/integration/test_api_budget_extra.py
+++ b/backend/tests/integration/test_api_budget_extra.py
@@ -44,8 +44,8 @@ async def test_update_budget_invalid_dates(authenticated_client: AsyncClient, te
     await db_session.commit()
     await db_session.refresh(budget)
 
-    # 종료일을 시작일보다 이전으로 수정 시도
-    early_date = (start_date - timedelta(days=10)).isoformat()
+    # 종료일을 시작일보다 이전으로 수정 시도 (date 형식)
+    early_date = (start_date.date() - timedelta(days=10)).isoformat()
     response = await authenticated_client.put(
         f"/api/budgets/{budget.id}",
         json={"end_date": early_date},

--- a/frontend/src/api/__tests__/households.test.ts
+++ b/frontend/src/api/__tests__/households.test.ts
@@ -108,7 +108,7 @@ const householdHandlers = [
   http.post(`${BASE_URL}/households/:id/leave`, () =>
     new HttpResponse(null, { status: 204 })
   ),
-  http.put(`${BASE_URL}/households/:householdId/members/:userId/role`, () =>
+  http.patch(`${BASE_URL}/households/:householdId/members/:userId/role`, () =>
     HttpResponse.json({ message: 'ok' })
   ),
   http.delete(`${BASE_URL}/households/:householdId/members/:userId`, () =>
@@ -205,7 +205,7 @@ describe('householdApi', () => {
   })
 
   describe('updateMemberRole', () => {
-    it('PUT /api/households/:id/members/:userId/role을 호출하여 역할을 변경한다', async () => {
+    it('PATCH /api/households/:id/members/:userId/role을 호출하여 역할을 변경한다', async () => {
       const response = await householdApi.updateMemberRole(1, 2, 'admin')
 
       expect(response.data).toEqual({ message: 'ok' })

--- a/frontend/src/api/households.ts
+++ b/frontend/src/api/households.ts
@@ -70,7 +70,7 @@ export const deleteHousehold = (id: number) =>
  * @param role - 변경할 역할
  */
 export const updateMemberRole = (householdId: number, userId: number, role: MemberRole) =>
-  apiClient.put(`/households/${householdId}/members/${userId}/role`, { role })
+  apiClient.patch(`/households/${householdId}/members/${userId}/role`, { role })
 
 /**
  * 멤버 추방 API (관리자/소유자가 다른 멤버를 추방)

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -112,8 +112,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const t = tokenRef.current ?? getCookieToken()
         if (t) {
           config.headers.Authorization = `Bearer ${t}`
-        } else {
-          // 토큰 없이 요청 — 디버깅용 (Safari ITP/Private 모드 추적)
+        } else if (import.meta.env.DEV) {
+          // 토큰 없이 요청 — 개발 환경 디버깅용 (Safari ITP/Private 모드 추적)
           console.warn('[podo-auth] 요청 토큰 없음:', config.url, {
             tokenRef: tokenRef.current,
             cookie: !!document.cookie.match(/podo_access_token/),

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -44,41 +44,55 @@ function getInitialMode(): ThemeMode {
   return 'system'
 }
 
+/** DOM에만 테마를 적용하는 순수 함수 (state 변경 없음)
+ *
+ * useEffect 내부에서 호출해도 cascading render가 발생하지 않는다.
+ * setResolvedTheme은 외부 이벤트(사용자 액션, OS 변경) 핸들러에서만 호출한다.
+ */
+function applyThemeToDom(resolved: 'light' | 'dark') {
+  const root = document.documentElement
+  if (resolved === 'dark') {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+  // PWA 상태바 색상 변경
+  const meta = document.querySelector('meta[name="theme-color"]')
+  if (meta) {
+    meta.setAttribute('content', resolved === 'dark' ? THEME_COLOR_DARK : THEME_COLOR_LIGHT)
+  }
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [mode, setModeState] = useState<ThemeMode>(getInitialMode)
   const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>(() => resolveTheme(getInitialMode()))
 
-  const applyTheme = useCallback((resolved: 'light' | 'dark') => {
-    const root = document.documentElement
-    if (resolved === 'dark') {
-      root.classList.add('dark')
-    } else {
-      root.classList.remove('dark')
-    }
-    // PWA 상태바 색상 변경
-    const meta = document.querySelector('meta[name="theme-color"]')
-    if (meta) {
-      meta.setAttribute('content', resolved === 'dark' ? THEME_COLOR_DARK : THEME_COLOR_LIGHT)
-    }
+  const setMode = useCallback((newMode: ThemeMode) => {
+    const resolved = resolveTheme(newMode)
+    setModeState(newMode)
     setResolvedTheme(resolved)
+    localStorage.setItem(STORAGE_KEY, newMode)
+    applyThemeToDom(resolved)
   }, [])
 
-  const setMode = useCallback((newMode: ThemeMode) => {
-    setModeState(newMode)
-    localStorage.setItem(STORAGE_KEY, newMode)
-    applyTheme(resolveTheme(newMode))
-  }, [applyTheme])
+  // 마운트 시 초기 테마 DOM 적용 (FOUC 방지)
+  // state는 이미 초기화되어 있으므로 DOM 업데이트만 수행한다
+  useEffect(() => {
+    applyThemeToDom(resolvedTheme)
+  }, [resolvedTheme])
 
   // system 모드일 때 OS 설정 변경 감지
   useEffect(() => {
     if (mode !== 'system' || !window.matchMedia) return
     const mq = window.matchMedia('(prefers-color-scheme: dark)')
     const handler = (e: MediaQueryListEvent) => {
-      applyTheme(e.matches ? 'dark' : 'light')
+      const resolved = e.matches ? 'dark' : 'light'
+      setResolvedTheme(resolved)
+      applyThemeToDom(resolved)
     }
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
-  }, [mode, applyTheme])
+  }, [mode])
 
   return (
     <ThemeContext.Provider value={{ mode, resolvedTheme, setMode }}>

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -5,7 +5,7 @@
  * 토스트 알림을 추가/제거할 수 있는 기능을 제공한다.
  */
 
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useState, useCallback } from 'react'
 import type { ReactNode } from 'react'
 import Toast from '../components/Toast'
 import type { ToastType } from '../components/Toast'
@@ -46,9 +46,11 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     setToasts((prev) => [...prev, { id, type, message, duration }])
   }
 
-  const removeToast = (id: string) => {
+  // useCallback으로 참조 안정화: Toast의 useEffect deps에 onClose가 포함되어
+  // removeToast가 재생성될 때마다 타이머가 리셋되는 stale closure 방지
+  const removeToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((toast) => toast.id !== id))
-  }
+  }, [])
 
   return (
     <ToastContext.Provider value={{ addToast, removeToast }}>

--- a/frontend/src/pages/ExpenseForm.tsx
+++ b/frontend/src/pages/ExpenseForm.tsx
@@ -11,6 +11,7 @@ import { useNavigate, Link } from 'react-router-dom'
 import { ArrowLeft, Camera } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { expenseApi } from '../api/expenses'
+import { incomeApi } from '../api/income'
 import { categoryApi } from '../api/categories'
 import { chatApi } from '../api/chat'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
@@ -115,19 +116,25 @@ export default function ExpenseForm() {
     try {
       let savedCount = 0
       for (const item of previewItems) {
-        await expenseApi.create({
+        // date input은 YYYY-MM-DD 형식이므로 datetime으로 변환 (Pydantic v2는 날짜 전용 문자열 거부)
+        const dateValue = item.date.includes('T') ? item.date : `${item.date}T00:00:00`
+        const payload = {
           amount: item.amount,
           description: item.description,
           category_id: item.category_id,
-          // date input은 YYYY-MM-DD 형식이므로 datetime으로 변환 (Pydantic v2는 날짜 전용 문자열 거부)
-          date: item.date.includes('T') ? item.date : `${item.date}T00:00:00`,
+          date: dateValue,
           household_id: activeHouseholdId,
           raw_input: rawInput,
           memo: item.memo || undefined,
-        })
+        }
+        if (item.type === 'income') {
+          await incomeApi.create(payload)
+        } else {
+          await expenseApi.create(payload)
+        }
         savedCount++
       }
-      addToast('success', `🍇 포도알 +${savedCount}! 지출이 저장되었습니다`)
+      addToast('success', `🍇 포도알 +${savedCount}! 거래가 저장되었습니다`)
       setPreviewItems(null)
       setNaturalInput('')
       setTimeout(() => navigate('/expenses'), 500)

--- a/frontend/src/pages/TransactionList.tsx
+++ b/frontend/src/pages/TransactionList.tsx
@@ -6,7 +6,6 @@
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import PeriodNavigator from '../components/stats/PeriodNavigator'
-import toast from 'react-hot-toast'
 import { expenseApi } from '../api/expenses'
 import { incomeApi } from '../api/income'
 import { recurringApi } from '../api/recurring'
@@ -208,7 +207,7 @@ export default function TransactionList() {
       }
       setSheetOpen(false)
     } catch {
-      toast.error('카테고리 변경에 실패했습니다')
+      addToast('error', '카테고리 변경에 실패했습니다')
     } finally {
       setSheetSaving(false)
     }

--- a/frontend/src/pages/__tests__/ExpenseForm.test.tsx
+++ b/frontend/src/pages/__tests__/ExpenseForm.test.tsx
@@ -134,7 +134,7 @@ describe('ExpenseForm', () => {
       fireEvent.submit(submitBtn.closest('form')!)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', expect.stringContaining('지출이 저장되었습니다'))
+        expect(mockAddToast).toHaveBeenCalledWith('success', expect.stringContaining('저장되었습니다'))
       })
     })
 
@@ -344,7 +344,7 @@ describe('ExpenseForm', () => {
         // 핵심 검증: date 필드에 반드시 T가 포함되어야 함
         // T가 없으면 백엔드에서 422 에러 발생 (Pydantic v2 datetime 파싱 실패)
         expect(capturedExpenseBody!['date']).toContain('T')
-        expect(mockAddToast).toHaveBeenCalledWith('success', expect.stringContaining('지출이 저장되었습니다'))
+        expect(mockAddToast).toHaveBeenCalledWith('success', expect.stringContaining('거래가 저장되었습니다'))
       })
     })
 

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -15,10 +15,11 @@ export function formatCompactAmount(amount: number): string {
     return amount.toLocaleString('ko-KR')
   }
   if (amount < 1000000) {
-    const man = amount / 10000
-    const formatted = man % 1 === 0 ? man.toFixed(0) : man.toFixed(1)
-    return `${formatted}만`
+    // Math.floor로 반올림 방지 (예: 999,999원 → "99.9만", "100.0만" 아님)
+    const man = Math.floor(amount / 10000)
+    const tenths = Math.floor((amount % 10000) / 1000)
+    return tenths === 0 ? `${man}만` : `${man}.${tenths}만`
   }
-  const man = Math.round(amount / 10000)
+  const man = Math.floor(amount / 10000)
   return `${man}만`
 }

--- a/frontend/src/utils/healthScore.ts
+++ b/frontend/src/utils/healthScore.ts
@@ -19,6 +19,11 @@ interface HealthScoreInput {
  * - overall: 가중 평균 → grade
  */
 export function calculateHealthScore(input: HealthScoreInput): HealthScore {
+  // 수입/지출 모두 0이면 데이터 없음 (신규 사용자) — 의미없는 점수 대신 '-' 등급 반환
+  if (input.incomeTotal === 0 && input.expenseTotal === 0) {
+    return { savings: 0, spending: 0, debt: 100, overall: 0, grade: '-' }
+  }
+
   const {
     incomeTotal,
     expenseTotal,


### PR DESCRIPTION
## Summary

- #148: `ExpenseForm` - LLM이 `type:income`으로 파싱한 항목을 `incomeApi`로 저장 (기존: 모두 `expenseApi`)
- #150: `updateMemberRole` PUT → PATCH 메서드 수정 (백엔드 엔드포인트와 일치)
- #155: Sentry webhook 서명에서 `sha256=` prefix 파싱, `AuthContext` `console.warn` DEV 전용으로 제한
- #156: `ThemeProvider` 마운트 시 DOM에 테마 즉시 적용(FOUC 방지), `BudgetCreate` `start_date`/`end_date` `date` 타입으로 통일
- #160: `formatCompactAmount` `Math.floor` 적용(999,999원→"99.9만"), `calculateHealthScore` 신규 사용자 `-` 등급, `removeToast` `useCallback` 적용
- #188: `TransactionList` `react-hot-toast` 직접 import 제거, `useToast` 훅으로 통일

close #148
close #150
close #155
close #156
close #160
close #188

## Test plan

- [x] BE: `575 passed, 5 skipped` (기존 동일)
- [x] FE: `520 passed` (기존 동일)
- [x] `ruff check + ruff format` 통과
- [x] `npm run lint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)