### PR TITLE
fix: BE 버그 수정 — amount Decimal·레거시 데이터·온보딩 중복 (#146, #147, #150, #152)

### DIFF
--- a/backend/app/api/expenses.py
+++ b/backend/app/api/expenses.py
@@ -612,18 +612,23 @@ async def update_expense(
     if not expense:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="지출을 찾을 수 없습니다")
 
-    # 가구 멤버 검증 (비멤버는 존재 여부 노출 방지를 위해 404)
-    try:
-        member = await get_household_member(expense.household_id, current_user, db)
-    except HTTPException:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="지출을 찾을 수 없습니다") from None
+    if expense.household_id is None:
+        # 레거시 데이터(마이그레이션 이전): household_id=None → 본인 확인만으로 수정 허용 (#147)
+        if expense.user_id != current_user.id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="지출을 찾을 수 없습니다")
+    else:
+        # 가구 멤버 검증 (비멤버는 존재 여부 노출 방지를 위해 404)
+        try:
+            member = await get_household_member(expense.household_id, current_user, db)
+        except HTTPException:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="지출을 찾을 수 없습니다") from None
 
-    # 본인 거래가 아니면 admin/owner만 수정 가능
-    if expense.user_id != current_user.id and member.role not in ("admin", "owner"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="이 항목을 수정할 권한이 없습니다",
-        )
+        # 본인 거래가 아니면 admin/owner만 수정 가능
+        if expense.user_id != current_user.id and member.role not in ("admin", "owner"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="이 항목을 수정할 권한이 없습니다",
+            )
 
     update_data = expense_update.model_dump(exclude_unset=True)
     for key, value in update_data.items():
@@ -650,18 +655,23 @@ async def delete_expense(
     if not expense:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="지출을 찾을 수 없습니다")
 
-    # 가구 멤버 검증 (비멤버는 존재 여부 노출 방지를 위해 404)
-    try:
-        member = await get_household_member(expense.household_id, current_user, db)
-    except HTTPException:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="지출을 찾을 수 없습니다") from None
+    if expense.household_id is None:
+        # 레거시 데이터(마이그레이션 이전): household_id=None → 본인 확인만으로 삭제 허용 (#147)
+        if expense.user_id != current_user.id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="지출을 찾을 수 없습니다")
+    else:
+        # 가구 멤버 검증 (비멤버는 존재 여부 노출 방지를 위해 404)
+        try:
+            member = await get_household_member(expense.household_id, current_user, db)
+        except HTTPException:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="지출을 찾을 수 없습니다") from None
 
-    # 본인 거래가 아니면 admin/owner만 삭제 가능
-    if expense.user_id != current_user.id and member.role not in ("admin", "owner"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="이 항목을 삭제할 권한이 없습니다",
-        )
+        # 본인 거래가 아니면 admin/owner만 삭제 가능
+        if expense.user_id != current_user.id and member.role not in ("admin", "owner"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="이 항목을 삭제할 권한이 없습니다",
+            )
 
     await db.delete(expense)
     await db.commit()

--- a/backend/app/api/income.py
+++ b/backend/app/api/income.py
@@ -246,18 +246,23 @@ async def update_income(
     if not income:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="수입을 찾을 수 없습니다")
 
-    # 가구 멤버 검증 (비멤버는 존재 여부 노출 방지를 위해 404)
-    try:
-        member = await get_household_member(income.household_id, current_user, db)
-    except HTTPException:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="수입을 찾을 수 없습니다") from None
+    if income.household_id is None:
+        # 레거시 데이터(마이그레이션 이전): household_id=None → 본인 확인만으로 수정 허용 (#147)
+        if income.user_id != current_user.id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="수입을 찾을 수 없습니다")
+    else:
+        # 가구 멤버 검증 (비멤버는 존재 여부 노출 방지를 위해 404)
+        try:
+            member = await get_household_member(income.household_id, current_user, db)
+        except HTTPException:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="수입을 찾을 수 없습니다") from None
 
-    # 본인이 아닌 경우 admin/owner 권한 필요
-    if income.user_id != current_user.id and member.role not in ("admin", "owner"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="이 항목을 수정할 권한이 없습니다",
-        )
+        # 본인이 아닌 경우 admin/owner 권한 필요
+        if income.user_id != current_user.id and member.role not in ("admin", "owner"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="이 항목을 수정할 권한이 없습니다",
+            )
 
     update_data = income_update.model_dump(exclude_unset=True)
     for key, value in update_data.items():
@@ -280,18 +285,23 @@ async def delete_income(
     if not income:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="수입을 찾을 수 없습니다")
 
-    # 가구 멤버 검증 (비멤버는 존재 여부 노출 방지를 위해 404)
-    try:
-        member = await get_household_member(income.household_id, current_user, db)
-    except HTTPException:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="수입을 찾을 수 없습니다") from None
+    if income.household_id is None:
+        # 레거시 데이터(마이그레이션 이전): household_id=None → 본인 확인만으로 삭제 허용 (#147)
+        if income.user_id != current_user.id:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="수입을 찾을 수 없습니다")
+    else:
+        # 가구 멤버 검증 (비멤버는 존재 여부 노출 방지를 위해 404)
+        try:
+            member = await get_household_member(income.household_id, current_user, db)
+        except HTTPException:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="수입을 찾을 수 없습니다") from None
 
-    # 본인이 아닌 경우 admin/owner 권한 필요
-    if income.user_id != current_user.id and member.role not in ("admin", "owner"):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="이 항목을 삭제할 권한이 없습니다",
-        )
+        # 본인이 아닌 경우 admin/owner 권한 필요
+        if income.user_id != current_user.id and member.role not in ("admin", "owner"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="이 항목을 삭제할 권한이 없습니다",
+            )
 
     await db.delete(income)
     await db.commit()

--- a/backend/app/api/onboarding.py
+++ b/backend/app/api/onboarding.py
@@ -6,7 +6,7 @@
 
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -59,7 +59,16 @@ async def create_default_household(
     """기본 가구 생성 + owner 멤버십 추가
 
     가구 이름을 지정하지 않으면 "{username}님의 가계부"로 생성됩니다.
+    이미 활성 가구가 있는 경우 중복 생성을 방지합니다 (#152).
     """
+    # 이미 활성 가구가 있으면 중복 생성 방지 (#152)
+    existing_count = await _count_active_households(current_user.id, db)
+    if existing_count > 0:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="이미 가구에 소속되어 있습니다",
+        )
+
     name = body.name or f"{current_user.username}님의 가계부"
 
     household = Household(name=name)

--- a/backend/app/schemas/expense.py
+++ b/backend/app/schemas/expense.py
@@ -1,6 +1,7 @@
 """지출 스키마"""
 
 from datetime import datetime
+from decimal import Decimal
 from enum import Enum
 from typing import Any
 
@@ -8,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ExpenseBase(BaseModel):
-    amount: float = Field(..., gt=0, description="지출 금액 (0보다 커야 함)")
+    amount: Decimal = Field(..., gt=0, description="지출 금액 (0보다 커야 함)")
     description: str
     category_id: int | None = None
     date: datetime
@@ -35,7 +36,7 @@ class ExpenseCreate(ExpenseBase):
 
 
 class ExpenseUpdate(BaseModel):
-    amount: float | None = Field(None, gt=0, description="지출 금액 (0보다 커야 함)")
+    amount: Decimal | None = Field(None, gt=0, description="지출 금액 (0보다 커야 함)")
     description: str | None = None
     category_id: int | None = None
     date: datetime | None = None
@@ -44,6 +45,8 @@ class ExpenseUpdate(BaseModel):
 
 
 class ExpenseResponse(ExpenseBase):
+    # 응답 시 float으로 직렬화 (JSON 호환성) — 입력은 ExpenseBase의 Decimal로 정밀도 보장 (#146)
+    amount: float
     id: int
     raw_input: str | None = None
     memo: str | None = None

--- a/backend/app/schemas/income.py
+++ b/backend/app/schemas/income.py
@@ -1,13 +1,14 @@
 """수입 스키마"""
 
 from datetime import datetime
+from decimal import Decimal
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class IncomeBase(BaseModel):
-    amount: float = Field(..., gt=0, description="수입 금액 (0보다 커야 함)")
+    amount: Decimal = Field(..., gt=0, description="수입 금액 (0보다 커야 함)")
     description: str
     category_id: int | None = None
     date: datetime
@@ -34,7 +35,7 @@ class IncomeCreate(IncomeBase):
 
 
 class IncomeUpdate(BaseModel):
-    amount: float | None = Field(None, gt=0, description="수입 금액 (0보다 커야 함)")
+    amount: Decimal | None = Field(None, gt=0, description="수입 금액 (0보다 커야 함)")
     description: str | None = None
     category_id: int | None = None
     date: datetime | None = None
@@ -43,6 +44,8 @@ class IncomeUpdate(BaseModel):
 
 
 class IncomeResponse(IncomeBase):
+    # 응답 시 float으로 직렬화 (JSON 호환성) — 입력은 IncomeBase의 Decimal로 정밀도 보장 (#146)
+    amount: float
     id: int
     raw_input: str | None = None
     memo: str | None = None

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -6,11 +6,48 @@
 """
 
 import pytest
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.household_member import HouseholdMember
 from app.models.user import User
+
+
+async def _make_fresh_client(db_session: AsyncSession) -> tuple[AsyncClient, User]:
+    """가구 없는 신규 사용자 + 인증 클라이언트 생성"""
+    from datetime import timedelta
+
+    from jose import jwt as pyjwt
+
+    from app.core.database import get_db
+    from app.main import app
+
+    fresh_user = User(
+        auth_user_id=9999999,
+        username="fresh_user",
+        email="fresh@example.com",
+        is_active=True,
+    )
+    db_session.add(fresh_user)
+    await db_session.flush()
+    await db_session.refresh(fresh_user)
+
+    from datetime import UTC, datetime
+
+    payload = {
+        "sub": str(fresh_user.auth_user_id),
+        "email": fresh_user.email,
+        "name": fresh_user.username,
+        "iss": "podo-auth",
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+    }
+    token = pyjwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    client = AsyncClient(app=app, base_url="http://test", headers={"Authorization": f"Bearer {token}"})
+    return client, fresh_user
 
 
 @pytest.mark.asyncio
@@ -28,12 +65,14 @@ async def test_onboarding_status_has_household(authenticated_client, test_user: 
 
 
 @pytest.mark.asyncio
-async def test_create_household_with_name(authenticated_client, test_user: User, db_session: AsyncSession):
-    """이름을 지정하여 가구 생성"""
-    response = await authenticated_client.post(
-        "/api/onboarding/create-household",
-        json={"name": "우리 가족 가계부"},
-    )
+async def test_create_household_with_name(db_session: AsyncSession):
+    """이름을 지정하여 가구 생성 (가구 없는 신규 사용자)"""
+    client, fresh_user = await _make_fresh_client(db_session)
+    async with client:
+        response = await client.post(
+            "/api/onboarding/create-household",
+            json={"name": "우리 가족 가계부"},
+        )
 
     assert response.status_code == 201
     data = response.json()
@@ -45,7 +84,7 @@ async def test_create_household_with_name(authenticated_client, test_user: User,
     result = await db_session.execute(
         select(HouseholdMember).where(
             HouseholdMember.household_id == household_id,
-            HouseholdMember.user_id == test_user.id,
+            HouseholdMember.user_id == fresh_user.id,
         )
     )
     member = result.scalar_one()
@@ -53,12 +92,14 @@ async def test_create_household_with_name(authenticated_client, test_user: User,
 
 
 @pytest.mark.asyncio
-async def test_create_household_without_name(authenticated_client, test_user: User):
-    """이름 미지정 시 기본 이름으로 가구 생성"""
-    response = await authenticated_client.post(
-        "/api/onboarding/create-household",
-        json={},
-    )
+async def test_create_household_without_name(db_session: AsyncSession):
+    """이름 미지정 시 기본 이름으로 가구 생성 (가구 없는 신규 사용자)"""
+    client, _ = await _make_fresh_client(db_session)
+    async with client:
+        response = await client.post(
+            "/api/onboarding/create-household",
+            json={},
+        )
 
     assert response.status_code == 201
     data = response.json()
@@ -67,17 +108,31 @@ async def test_create_household_without_name(authenticated_client, test_user: Us
 
 
 @pytest.mark.asyncio
-async def test_onboarding_status_after_create(authenticated_client, test_user: User):
-    """가구 생성 후 온보딩 상태 변경 확인"""
-    # 추가 가구 생성
-    await authenticated_client.post(
+async def test_create_household_duplicate_blocked(authenticated_client, test_user: User):
+    """이미 가구가 있는 사용자의 중복 생성 시도 → 409 (#152)"""
+    response = await authenticated_client.post(
         "/api/onboarding/create-household",
-        json={"name": "새 가계부"},
+        json={"name": "중복 가계부"},
     )
 
-    # 상태 확인 (conftest 기본 가구 + 새 가구)
-    response = await authenticated_client.get("/api/onboarding/status")
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_onboarding_status_after_create(db_session: AsyncSession):
+    """가구 생성 후 온보딩 상태 변경 확인"""
+    client, _ = await _make_fresh_client(db_session)
+    async with client:
+        # 가구 생성
+        await client.post(
+            "/api/onboarding/create-household",
+            json={"name": "새 가계부"},
+        )
+
+        # 상태 확인
+        response = await client.get("/api/onboarding/status")
+
     assert response.status_code == 200
     data = response.json()
     assert data["has_household"] is True
-    assert data["household_count"] >= 2
+    assert data["household_count"] == 1

--- a/frontend/src/pages/HouseholdDetailPage.tsx
+++ b/frontend/src/pages/HouseholdDetailPage.tsx
@@ -444,7 +444,7 @@ export default function HouseholdDetailPage() {
                             >
                               추방
                             </button>
-                          ) : isMe && member.role !== 'owner' ? (
+                          ) : isMe && (member.role !== 'owner' || currentHousehold.members.length > 1) ? (
                             <button
                               onClick={handleLeave}
                               className="text-rose-600 hover:text-rose-700 font-medium"


### PR DESCRIPTION
## Summary
- **#146** `amount: float` → `Decimal` (입력 스키마, 응답은 `float` 유지) — 정밀도 손실 방지
- **#147** `household_id=None` 레거시 데이터 수정/삭제: 본인 확인만으로 허용
- **#150** `updateMemberRole` PUT → PATCH 이미 수정됨 (no-op)
- **#151** `_migrate_bot_user_data`로 이미 처리됨 (no-op)
- **#152** 온보딩: 이미 가구 소속 사용자 중복 생성 409 차단 + Owner 탈퇴 버튼 표시(2명 이상)

## Test plan
- [x] `pytest` 583 passed, 5 skipped
- [x] `npm run lint` warnings only
- [x] `npm run test:run` 520 passed
- [x] `ruff check/format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)