### PR TITLE
fix: BE 보안 취약점 수정 (#133, #131, #142, #143, #144)

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -186,7 +186,8 @@ async def require_admin(
     """
     from app.core.config import settings
 
-    if current_user.id != settings.ADMIN_USER_ID:
+    # ADMIN_USER_ID <= 0은 "미설정" — 환경변수 미설정 시 관리자 기능 완전 비활성화
+    if settings.ADMIN_USER_ID <= 0 or current_user.id != settings.ADMIN_USER_ID:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="관리자만 접근할 수 있습니다",

--- a/backend/app/api/kakao.py
+++ b/backend/app/api/kakao.py
@@ -127,11 +127,12 @@ async def kakao_webhook(request: Request, db: AsyncSession = Depends(get_db)):
 
     보안: KAKAO_BOT_API_KEY 설정 시 Authorization 헤더 검증
     """
-    # Webhook API 키 검증 (설정된 경우에만)
-    if settings.KAKAO_BOT_API_KEY:
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header != settings.KAKAO_BOT_API_KEY:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="유효하지 않은 API 키")
+    # KAKAO_BOT_API_KEY가 곧 인증 수단 — 미설정 시 무인증 상태이므로 모든 요청 거부
+    if not settings.KAKAO_BOT_API_KEY:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="카카오 봇 API 키가 설정되지 않았습니다")
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header != settings.KAKAO_BOT_API_KEY:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="유효하지 않은 API 키")
 
     try:
         data = await request.json()

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -188,7 +188,10 @@ async def telegram_webhook(request: Request, db: AsyncSession = Depends(get_db))
 
     보안: TELEGRAM_WEBHOOK_SECRET 설정 시 X-Telegram-Bot-Api-Secret-Token 헤더 검증
     """
-    # Webhook 시크릿 토큰 검증 (설정된 경우에만)
+    # 봇 토큰이 활성화된 경우 시크릿도 반드시 설정되어야 함
+    # 미설정 시 누구나 webhook을 호출하여 LLM 비용 발생 및 임의 데이터 생성 가능
+    if settings.TELEGRAM_BOT_TOKEN and not settings.TELEGRAM_WEBHOOK_SECRET:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Webhook 시크릿이 설정되지 않았습니다")
     if settings.TELEGRAM_WEBHOOK_SECRET:
         token = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
         if token != settings.TELEGRAM_WEBHOOK_SECRET:

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -70,6 +70,11 @@ async def sentry_webhook(
 
     body = await request.body()
 
+    # 텔레그램이 활성화된 경우 Sentry webhook 시크릿도 반드시 필요
+    # 미설정 시 누구나 관리자 텔레그램에 스팸/피싱 메시지 주입 가능
+    if not settings.SENTRY_WEBHOOK_SECRET:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Webhook 시크릿이 설정되지 않았습니다")
+
     # 서명 검증
     if settings.SENTRY_WEBHOOK_SECRET and (
         not sentry_hook_signature or not _verify_sentry_signature(body, sentry_hook_signature, settings.SENTRY_WEBHOOK_SECRET)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -52,11 +52,13 @@ class Settings(BaseSettings):
     SENTRY_WEBHOOK_SECRET: str = ""  # Sentry → 텔레그램 알림 webhook 인증용
     SENTRY_ALERT_CHAT_ID: str = ""  # Sentry 알림 수신할 텔레그램 채팅 ID
 
-    # 관리자 설정
-    ADMIN_USER_ID: int = 1  # 피드백 관리 등 관리자 기능용 사용자 ID
+    # 관리자 설정 — 기본값 -1은 "미설정" 의미 (DB에 존재하지 않는 ID)
+    # .env에서 실제 사용자 ID를 설정하지 않으면 관리자 기능이 비활성화됨
+    ADMIN_USER_ID: int = -1
 
     # CORS — 허용할 프론트엔드 오리진 (쉼표로 구분)
-    CORS_ORIGINS: str = "http://localhost:5173,https://budget.podonest.com"
+    # 기본값은 프로덕션 도메인만. 로컬 개발 시 .env에서 http://localhost:5173 추가
+    CORS_ORIGINS: str = "https://budget.podonest.com"
 
     # Email (Resend) — 빈 문자열이면 이메일 발송 비활성화
     RESEND_API_KEY: str = ""

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -11,9 +11,12 @@ def register_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(ValueError)
     async def value_error_handler(request: Request, exc: ValueError):
+        # str(exc) 전달 금지 — SQLAlchemy 쿼리, 파일 경로, 모델 구조 등 내부 정보 노출 위험
+        # Sentry에 전체 스택트레이스를 기록하고 사용자에게는 일반 메시지만 반환
+        sentry_sdk.capture_exception(exc)
         return JSONResponse(
             status_code=400,
-            content={"error": {"code": "VALIDATION_ERROR", "message": str(exc)}},
+            content={"error": {"code": "VALIDATION_ERROR", "message": "잘못된 요청입니다"}},
         )
 
     @app.exception_handler(IntegrityError)

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -4,6 +4,7 @@ Resend API를 사용한 이메일 발송을 담당합니다.
 RESEND_API_KEY가 설정되지 않으면 이메일 발송을 건너뜁니다.
 """
 
+import html
 import logging
 
 import resend
@@ -38,17 +39,23 @@ async def send_invitation_email(
     frontend_url = settings.CORS_ORIGINS.split(",")[0].strip()
     accept_url = f"{frontend_url}/invitations/accept?token={invite_token}"
 
+    # HTML 인젝션 방지: 사용자 입력값을 HTML에 삽입하기 전에 반드시 이스케이프
+    safe_inviter_name = html.escape(inviter_name)
+    safe_household_name = html.escape(household_name)
+    # 제목 필드는 HTML이 아니므로 원본 값 사용 (이메일 클라이언트가 처리)
+    subject = f"{inviter_name}님이 '{household_name}' 가구에 초대했습니다"
+
     try:
         resend.Emails.send(
             {
                 "from": settings.RESEND_FROM_EMAIL,
                 "to": [to_email],
-                "subject": f"{inviter_name}님이 '{household_name}' 가구에 초대했습니다",
+                "subject": subject,
                 "html": f"""
             <div style="font-family: 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px;">
                 <h2 style="color: #292524; margin-bottom: 16px;">가구 초대</h2>
                 <p style="color: #57534e; font-size: 16px; line-height: 1.6;">
-                    <strong>{inviter_name}</strong>님이 <strong>{household_name}</strong> 가구에 초대했습니다.
+                    <strong>{safe_inviter_name}</strong>님이 <strong>{safe_household_name}</strong> 가구에 초대했습니다.
                 </p>
                 <div style="margin: 32px 0;">
                     <a href="{accept_url}"

--- a/backend/tests/integration/test_api_kakao.py
+++ b/backend/tests/integration/test_api_kakao.py
@@ -12,12 +12,53 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 
+from app.core.config import settings as _app_settings
+from app.core.database import get_db
+from app.main import app as _app
 from app.models.expense import Expense
 from app.models.household import Household
 from app.models.household_member import HouseholdMember
 from app.models.user import User
+
+# 테스트용 API 키 (실제 운영 키와 완전히 다른 값)
+_KAKAO_TEST_API_KEY = "kakao-test-key-for-pytest"  # pragma: allowlist secret
+
+
+@pytest.fixture(autouse=True)
+def _kakao_api_key():
+    """모든 카카오 테스트에서 KAKAO_BOT_API_KEY를 테스트 값으로 설정.
+
+    #131 보안 패치: API 키 미설정 시 503을 반환하므로 테스트 환경에서도 설정 필요.
+    """
+    with patch.object(_app_settings, "KAKAO_BOT_API_KEY", _KAKAO_TEST_API_KEY):
+        yield
+
+
+@pytest_asyncio.fixture
+async def client(db_session):
+    """카카오 테스트용 HTTP 클라이언트 (Authorization 헤더 자동 포함).
+
+    #131 보안 패치: API 키 검증이 필수화되었으므로 모든 요청에 올바른 키를 전송.
+    기존 보안 테스트는 patch("app.api.kakao.settings")로 키를 직접 제어하므로 영향 없음.
+    """
+
+    async def override_get_db():
+        yield db_session
+
+    _app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(
+        transport=ASGITransport(app=_app),
+        base_url="http://test",
+        headers={"Authorization": _KAKAO_TEST_API_KEY},
+    ) as ac:
+        yield ac
+
+    _app.dependency_overrides.clear()
 
 
 def make_kakao_request(utterance: str, user_id: str = "kakao_user_123") -> dict:

--- a/backend/tests/integration/test_api_webhooks.py
+++ b/backend/tests/integration/test_api_webhooks.py
@@ -24,18 +24,25 @@ SENTRY_PAYLOAD = {
 @pytest.mark.asyncio
 async def test_sentry_webhook_전송_성공(authenticated_client: AsyncClient):
     """Sentry webhook → 텔레그램 메시지 전송"""
+    # #131 보안 패치: SENTRY_WEBHOOK_SECRET 미설정 시 503 반환
+    # 테스트에서도 시크릿을 설정하고 올바른 HMAC 서명을 함께 전송해야 함
+    _secret = "test-sentry-secret"  # pragma: allowlist secret
+    _body = json.dumps(SENTRY_PAYLOAD).encode()
+    _sig = hmac.new(_secret.encode(), _body, hashlib.sha256).hexdigest()
+
     with (
         patch("app.api.webhooks.settings") as mock_settings,
         patch("app.api.telegram.send_telegram_message", new_callable=AsyncMock) as mock_send,
     ):
         mock_settings.TELEGRAM_BOT_TOKEN = "fake-token"
         mock_settings.SENTRY_ALERT_CHAT_ID = "12345"
-        mock_settings.SENTRY_WEBHOOK_SECRET = ""
+        mock_settings.SENTRY_WEBHOOK_SECRET = _secret
         mock_settings.SENTRY_ENVIRONMENT = "production"
 
         response = await authenticated_client.post(
             "/api/webhooks/sentry",
-            json=SENTRY_PAYLOAD,
+            content=_body,
+            headers={"content-type": "application/json", "sentry-hook-signature": _sig},
         )
 
     assert response.status_code == 200

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -2,19 +2,36 @@
 
 접근 제어(403), 대시보드 통합 통계, 사용자 관리 엔드포인트를 검증합니다.
 test_user(id=1)는 ADMIN_USER_ID=1과 일치하므로 관리자로 간주됩니다.
+
+참고: #133 패치로 ADMIN_USER_ID 기본값이 -1(미설정)로 바뀌었으므로,
+      admin 기능이 필요한 테스트는 아래 autouse 픽스처로 ADMIN_USER_ID=1로 패치합니다.
+      SQLite in-memory 테스트 DB에서 test_user는 항상 id=1로 생성됩니다.
 """
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 from httpx import AsyncClient
 
+from app.core.config import settings as _app_settings
 from app.models.expense import Expense
 from app.models.feedback import Feedback
 from app.models.household import Household
 from app.models.household_member import HouseholdMember
 from app.models.income import Income
 from app.models.user import User
+
+# SQLite in-memory 테스트 DB에서 test_user는 항상 id=1
+_TEST_ADMIN_USER_ID = 1
+
+
+@pytest.fixture(autouse=True)
+def _set_admin_user_id():
+    """ADMIN_USER_ID를 test_user.id(=1)로 패치하여 admin 엔드포인트 접근 허용."""
+    with patch.object(_app_settings, "ADMIN_USER_ID", _TEST_ADMIN_USER_ID):
+        yield
+
 
 # ── 접근 제어 테스트 ──
 


### PR DESCRIPTION
## 변경 내용

### #133 — ADMIN_USER_ID 기본값 보안 강화
- `ADMIN_USER_ID` 기본값 `1` → `-1` (미설정 의미)
- `require_admin`에서 `ADMIN_USER_ID <= 0` 이면 무조건 403 반환
- 환경변수 미설정 시 관리자 기능 완전 비활성화

### #131 — Webhook/봇 API 무인증 요청 차단
- Kakao webhook: `KAKAO_BOT_API_KEY` 미설정 시 503 반환, 설정 시 무조건 Authorization 헤더 검증
- Telegram webhook: `TELEGRAM_WEBHOOK_SECRET` 미설정 시 503 반환
- Sentry webhook: `SENTRY_WEBHOOK_SECRET` 미설정 시 503 반환

### #142 — CORS 기본값에서 localhost 제거
- `CORS_ORIGINS` 기본값에서 `http://localhost:5173` 제거
- 운영 환경 기본값: `https://budget.podonest.com`만 허용

### #143 — ValueError 핸들러 내부 정보 노출 방지
- `str(exc)` 대신 일반 메시지 `"잘못된 요청입니다"` 반환
- Sentry에 전체 스택트레이스 보고 추가

### #144 — 초대 이메일 HTML 인젝션 방지
- `inviter_name`, `household_name`을 `html.escape()` 처리 후 HTML 삽입

## 테스트
- `test_admin.py`: `ADMIN_USER_ID=1` 패치로 기존 동작 유지
- `test_api_kakao.py`: `KAKAO_BOT_API_KEY` 설정 + Authorization 헤더 포함 client 픽스처 추가
- `test_api_webhooks.py`: `SENTRY_WEBHOOK_SECRET` 설정 + HMAC 서명 전송으로 수정
- BE 전체 575개 통과, 5개 스킵

close #133
close #131
close #142
close #143
close #144