### PR TITLE
fix: 코드품질/보안/인프라 수정 (#205, #192, #163, #157, #158)

### DIFF
--- a/backend/app/api/assets.py
+++ b/backend/app/api/assets.py
@@ -95,6 +95,7 @@ async def get_snapshots(
 async def search_assets(
     q: str = Query(..., min_length=1),
     market: str = Query("all", pattern="^(all|kr|us|crypto)$"),
+    current_user: User = Depends(get_current_user),  # 비인증 외부 API 프록시 차단 (#205)
 ):
     """종목/코인 검색"""
     results = []

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -14,8 +14,7 @@ from slowapi import Limiter
 
 from app.core.config import settings
 
-# JWT 설정 (app/core/auth.py와 동일)
-ALGORITHM = "HS256"
+# JWT 알고리즘은 settings에서 단일 관리 — 하드코딩 금지 (#163)
 
 
 def get_user_identifier(request: Request) -> str:
@@ -46,7 +45,7 @@ def get_user_identifier(request: Request) -> str:
 
         try:
             # podo-auth JWT 디코딩 및 사용자 ID(sub) 추출
-            payload = pyjwt.decode(token, settings.JWT_SECRET, algorithms=[ALGORITHM])
+            payload = pyjwt.decode(token, settings.JWT_SECRET, algorithms=[settings.JWT_ALGORITHM])
             # podo-auth 발급 토큰만 허용
             if payload.get("iss") == "podo-auth":
                 user_id = payload.get("sub")

--- a/backend/app/schemas/insights.py
+++ b/backend/app/schemas/insights.py
@@ -47,19 +47,22 @@ class HealthScoreBreakdown(BaseModel):
 
 
 class ComprehensiveInsightsRequest(BaseModel):
-    """프론트엔드가 사전 계산한 종합 재무 데이터"""
+    """프론트엔드가 사전 계산한 종합 재무 데이터
+
+    금액 필드는 ge=0 제약을 적용하여 조작된 음수 데이터로 LLM rate limit이 소모되는 것을 방지. (#158)
+    """
 
     month: str = Field(..., pattern=r"^\d{4}-\d{2}$")
-    income_total: float
-    expense_total: float
+    income_total: float = Field(..., ge=0)
+    expense_total: float = Field(..., ge=0)
     top_expense_categories: list[CategorySummary] = []
     budget: BudgetSummary | None = None
     assets: AssetBreakdown | None = None
     debt: DebtSummary | None = None
-    savings_rate: float = 0
+    savings_rate: float = Field(0, ge=0, le=100)
     health_score: HealthScoreBreakdown | None = None
-    previous_month_expense: float | None = None
-    previous_month_income: float | None = None
+    previous_month_expense: float | None = Field(None, ge=0)
+    previous_month_income: float | None = Field(None, ge=0)
 
 
 # ── 응답: LLM이 생성하는 구조화된 인사이트 ──

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -2,8 +2,13 @@
 
 Resend API를 사용한 이메일 발송을 담당합니다.
 RESEND_API_KEY가 설정되지 않으면 이메일 발송을 건너뜁니다.
+
+주의: resend.Emails.send()는 동기 함수이므로 asyncio 이벤트 루프 블로킹 방지를 위해
+      run_in_executor()로 스레드 풀에서 실행합니다. (#192)
 """
 
+import asyncio
+import functools
 import html
 import logging
 
@@ -46,12 +51,11 @@ async def send_invitation_email(
     subject = f"{inviter_name}님이 '{household_name}' 가구에 초대했습니다"
 
     try:
-        resend.Emails.send(
-            {
-                "from": settings.RESEND_FROM_EMAIL,
-                "to": [to_email],
-                "subject": subject,
-                "html": f"""
+        email_params = {
+            "from": settings.RESEND_FROM_EMAIL,
+            "to": [to_email],
+            "subject": subject,
+            "html": f"""
             <div style="font-family: 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px;">
                 <h2 style="color: #292524; margin-bottom: 16px;">가구 초대</h2>
                 <p style="color: #57534e; font-size: 16px; line-height: 1.6;">
@@ -68,8 +72,10 @@ async def send_invitation_email(
                 <p style="color: #a8a29e; font-size: 14px;">이 링크는 7일 후 만료됩니다.</p>
             </div>
             """,
-            }
-        )
+        }
+        # resend.Emails.send()는 동기 블로킹 I/O — 이벤트 루프 블로킹 방지
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, functools.partial(resend.Emails.send, email_params))
         logger.info(f"초대 이메일 발송 완료: {to_email}")
         return True
     except Exception as e:

--- a/backend/fly.dev.toml
+++ b/backend/fly.dev.toml
@@ -11,7 +11,7 @@ primary_region = "nrt"
 [env]
   PORT = "8000"
   APP_NAME = "PodoBudget-Dev"
-  DEBUG = "True"
+  # DEBUG는 Fly.io secrets로 관리 — 스택 트레이스 공개 노출 방지 (#157)
   DATABASE_URL = "sqlite+aiosqlite:////app/data/db.sqlite3"
   SENTRY_ENVIRONMENT = "development"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,9 @@ services:
       - ./backend/.env
     environment:
       - DATABASE_URL=sqlite+aiosqlite:////app/data/db.sqlite3
-      - JWT_SECRET=${JWT_SECRET:-podo-jwt-secret-change-in-production}
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET 환경변수를 설정하세요}
       - AUTH_SERVER_URL=https://auth.podonest.com
+    # --reload는 개발 전용 — 운영 배포 시 Fly.io Dockerfile CMD를 사용 (reload 없음)
     command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
   frontend:

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -90,8 +90,8 @@ export default function OnboardingPage() {
                   )}
                 </div>
                 <button
-                  onClick={() => handleAccept(inv.token!, inv.household_name)}
-                  disabled={isDisabled}
+                  onClick={() => inv.token && handleAccept(inv.token, inv.household_name)}
+                  disabled={isDisabled || !inv.token}
                   className="ml-3 shrink-0 px-3 py-1.5 text-xs font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1"
                 >
                   {acceptingToken === inv.token && <div className="animate-spin rounded-full border-b-2 border-current w-3 h-3" />}


### PR DESCRIPTION
## 변경 내용

### #205 — search_assets 인증 누락 (P0 보안)
- `GET /assets/search`에 `Depends(get_current_user)` 추가
- 비인증 외부 API 프록시 차단

### #192 — email_service.py 동기 블로킹 (P0 코드품질)
- `resend.Emails.send()` → `asyncio.get_event_loop().run_in_executor()` 비동기 처리
- FastAPI 이벤트 루프 블로킹 방지

### #163 — rate_limit.py JWT 알고리즘 하드코딩 (P0 아키텍처)
- `ALGORITHM = "HS256"` 하드코딩 → `settings.JWT_ALGORITHM` 참조
- 알고리즘 변경 시 동기화 보장

### #157 — docker-compose + fly.dev.toml 보안 (P1)
- `docker-compose.yml`: `JWT_SECRET` 기본값 제거 (`:?` 문법으로 미설정 시 오류)
- `fly.dev.toml`: `DEBUG=True` 하드코딩 제거 → secrets 관리 권장 주석

### #158 — LLM 입력 검증 + null assertion (P1 버그)
- `ComprehensiveInsightsRequest`: 금액 필드에 `ge=0` Pydantic 제약 추가
- `savings_rate: float = Field(0, ge=0, le=100)` 범위 제한
- `OnboardingPage.tsx`: `inv.token!` → null 안전 처리

## 테스트
- BE 575개 통과, 5개 스킵
- FE 520개 통과

close #205
close #192
close #163
close #157
close #158