### PR TITLE
fix: 코드 리뷰 그룹8 — rate limit IP 스푸핑, 자산/계좌 권한 검증

### DIFF
--- a/backend/app/api/accounts.py
+++ b/backend/app/api/accounts.py
@@ -47,6 +47,12 @@ async def get_account(
     account = await account_service.get_account_by_id(db, account_id, current_user)
     if not account:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="계좌를 찾을 수 없습니다")
+    # household 멤버십 검증 — IDOR 방지 (#137)
+    if account.household_id is not None:
+        try:
+            await get_household_member(account.household_id, current_user, db)
+        except HTTPException:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="계좌를 찾을 수 없습니다") from None
     return account
 
 

--- a/backend/app/api/assets.py
+++ b/backend/app/api/assets.py
@@ -75,6 +75,7 @@ async def get_snapshots(
     """월별 스냅샷 (순자산 추이)"""
     if household_id is None:
         household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)  # 가구 접근 권한 검증 (#135)
     snapshots = await asset_service.get_snapshots(db, current_user, household_id, months)
     results = []
     for s in snapshots:
@@ -127,6 +128,7 @@ async def get_all_prices(
     """보유 투자형 자산 일괄 시세"""
     if household_id is None:
         household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)  # 가구 접근 권한 검증 (#135)
     assets = await asset_service.get_assets(db, current_user, household_id)
     prices = {}
     for asset in assets:
@@ -230,7 +232,7 @@ async def update_asset(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """자산 수정 (본인 생성분만)"""
+    """자산 수정 (본인 생성분만 + 현재 가구 멤버만)"""
     from sqlalchemy import select
 
     from app.models.asset import Asset
@@ -239,6 +241,12 @@ async def update_asset(
     asset = result.scalar_one_or_none()
     if not asset:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="자산을 찾을 수 없습니다")
+    # 탈퇴 멤버가 이전 가구 자산 수정 방지 (#135)
+    if asset.household_id is not None:
+        try:
+            await get_household_member(asset.household_id, current_user, db)
+        except HTTPException:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="자산을 찾을 수 없습니다") from None
     update_data = asset_update.model_dump(exclude_unset=True)
     return await asset_service.update_asset(db, asset, update_data)
 
@@ -249,7 +257,7 @@ async def delete_asset(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """자산 삭제 (본인 생성분만)"""
+    """자산 삭제 (본인 생성분만 + 현재 가구 멤버만)"""
     from sqlalchemy import select
 
     from app.models.asset import Asset
@@ -258,4 +266,10 @@ async def delete_asset(
     asset = result.scalar_one_or_none()
     if not asset:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="자산을 찾을 수 없습니다")
+    # 탈퇴 멤버가 이전 가구 자산 삭제 방지 (#135)
+    if asset.household_id is not None:
+        try:
+            await get_household_member(asset.household_id, current_user, db)
+        except HTTPException:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="자산을 찾을 수 없습니다") from None
     await asset_service.delete_asset(db, asset)

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -58,9 +58,10 @@ def get_user_identifier(request: Request) -> str:
             pass
 
     # 인증되지 않은 요청은 IP 주소를 식별자로 사용
-    # X-Forwarded-For 헤더를 먼저 확인 (프록시/로드밸런서 뒤에 있을 때)
-    forwarded = request.headers.get("X-Forwarded-For")
-    client_ip = forwarded.split(",")[0].strip() if forwarded else (request.client.host if request.client else "unknown")
+    # Fly-Client-IP: Fly.io 프록시가 설정하는 실제 클라이언트 IP (클라이언트 조작 불가, #132)
+    # X-Forwarded-For는 클라이언트가 임의 값을 주입할 수 있어 rate limit 우회에 악용됨
+    fly_client_ip = request.headers.get("Fly-Client-IP")
+    client_ip = fly_client_ip or (request.client.host if request.client else "unknown")
 
     return f"ip:{client_ip}"
 

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -36,14 +36,13 @@ async def get_accounts(db: AsyncSession, user: User, household_id: int | None = 
 
 
 async def get_account_by_id(db: AsyncSession, account_id: int, user: User) -> Account | None:
-    """계좌 상세 조회 (권한 체크)"""
+    """계좌 상세 조회 — household 멤버십은 API 레이어에서 get_household_member()로 검증 (#137)"""
     result = await db.execute(select(Account).where(Account.id == account_id))
     account = result.scalar_one_or_none()
     if not account:
         return None
-    if account.household_id:
-        return account
-    elif account.created_by != user.id:
+    # household 없는 레거시 데이터: created_by 기반 소유권 확인
+    if account.household_id is None and account.created_by != user.id:
         return None
     return account
 

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -32,12 +32,9 @@ async def create_asset(db: AsyncSession, asset_data: dict, user: User) -> Asset:
     return asset
 
 
-async def get_assets(db: AsyncSession, user: User, household_id: int | None = None) -> list[Asset]:
-    """자산 목록 조회 (household 기반)"""
-    query = (
-        select(Asset).where(Asset.household_id == household_id) if household_id is not None else select(Asset).where(Asset.created_by == user.id)
-    )  # 레거시 폴백
-    query = query.order_by(Asset.type, Asset.name)
+async def get_assets(db: AsyncSession, user: User, household_id: int) -> list[Asset]:
+    """자산 목록 조회 (household 기반) — household_id는 API 레이어에서 반드시 resolve (#135)"""
+    query = select(Asset).where(Asset.household_id == household_id).order_by(Asset.type, Asset.name)
     result = await db.execute(query)
     return list(result.scalars().all())
 

--- a/backend/tests/unit/test_rate_limit.py
+++ b/backend/tests/unit/test_rate_limit.py
@@ -4,7 +4,7 @@ get_user_identifier 함수의 다양한 시나리오를 테스트합니다:
 - 유효한 podo-auth JWT 토큰 → auth_user_id 반환
 - 유효하지 않은 토큰 → IP 폴백
 - 토큰 없음 → IP 폴백
-- X-Forwarded-For 헤더 → 첫 번째 IP 사용
+- Fly-Client-IP 헤더 → 해당 IP 사용 (X-Forwarded-For 대신, #132)
 """
 
 from unittest.mock import MagicMock
@@ -15,7 +15,7 @@ from tests.conftest import TEST_AUTH_USER_ID_1, create_test_token
 
 def _make_request(
     auth_header: str | None = None,
-    forwarded_for: str | None = None,
+    fly_client_ip: str | None = None,
     client_host: str = "127.0.0.1",
 ) -> MagicMock:
     """테스트용 Request 객체 생성"""
@@ -23,8 +23,8 @@ def _make_request(
     headers = {}
     if auth_header:
         headers["Authorization"] = auth_header
-    if forwarded_for:
-        headers["X-Forwarded-For"] = forwarded_for
+    if fly_client_ip:
+        headers["Fly-Client-IP"] = fly_client_ip
     request.headers = headers
     request.client = MagicMock()
     request.client.host = client_host
@@ -64,12 +64,23 @@ def test_non_bearer_auth_header():
     assert result == "ip:127.0.0.1"
 
 
-def test_x_forwarded_for_uses_first_ip():
-    """X-Forwarded-For 헤더가 있으면 첫 번째 IP 사용"""
-    request = _make_request(forwarded_for="10.0.0.1, 10.0.0.2, 10.0.0.3")
+def test_fly_client_ip_used_when_present():
+    """Fly-Client-IP 헤더가 있으면 해당 IP 사용 (X-Forwarded-For 스푸핑 방지, #132)"""
+    request = _make_request(fly_client_ip="203.0.113.1")
 
     result = get_user_identifier(request)
-    assert result == "ip:10.0.0.1"
+    assert result == "ip:203.0.113.1"
+
+
+def test_x_forwarded_for_ignored():
+    """X-Forwarded-For 헤더는 무시 — 스푸핑 가능하므로 rate limit 기준으로 사용 안 함 (#132)"""
+    request = MagicMock()
+    request.headers = {"X-Forwarded-For": "10.0.0.1, 10.0.0.2"}
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+
+    result = get_user_identifier(request)
+    assert result == "ip:127.0.0.1"  # client.host 사용, X-Forwarded-For 무시
 
 
 def test_no_client_returns_unknown():


### PR DESCRIPTION
## 변경 내용

close #132 close #135 close #137

### #132 — X-Forwarded-For 스푸핑으로 rate limit 우회
- `rate_limit.py`: `X-Forwarded-For` 대신 `Fly-Client-IP` 헤더 사용
- `Fly-Client-IP`는 Fly.io 프록시가 설정하는 신뢰할 수 있는 실제 클라이언트 IP
- 테스트: `test_x_forwarded_for_uses_first_ip` → `test_fly_client_ip_used_when_present` + `test_x_forwarded_for_ignored` 로 교체

### #135 — 자산 API household_id 권한 검증 누락
- `/snapshots`, `/prices`: `get_household_member()` 검증 추가
- `PUT /{asset_id}`, `DELETE /{asset_id}`: 탈퇴 멤버가 이전 가구 자산 수정/삭제하는 경로 차단
- `asset_service.get_assets`: `household_id=None` 레거시 폴백 제거, 시그니처를 `int`로 고정

### #137 — 계좌 조회 IDOR 취약점
- `account_service.get_account_by_id`: `household_id` 있으면 무조건 반환하던 로직 수정
- `accounts.py GET /{account_id}`: `get_household_member()` 검증 추가

## 테스트
- BE: 576 passed (+1), 5 skipped
- FE: 520 passed (58 test files)