### PR TITLE
fix: 코드 리뷰 그룹7 — CI/CD 공급망 보안 버전 고정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@v1  # 버전 고정 — 공급망 보안 (#139)
 
       - name: 백엔드 배포
         run: |

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: uv 설치
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.5.20"  # 버전 고정 — 공급망 보안 (#139)
           enable-cache: true
 
       - name: Python 설정

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 # uv 설치
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.5.20 /uv /uvx /bin/  # 버전 고정 — 공급망 보안 (#139)
 
 # 의존성 파일 복사 (build context = 프로젝트 루트)
 COPY pyproject.toml uv.lock ./


### PR DESCRIPTION
## 변경 내용

close #139

### #139 — CI/CD 공급망 보안 취약점 (버전 고정)
외부 의존성을 `latest`/`master` 대신 특정 버전으로 고정하여 공급망 공격 방어

| 파일 | 변경 전 | 변경 후 |
|------|---------|---------|
| `backend/Dockerfile` | `uv:latest` | `uv:0.5.20` |
| `.github/workflows/cd.yml` | `flyctl-actions@master` | `flyctl-actions@v1` |
| `.github/workflows/ci-test.yml` | `version: "latest"` | `version: "0.5.20"` |

> #140 (fly.toml DATABASE_URL), #191 (onboarding UTC) 은 이전 그룹에서 이미 수정 확인

## 테스트
- BE: 575 passed, 5 skipped
- FE: 520 passed (58 test files)