### PR TITLE
perf: N+1 쿼리 및 불필요한 DB 재조회 제거 (#164, #168)

### DIFF
--- a/backend/app/api/expenses.py
+++ b/backend/app/api/expenses.py
@@ -228,15 +228,14 @@ async def get_stats(
     # 트렌드
     trend: list[TrendPoint] = []
     if period == StatsPeriod.yearly:
-        # 월별 12포인트
+        # 월별 12포인트 — 단일 GROUP BY 쿼리 (12번 직렬 → 1번, #164)
+        month_col = func.extract("month", Expense.date).label("month")
+        monthly_result = await db.execute(
+            select(month_col, func.coalesce(func.sum(Expense.amount), 0).label("amount")).where(*base_where).group_by(month_col).order_by(month_col)
+        )
+        monthly_map = {int(r.month): float(r.amount) for r in monthly_result.all()}
         for m in range(1, 13):
-            m_start = datetime(ref_date.year, m, 1)
-            _, m_last = monthrange(ref_date.year, m)
-            m_end = datetime(ref_date.year, m, m_last, 23, 59, 59)
-            r = await db.execute(
-                select(func.coalesce(func.sum(Expense.amount), 0)).where(scope_filter, stats_filter, Expense.date >= m_start, Expense.date <= m_end)
-            )
-            trend.append(TrendPoint(label=f"{m}월", amount=float(r.scalar())))
+            trend.append(TrendPoint(label=f"{m}월", amount=monthly_map.get(m, 0.0)))
     else:
         # 일별
         day_col = func.date(Expense.date).label("day")
@@ -336,19 +335,30 @@ async def get_stats_comparison(
             current_label = f"{cur_y}년 {cur_m}월"
             previous_label = f"{prev_y}년 {prev_m}월"
 
-        # N개월 트렌드 (현재 월 포함 과거 N개월) — 트렌드는 전체 달 기준 유지
+        # N개월 트렌드 (현재 월 포함 과거 N개월) — 단일 GROUP BY 쿼리 (#164)
         trend_data: list[PeriodTotal] = []
         y, m = cur_y, cur_m
-        # months-1 만큼 뒤로
         for _ in range(months - 1):
             m -= 1
             if m < 1:
                 m = 12
                 y -= 1
-        # 시작점부터 현재까지 순서대로
+        start_y, start_m = y, m
+        _, end_last = monthrange(cur_y, cur_m)
+        trend_start = datetime(start_y, start_m, 1)
+        trend_end = datetime(cur_y, cur_m, end_last, 23, 59, 59)
+
+        yr_col = func.extract("year", Expense.date).label("year")
+        mo_col = func.extract("month", Expense.date).label("month")
+        trend_result = await db.execute(
+            select(yr_col, mo_col, func.coalesce(func.sum(Expense.amount), 0).label("amount"))
+            .where(scope_filter, excl_filter, Expense.date >= trend_start, Expense.date <= trend_end)
+            .group_by(yr_col, mo_col)
+            .order_by(yr_col, mo_col)
+        )
+        trend_map = {(int(r.year), int(r.month)): float(r.amount) for r in trend_result.all()}
         for _ in range(months):
-            t = await _month_total(y, m)
-            trend_data.append(PeriodTotal(label=f"{y}년 {m}월", total=t))
+            trend_data.append(PeriodTotal(label=f"{y}년 {m}월", total=trend_map.get((y, m), 0.0)))
             m += 1
             if m > 12:
                 m = 1

--- a/backend/app/api/income.py
+++ b/backend/app/api/income.py
@@ -179,14 +179,14 @@ async def get_income_stats(
     # 추이 데이터
     trend: list[TrendPoint] = []
     if period == StatsPeriod.yearly:
+        # 월별 12포인트 — 단일 GROUP BY 쿼리 (12번 직렬 → 1번, #164)
+        month_col = func.extract("month", Income.date).label("month")
+        monthly_result = await db.execute(
+            select(month_col, func.coalesce(func.sum(Income.amount), 0).label("amount")).where(*base_where).group_by(month_col).order_by(month_col)
+        )
+        monthly_map = {int(r.month): float(r.amount) for r in monthly_result.all()}
         for m in range(1, 13):
-            m_start = datetime(ref_date.year, m, 1)
-            _, m_last = monthrange(ref_date.year, m)
-            m_end = datetime(ref_date.year, m, m_last, 23, 59, 59)
-            r = await db.execute(
-                select(func.coalesce(func.sum(Income.amount), 0)).where(scope_filter, stats_filter, Income.date >= m_start, Income.date <= m_end)
-            )
-            trend.append(TrendPoint(label=f"{m}월", amount=float(r.scalar())))
+            trend.append(TrendPoint(label=f"{m}월", amount=monthly_map.get(m, 0.0)))
     else:
         day_col = func.date(Income.date).label("day")
         daily_result = await db.execute(select(day_col, func.sum(Income.amount).label("amount")).where(*base_where).group_by(day_col).order_by(day_col))

--- a/backend/app/api/kakao.py
+++ b/backend/app/api/kakao.py
@@ -293,8 +293,7 @@ async def kakao_webhook(request: Request, db: AsyncSession = Depends(get_db)):
                 count = len(parsed)
                 message_lines = [f"✅ {count}건의 지출이 기록되었어요!\n"]
 
-                for idx, (expense, item) in enumerate(zip(created_expenses, parsed, strict=False), 1):
-                    await db.refresh(expense)
+                for idx, (_expense, item) in enumerate(zip(created_expenses, parsed, strict=False), 1):
                     message_lines.append(f"{idx}. 💰 {item['amount']:,.0f}원 - 📂 {item.get('category', '기타')} - {item.get('description', '')}")
 
                 message_lines.append(f"\n💰 총 {total_amount:,.0f}원")
@@ -514,11 +513,13 @@ async def handle_budget_command(db: AsyncSession, household_id: int | None) -> d
         )
 
     try:
-        # 해당 가구의 활성 예산 조회
-        budget_result = await db.execute(select(Budget).where(Budget.household_id == household_id))
-        budgets = budget_result.scalars().all()
+        # Budget + Category JOIN으로 카테고리 개별 조회 제거 (N번 → 0번, #168)
+        budget_cat_result = await db.execute(
+            select(Budget, Category).join(Category, Budget.category_id == Category.id).where(Budget.household_id == household_id)
+        )
+        budget_cats = budget_cat_result.all()
 
-        if not budgets:
+        if not budget_cats:
             return make_simple_text_response(
                 "💵 예산 현황\n\n아직 설정된 예산이 없어요.",
                 quick_replies=[make_quick_reply("📊 이번달 지출 보기", "리포트"), make_quick_reply("❓ 도움말", "도움말")],
@@ -527,20 +528,14 @@ async def handle_budget_command(db: AsyncSession, household_id: int | None) -> d
         budget_data = []
         now = datetime.now()
 
-        for budget in budgets:
+        for budget, category in budget_cats:
             # 예산 기간 내의 지출 집계
             end_date = budget.end_date if budget.end_date else now
 
             if budget.start_date > now:
                 continue
 
-            # 카테고리 정보
-            category_result = await db.execute(select(Category).where(Category.id == budget.category_id))
-            category = category_result.scalar_one_or_none()
-            if not category:
-                continue
-
-            # 지출 합계 (가구 단위)
+            # 지출 합계 (예산별 날짜 범위가 다르므로 개별 집계 유지)
             expense_result = await db.execute(
                 select(func.sum(Expense.amount))
                 .where(Expense.household_id == household_id)

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -419,8 +419,7 @@ async def _handle_multiple_expenses(
     count = len(created_expenses)
     message_lines = [f"✅ {count}건의 지출이 기록되었어요!\n"]
 
-    for idx, (expense, item, cat_name) in enumerate(created_expenses, 1):
-        await db.refresh(expense)
+    for idx, (_expense, item, cat_name) in enumerate(created_expenses, 1):
         message_lines.append(f"{idx}. 💰 {item['amount']:,.0f}원 - 📂 {cat_name} - {item.get('description', '')}")
 
     message_lines.append(f"\n💰 총 {total_amount:,.0f}원")
@@ -645,7 +644,7 @@ async def answer_callback_query(callback_id: str, text: str):
     import httpx
 
     url = f"{TELEGRAM_API.format(token=settings.TELEGRAM_BOT_TOKEN)}/answerCallbackQuery"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=10.0) as client:
         await client.post(url, json={"callback_query_id": callback_id, "text": text})
 
 
@@ -719,20 +718,19 @@ async def handle_budget_command(chat_id: int, db: AsyncSession, household_id: in
         budget_data = []
         now = datetime.now()
 
-        for budget in budgets:
-            # 예산 기간 내의 지출 집계
+        # Budget + Category JOIN으로 카테고리 개별 조회 제거 (N번 → 0번, #168)
+        budget_cat_result = await db.execute(
+            select(Budget, Category).join(Category, Budget.category_id == Category.id).where(Budget.household_id == household_id)
+        )
+        budget_cats = budget_cat_result.all()
+
+        for budget, category in budget_cats:
             end_date = budget.end_date if budget.end_date else now
 
             if budget.start_date > now:
                 continue
 
-            # 카테고리 정보
-            category_result = await db.execute(select(Category).where(Category.id == budget.category_id))
-            category = category_result.scalar_one_or_none()
-            if not category:
-                continue
-
-            # 지출 합계 (가구 단위)
+            # 지출 합계 (예산별 날짜 범위가 다르므로 개별 집계 유지)
             expense_result = await db.execute(
                 select(func.sum(Expense.amount))
                 .where(Expense.household_id == household_id)


### PR DESCRIPTION
## 변경 사항

### #164 — 연간 트렌드 12회 직렬 쿼리 → 단일 GROUP BY
- `expenses.py` `get_expense_stats`: `period=yearly` 시 12개월별 개별 쿼리 → `func.extract("month")` + `GROUP BY`
- `expenses.py` `get_expense_comparison`: N개월 `_month_total()` 루프 → `GROUP BY (year, month)` 단일 쿼리
- `income.py` `get_income_stats`: 동일한 yearly trend 최적화

### #168 — 봇 N+1 쿼리 제거
- `telegram.py` `handle_budget_command`: 예산 N개마다 개별 Category SELECT → Budget+Category JOIN (N번 → 0번)
- `kakao.py` `handle_budget_command`: 동일한 JOIN 최적화
- `telegram.py` `_handle_multiple_expenses`: `db.refresh(expense)` 제거 (commit 후 불필요한 재조회)
- `kakao.py` `_handle_multiple_expenses`: 동일한 refresh 제거
- `telegram.py` `answer_callback_query`: `httpx.AsyncClient(timeout=10.0)` 추가 (무한 대기 방지)

## 테스트

- 582 passed, 5 skipped — 기존 테스트 전부 통과
- ruff lint/format 통과

## 관련 이슈

Closes #164
Closes #168