### PR TITLE
fix: Dockerfile COPY 인라인 주석 제거 — CD 빌드 오류 수정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# uv 설치
-COPY --from=ghcr.io/astral-sh/uv:0.5.20 /uv /uvx /bin/  # 버전 고정 — 공급망 보안 (#139)
+# uv 설치 — 버전 고정으로 공급망 보안 확보 (#139)
+COPY --from=ghcr.io/astral-sh/uv:0.5.20 /uv /uvx /bin/
 
 # 의존성 파일 복사 (build context = 프로젝트 루트)
 COPY pyproject.toml uv.lock ./


### PR DESCRIPTION
## 문제
그룹7(#213) 머지 이후 CD 빌드가 연속 실패 중.

```
ERROR: failed to calculate checksum of ref ...: "/보안": not found
```

**원인**: `COPY` 명령 뒤 인라인 한국어 주석을 Docker가 파일 경로로 해석

```dockerfile
# 잘못된 방식 — # 이후가 파일 경로 인자로 해석됨
COPY --from=ghcr.io/astral-sh/uv:0.5.20 /uv /uvx /bin/  # 버전 고정 — 공급망 보안 (#139)
```

## 수정
주석을 `COPY` 명령 위 별도 줄로 이동

```dockerfile
# uv 설치 — 버전 고정으로 공급망 보안 확보 (#139)
COPY --from=ghcr.io/astral-sh/uv:0.5.20 /uv /uvx /bin/
```

그룹7, 그룹8, 그룹9 CD 실패 모두 이 원인.