### PR TITLE
fix: 코드품질/보안/CI 수정 (#174, #161, #177, #200)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -43,6 +43,9 @@ jobs:
       - name: 린트
         run: uv run ruff check backend/
 
+      - name: 포맷 검증
+        run: uv run ruff format --check backend/  # 포맷 미준수 코드 CI 차단 (#177)
+
       - name: 테스트 실행
         env:
           DATABASE_URL: sqlite+aiosqlite:///./test.db

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -24,7 +24,9 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          # shell injection 방지: inputs.message를 직접 shell에 삽입하지 않고 환경변수로 전달 (#161)
+          TELEGRAM_MESSAGE: ${{ inputs.message }}
         run: |
           curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d chat_id="${TELEGRAM_CHAT_ID}" \
-            --data-urlencode "text=${{ inputs.message }}" || true
+            --data-urlencode "text=${TELEGRAM_MESSAGE}" || true

--- a/backend/app/api/budget.py
+++ b/backend/app/api/budget.py
@@ -5,7 +5,7 @@ household_id가 있으면 가구 공유 예산, 없으면 개인 예산으로 �
 expenses/recurring과 동일한 household 패턴을 따릅니다.
 """
 
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import and_, extract, func, or_, select
@@ -158,7 +158,7 @@ async def get_budget_alerts(
     budgets = result.scalars().all()
 
     alerts = []
-    now = datetime.now()
+    now = datetime.now(UTC).replace(tzinfo=None)
 
     # 유효한 예산만 필터 (기간 미시작 제외)
     active_budgets = [b for b in budgets if b.start_date <= now]
@@ -250,7 +250,7 @@ async def get_category_overview(
     budget_scope = _budget_scope_filter(household_id)
     expense_scope = _expense_scope_filter(household_id)
 
-    now = datetime.now()
+    now = datetime.now(UTC).replace(tzinfo=None)
 
     # 최근 3개월 시작일 계산 (현재 월 포함 3개월)
     start_month = now.month - 2

--- a/backend/tests/integration/test_api_budget.py
+++ b/backend/tests/integration/test_api_budget.py
@@ -4,7 +4,7 @@
 모든 엔드포인트는 JWT 인증이 필요합니다.
 """
 
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -111,7 +111,7 @@ async def test_get_budgets_list(authenticated_client: AsyncClient, test_user: Us
         category_id=category.id,
         amount=200000,
         period="monthly",
-        start_date=datetime.now(),
+        start_date=datetime.now(UTC).replace(tzinfo=None),
         alert_threshold=0.8,
     )
     db_session.add(budget)
@@ -140,7 +140,7 @@ async def test_update_budget_success(authenticated_client: AsyncClient, test_use
         category_id=category.id,
         amount=100000,
         period="monthly",
-        start_date=datetime.now(),
+        start_date=datetime.now(UTC).replace(tzinfo=None),
     )
     db_session.add(budget)
     await db_session.commit()
@@ -182,7 +182,7 @@ async def test_delete_budget_success(authenticated_client: AsyncClient, test_use
         category_id=category.id,
         amount=50000,
         period="monthly",
-        start_date=datetime.now(),
+        start_date=datetime.now(UTC).replace(tzinfo=None),
     )
     db_session.add(budget)
     await db_session.commit()
@@ -218,7 +218,7 @@ async def test_get_budget_alerts_with_expenses(authenticated_client: AsyncClient
     await db_session.commit()
     await db_session.refresh(category)
 
-    start_date = datetime.now() - timedelta(days=5)
+    start_date = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=5)
     budget = Budget(
         user_id=test_user.id,
         household_id=test_household.id,
@@ -237,7 +237,7 @@ async def test_get_budget_alerts_with_expenses(authenticated_client: AsyncClient
         amount=250000,
         description="식비 지출",
         category_id=category.id,
-        date=datetime.now(),
+        date=datetime.now(UTC).replace(tzinfo=None),
     )
     db_session.add(expense)
     await db_session.commit()
@@ -266,7 +266,7 @@ async def test_get_budget_alerts_exceeded(authenticated_client: AsyncClient, tes
     await db_session.commit()
     await db_session.refresh(category)
 
-    start_date = datetime.now() - timedelta(days=5)
+    start_date = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=5)
     budget = Budget(
         user_id=test_user.id,
         household_id=test_household.id,
@@ -284,7 +284,7 @@ async def test_get_budget_alerts_exceeded(authenticated_client: AsyncClient, tes
         amount=150000,
         description="택시비",
         category_id=category.id,
-        date=datetime.now(),
+        date=datetime.now(UTC).replace(tzinfo=None),
     )
     db_session.add(expense)
     await db_session.commit()

--- a/frontend/src/pages/AccountManager.tsx
+++ b/frontend/src/pages/AccountManager.tsx
@@ -25,8 +25,8 @@ export default function AccountManager() {
   const { activeHouseholdId } = useHouseholdStore()
 
   function loadAccounts() {
-    const hid = activeHouseholdId!
-    accountApi.getAll(hid)
+    if (!activeHouseholdId) return  // null 안전 처리 (#200)
+    accountApi.getAll(activeHouseholdId)
       .then(res => setAccounts(res.data))
       .catch(() => addToast('error', '계좌 목록을 불러오지 못했습니다'))
       .finally(() => setLoading(false))

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -287,7 +287,8 @@ function MyAccountSection() {
   const handleCopyKakaoCode = async () => {
     if (!kakaoLinkCode) return
     try {
-      await navigator.clipboard.writeText(`/link ${kakaoLinkCode.code}`)
+      // 카카오 봇은 "연동 {code}" 형식 사용 (한글 명령어 = /link 슬래시 명령어) (#200)
+      await navigator.clipboard.writeText(`연동 ${kakaoLinkCode.code}`)
       toast.success('복사되었습니다!')
     } catch {
       toast.error('자동 복사 실패 — 아래 명령어를 직접 복사해주세요')
@@ -503,7 +504,7 @@ function MyAccountSection() {
                   }}
                 >
                   <p className="text-xs text-[var(--text-tertiary)] mb-1">카카오톡 채널 채팅에 아래 명령어를 입력하세요: (탭하면 선택됩니다)</p>
-                  <p className="selectable font-mono text-sm text-grape-600 font-bold select-all">/link {kakaoLinkCode.code}</p>
+                  <p className="selectable font-mono text-sm text-grape-600 font-bold select-all">연동 {kakaoLinkCode.code}</p>
                 </div>
               </div>
             ) : (


### PR DESCRIPTION
## 변경 내용

### #174 — budget.py datetime UTC 미지정 수정 (P1)
- `datetime.now()` → `datetime.now(UTC).replace(tzinfo=None)` 두 곳 수정
- 서버 타임존에 관계없이 UTC 기준 예산 활성 판정 보장
- 테스트도 UTC 기준으로 통일

### #161 — GitHub Actions shell injection 방지 (P2 보안)
- `notify.yml`: `${{ inputs.message }}`를 shell에 직접 삽입하지 않고 환경변수 `TELEGRAM_MESSAGE`로 전달
- PR 제목 등 특수문자가 포함되어도 명령 실행 불가

### #177 — CI ruff format --check 추가 (P1)
- `ci-test.yml`에 `ruff format --check backend/` 단계 추가
- 포맷 미준수 코드가 CI를 통과하는 문제 차단

### #200 — SettingsPage 카카오 명령어 불일치 + AccountManager null assertion (P1)
- 복사 명령어: `/link {code}` → `연동 {code}` (카카오 봇 형식과 통일)
- 화면 표시 텍스트도 동일하게 수정
- `AccountManager.loadAccounts()`: `activeHouseholdId!` → null guard 추가

## 테스트
- BE 575개 통과, 5개 스킵
- FE 520개 통과, 경고 0개 에러

close #174
close #161
close #177
close #200