### PR TITLE
security: 보안 강화 — 감사로그·timing attack·Admin 권한 (#141, #145, #154, #155)

### DIFF
--- a/backend/app/api/households.py
+++ b/backend/app/api/households.py
@@ -427,6 +427,10 @@ async def remove_member(
     if target_member.role == "owner":
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="소유자는 추방할 수 없습니다")
 
+    # admin은 다른 admin 추방 불가 — owner 권한 필요 (#154)
+    if member.role == "admin" and target_member.role == "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="관리자는 다른 관리자를 추방할 수 없습니다. 소유자 권한이 필요합니다")
+
     # 소프트 삭제 (left_at 설정)
     target_member.left_at = datetime.now(UTC).replace(tzinfo=None)
     await db.commit()

--- a/backend/app/api/kakao.py
+++ b/backend/app/api/kakao.py
@@ -9,6 +9,7 @@ LLM 호출을 4.5초로 제한하고 타임아웃 시 안내 메시지를 반환
 """
 
 import asyncio
+import hmac
 import logging
 from datetime import datetime
 
@@ -131,7 +132,10 @@ async def kakao_webhook(request: Request, db: AsyncSession = Depends(get_db)):
     if not settings.KAKAO_BOT_API_KEY:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="카카오 봇 API 키가 설정되지 않았습니다")
     auth_header = request.headers.get("Authorization", "")
-    if auth_header != settings.KAKAO_BOT_API_KEY:
+    # 카카오 오픈빌더는 "Bearer TOKEN" 형식으로 전송할 수 있으므로 prefix 제거 (#145)
+    api_key = auth_header.removeprefix("Bearer ").strip()
+    # hmac.compare_digest로 timing attack 방지 (#145)
+    if not hmac.compare_digest(api_key, settings.KAKAO_BOT_API_KEY):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="유효하지 않은 API 키")
 
     try:

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -11,6 +11,8 @@ podo-auth에서 발급된 JWT를 검증하고, 로컬 users 테이블의 Shadow 
   5. 기존 FK 관계는 users.id (Integer)로 그대로 유지
 """
 
+import logging
+
 from cachetools import TTLCache
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -22,6 +24,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.user import User
+
+logger = logging.getLogger(__name__)
 
 # HTTPBearer 스키마 (auto_error=False → 토큰 없을 때 None 반환, 직접 401 처리)
 security = HTTPBearer(auto_error=False)
@@ -101,7 +105,14 @@ async def get_current_user(
     user = result.scalar_one_or_none()
 
     if user:
-        # 기존 유저에 auth_user_id 연결
+        # 기존 유저에 auth_user_id 연결 — 보안 감사 로그 (#141)
+        # 이메일 매칭으로 계정 연결 시 로그 기록 (podo-auth 이메일 검증 강도에 의존)
+        logger.warning(
+            "Shadow User 이메일 매칭으로 계정 연결: user_id=%s email=%s auth_user_id=%s",
+            user.id,
+            email,
+            auth_user_id,
+        )
         user.auth_user_id = auth_user_id
         await db.commit()
         await db.refresh(user)

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -21,7 +21,7 @@ const TABS = ['현황', '피드백', '사용자'] as const
 type TabName = typeof TABS[number]
 
 export default function AdminPage() {
-  const { user } = useAuth()
+  const { user, loading: authLoading } = useAuth()
   const [activeTab, setActiveTab] = useState<TabName>('현황')
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
@@ -45,7 +45,12 @@ export default function AdminPage() {
     loadData()
   }, [user?.is_admin, loadData])
 
-  // 비관리자 접근 방지
+  // 사용자 프로필 로딩 중 — 비관리자로 오판하지 않도록 스피너 표시 (#154)
+  if (authLoading) {
+    return <LoadingSpinner className="min-h-[50vh]" />
+  }
+
+  // 비관리자 접근 방지 (백엔드 API도 require_admin으로 검증)
   if (!user?.is_admin) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[50vh] text-[var(--text-muted)]">


### PR DESCRIPTION
## Summary
- **#141** Shadow User 이메일 매칭 시 WARNING 감사 로그 기록 (`auth.py`)
- **#145** 카카오 인증 `hmac.compare_digest` 적용 + `Bearer` prefix 파싱 (`kakao.py`)
- **#154** admin이 다른 admin 추방 불가 (owner 권한 필요) + AdminPage authLoading 스피너
- **#155** Sentry sha256= prefix 파싱 및 console.warn DEV 조건 이미 적용됨 (no-op)

## Test plan
- [x] `pytest` 582 passed, 5 skipped
- [x] `npm run lint` warnings only (기존 warnings)
- [x] `npm run test:run` 520 passed
- [x] `ruff check/format` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)