### PR TITLE
perf: 자산 시세 병렬화·singleflight + FE 리렌더링 최소화 (#166, #167)

### DIFF
--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -71,10 +71,13 @@ async def delete_asset(db: AsyncSession, asset: Asset) -> None:
 
 async def get_assets_with_prices(db: AsyncSession, user: User, household_id: int | None = None) -> list[dict]:
     """시세 포함 자산 목록"""
+    import asyncio
+
     assets = await get_assets(db, user, household_id)
+    # 시세 조회 병렬화 — 자산 수만큼 직렬 await → asyncio.gather 동시 실행 (#166)
+    price_infos = await asyncio.gather(*[get_asset_current_value(asset) for asset in assets])
     results = []
-    for asset in assets:
-        price_info = await get_asset_current_value(asset)
+    for asset, price_info in zip(assets, price_infos, strict=False):
         asset_dict = {
             "id": asset.id,
             "household_id": asset.household_id,

--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -6,6 +6,7 @@
 환율: exchangerate-api
 """
 
+import asyncio
 import logging
 import time
 
@@ -18,6 +19,17 @@ logger = logging.getLogger(__name__)
 # 시세 캐시 (5분)
 _price_cache: dict[str, tuple[float, float]] = {}  # key → (price, timestamp)
 CACHE_TTL = 300  # 5분
+
+# singleflight 락 — 동시 요청이 같은 ticker 외부 API를 중복 호출하는 것을 방지 (#166)
+_price_locks: dict[str, asyncio.Lock] = {}
+
+
+def _lock_for(key: str) -> asyncio.Lock:
+    """키별 락 반환 (없으면 생성) — asyncio 단일 스레드이므로 race-free"""
+    if key not in _price_locks:
+        _price_locks[key] = asyncio.Lock()
+    return _price_locks[key]
+
 
 # 한투 API 토큰 캐시
 _kis_token: str | None = None
@@ -66,23 +78,25 @@ async def _get_kis_token() -> str | None:
 
 async def get_stock_kr_price(ticker: str) -> float | None:
     """한국 주식/ETF 현재가 조회 (한투 API 우선, 네이버 fallback)"""
-    cached = _get_cached(f"kr:{ticker}")
+    key = f"kr:{ticker}"
+    cached = _get_cached(key)
     if cached is not None:
         return cached
 
-    # 1차: 한투 API
-    price = await _get_stock_kr_price_kis(ticker)
-    if price:
-        _set_cached(f"kr:{ticker}", price)
-        return price
+    async with _lock_for(key):
+        # 락 획득 후 재확인 — 대기 중에 다른 코루틴이 이미 채웠을 수 있음
+        cached = _get_cached(key)
+        if cached is not None:
+            return cached
 
-    # 2차: 네이버 금융 fallback
-    price = await _get_stock_kr_price_naver(ticker)
-    if price:
-        _set_cached(f"kr:{ticker}", price)
+        # 1차: 한투 API
+        price = await _get_stock_kr_price_kis(ticker)
+        if not price:
+            # 2차: 네이버 금융 fallback
+            price = await _get_stock_kr_price_naver(ticker)
+        if price:
+            _set_cached(key, price)
         return price
-
-    return None
 
 
 async def _get_stock_kr_price_kis(ticker: str) -> float | None:
@@ -141,28 +155,34 @@ async def _get_stock_kr_price_naver(ticker: str) -> float | None:
 
 async def get_stock_us_price(ticker: str) -> tuple[float | None, float | None]:
     """미국 주식/ETF 현재가 조회 (USD + KRW 환산)"""
-    cached_usd = _get_cached(f"us:{ticker}")
+    key = f"us:{ticker}"
+    cached_usd = _get_cached(key)
     exchange_rate = await get_usd_krw_rate()
 
     if cached_usd is not None and exchange_rate is not None:
         return cached_usd, cached_usd * exchange_rate
 
-    try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.get(
-                f"https://query1.finance.yahoo.com/v8/finance/chart/{ticker}",
-                params={"interval": "1d", "range": "1d"},
-                headers={"User-Agent": "Mozilla/5.0"},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                meta = data["chart"]["result"][0]["meta"]
-                price_usd = float(meta["regularMarketPrice"])
-                _set_cached(f"us:{ticker}", price_usd)
-                krw_price = price_usd * exchange_rate if exchange_rate else None
-                return price_usd, krw_price
-    except Exception:
-        pass
+    async with _lock_for(key):
+        cached_usd = _get_cached(key)
+        if cached_usd is not None and exchange_rate is not None:
+            return cached_usd, cached_usd * exchange_rate
+
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(
+                    f"https://query1.finance.yahoo.com/v8/finance/chart/{ticker}",
+                    params={"interval": "1d", "range": "1d"},
+                    headers={"User-Agent": "Mozilla/5.0"},
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    meta = data["chart"]["result"][0]["meta"]
+                    price_usd = float(meta["regularMarketPrice"])
+                    _set_cached(key, price_usd)
+                    krw_price = price_usd * exchange_rate if exchange_rate else None
+                    return price_usd, krw_price
+        except Exception:
+            pass
     return None, None
 
 
@@ -171,25 +191,31 @@ async def get_stock_us_price(ticker: str) -> tuple[float | None, float | None]:
 
 async def get_crypto_price(symbol: str) -> float | None:
     """업비트 코인 현재가 조회 (KRW)"""
-    cached = _get_cached(f"crypto:{symbol}")
+    key = f"crypto:{symbol}"
+    cached = _get_cached(key)
     if cached is not None:
         return cached
 
-    market = f"KRW-{symbol.upper()}"
-    try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.get(
-                "https://api.upbit.com/v1/ticker",
-                params={"markets": market},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                if data and len(data) > 0:
-                    price = float(data[0]["trade_price"])
-                    _set_cached(f"crypto:{symbol}", price)
-                    return price
-    except Exception:
-        pass
+    async with _lock_for(key):
+        cached = _get_cached(key)
+        if cached is not None:
+            return cached
+
+        market = f"KRW-{symbol.upper()}"
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(
+                    "https://api.upbit.com/v1/ticker",
+                    params={"markets": market},
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    if data and len(data) > 0:
+                        price = float(data[0]["trade_price"])
+                        _set_cached(key, price)
+                        return price
+        except Exception:
+            pass
     return None
 
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -23,10 +23,11 @@ const navItems: { path: string; label: string; icon: LucideIcon }[] = [
 export default function Layout() {
   const [householdDropdownOpen, setHouseholdDropdownOpen] = useState(false)
   const location = useLocation()
-  const {
-    households, activeHouseholdId, myInvitations,
-    setActiveHouseholdId,
-  } = useHouseholdStore()
+  // selector로 필요한 값만 구독 — isLoading 등 미사용 필드 변경 시 불필요한 리렌더 방지 (#167)
+  const households = useHouseholdStore((s) => s.households)
+  const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
+  const myInvitations = useHouseholdStore((s) => s.myInvitations)
+  const setActiveHouseholdId = useHouseholdStore((s) => s.setActiveHouseholdId)
 
   // 초기 fetch는 ProtectedRoute의 initializeApp()에서 수행
 

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -26,14 +26,18 @@ vi.mock('../../contexts/AuthContext', () => ({
  * useHouseholdStore 훅 모킹
  */
 vi.mock('../../stores/useHouseholdStore', () => ({
-  useHouseholdStore: () => ({
-    households: [],
-    activeHouseholdId: null,
-    myInvitations: [],
-    fetchHouseholds: vi.fn().mockResolvedValue(undefined),
-    fetchMyInvitations: vi.fn().mockResolvedValue(undefined),
-    setActiveHouseholdId: vi.fn(),
-  }),
+  // selector 방식(useHouseholdStore(s => s.x)) 지원 — Layout.tsx #167 수정 대응
+  useHouseholdStore: (selector?: (s: object) => unknown) => {
+    const state = {
+      households: [],
+      activeHouseholdId: null,
+      myInvitations: [],
+      fetchHouseholds: vi.fn().mockResolvedValue(undefined),
+      fetchMyInvitations: vi.fn().mockResolvedValue(undefined),
+      setActiveHouseholdId: vi.fn(),
+    }
+    return selector ? selector(state) : state
+  },
 }))
 
 /**

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -215,13 +215,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setToken(newToken)
   }, []) // setToken은 React가 안정적 참조를 보장하므로 deps 불필요
 
-  const logout = () => {
+  // useCallback으로 참조 안정화 — Context value 재생성 최소화 (#167)
+  const logout = useCallback(() => {
     clearCookieToken()
     const authUrl = import.meta.env.VITE_AUTH_URL || 'https://auth.podonest.com'
     window.location.href = `${authUrl}/logout`
-  }
+  }, [])
 
-  const refreshUser = async () => {
+  const refreshUser = useCallback(async () => {
     if (!token) return
     try {
       const response = await authApi.getCurrentUser()
@@ -229,10 +230,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } catch {
       // 무시 (interceptor에서 401 처리)
     }
-  }
+  }, [token])
+
+  // useMemo로 Context value 안정화 — 의존값이 바뀔 때만 재생성 (#167)
+  const contextValue = useMemo(
+    () => ({ user, isAuthenticated, loading, logout, refreshUser, setTokenFromCallback }),
+    [user, isAuthenticated, loading, logout, refreshUser, setTokenFromCallback],
+  )
 
   return (
-    <AuthContext.Provider value={{ user, isAuthenticated, loading, logout, refreshUser, setTokenFromCallback }}>
+    <AuthContext.Provider value={contextValue}>
       {children}
     </AuthContext.Provider>
   )

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -5,7 +5,7 @@
  * 토스트 알림을 추가/제거할 수 있는 기능을 제공한다.
  */
 
-import { createContext, useContext, useState, useCallback } from 'react'
+import { createContext, useContext, useState, useCallback, useMemo } from 'react'
 import type { ReactNode } from 'react'
 import Toast from '../components/Toast'
 import type { ToastType } from '../components/Toast'
@@ -41,10 +41,11 @@ const ToastContext = createContext<ToastContextType | undefined>(undefined)
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastItem[]>([])
 
-  const addToast = (type: ToastType, message: string, duration = 3000) => {
+  // useCallback으로 참조 안정화 — toasts 변경 시 Context value 재생성 → 구독 컴포넌트 리렌더 방지 (#167)
+  const addToast = useCallback((type: ToastType, message: string, duration = 3000) => {
     const id = `toast-${Date.now()}-${Math.random()}`
     setToasts((prev) => [...prev, { id, type, message, duration }])
-  }
+  }, [])
 
   // useCallback으로 참조 안정화: Toast의 useEffect deps에 onClose가 포함되어
   // removeToast가 재생성될 때마다 타이머가 리셋되는 stale closure 방지
@@ -52,8 +53,11 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     setToasts((prev) => prev.filter((toast) => toast.id !== id))
   }, [])
 
+  // useMemo로 value 객체 안정화 — addToast/removeToast가 변경될 때만 재생성 (#167)
+  const contextValue = useMemo(() => ({ addToast, removeToast }), [addToast, removeToast])
+
   return (
-    <ToastContext.Provider value={{ addToast, removeToast }}>
+    <ToastContext.Provider value={contextValue}>
       {children}
       {/* 토스트 컨테이너: 화면 하단 중앙에 고정 */}
       <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 pointer-events-none">


### PR DESCRIPTION
## 변경 사항

### #166 — 자산 시세 N+1 외부 API 호출 + 중복 호출

**BE `asset_service.py`**
- `get_assets_with_prices`: `for asset: await` 직렬 루프 → `asyncio.gather` 병렬 실행
- 자산 5개 기준: 외부 API 응답 대기 5배 감소 (직렬 합산 → 가장 느린 1건)

**BE `price_service.py`**
- `_lock_for(key)` singleflight 헬퍼 추가
- `get_stock_kr_price` / `get_stock_us_price` / `get_crypto_price`: 락 획득 후 double-check 패턴
- `getAll + getSummary` 동시 요청이 같은 ticker 외부 API를 중복 호출하는 race 방지

### #167 — Layout/Context 불필요한 리렌더링

| 위치 | 기존 | 변경 |
|------|------|------|
| `Layout.tsx` | `useHouseholdStore()` 전체 구독 | selector로 필요한 4개 값만 구독 |
| `ToastContext` | `addToast` 매 렌더 재생성 | `useCallback([], [])` + `useMemo` value |
| `AuthContext` | `logout/refreshUser` 매 렌더 재생성 | `useCallback` + `useMemo` value |

**토스트 타이머 버그 수정**: `addToast` 재생성 → Context value 새 객체 → 구독 컴포넌트 리렌더 → Toast `useEffect` deps 재실행 → 타이머 리셋. `useCallback`으로 해결.

### 테스트 업데이트
- `Layout.test.tsx`: `useHouseholdStore` mock을 selector 방식(`(s) => selector(state)`) 지원으로 수정

## 테스트

- BE: 582 passed, 5 skipped
- FE: 520 passed (58 파일)
- ruff lint/format, ESLint warnings only (기존)

## 관련 이슈

Closes #166
Closes #167