### PR TITLE
refactor: BE 아키텍처 쿼리 최적화 및 코드 정리

### DIFF
--- a/backend/app/api/assets.py
+++ b/backend/app/api/assets.py
@@ -206,7 +206,7 @@ async def get_monthly_savings(
     if household_id is None:
         household_id = await get_user_active_household_id(current_user, db)
     await get_household_member(household_id, current_user, db)
-    return await asset_goal_service.get_monthly_savings(current_user.id, household_id, db)
+    return await asset_goal_service.get_monthly_savings(household_id, db)
 
 
 @router.get("/{asset_id}", response_model=AssetWithPrice)

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -104,6 +104,7 @@ async def get_household_member(
     """가구 멤버 정보 조회 및 검증
 
     현재 사용자가 해당 가구의 활성 멤버인지 확인합니다.
+    Household LEFT JOIN HouseholdMember 단일 쿼리로 404/403 구분 (#178)
 
     Args:
         household_id: 가구 ID
@@ -117,34 +118,34 @@ async def get_household_member(
         HTTPException 404: 가구가 존재하지 않거나 소프트 삭제됨
         HTTPException 403: 사용자가 해당 가구의 멤버가 아님
     """
-    # 가구 존재 여부 확인 (소프트 삭제되지 않은 가구)
-    household_query = select(Household).where(
-        and_(
-            Household.id == household_id,
-            Household.deleted_at.is_(None),  # 소프트 삭제되지 않은 가구만
+    # Household LEFT JOIN HouseholdMember 단일 쿼리
+    # - Household 없음 → row is None → 404
+    # - Household 있지만 멤버 아님 → row.HouseholdMember is None → 403
+    result = await db.execute(
+        select(Household.id, HouseholdMember)
+        .outerjoin(
+            HouseholdMember,
+            and_(
+                HouseholdMember.household_id == Household.id,
+                HouseholdMember.user_id == current_user.id,
+                HouseholdMember.left_at.is_(None),
+            ),
+        )
+        .where(
+            and_(
+                Household.id == household_id,
+                Household.deleted_at.is_(None),
+            )
         )
     )
-    result = await db.execute(household_query)
-    household = result.scalar_one_or_none()
+    row = result.first()
 
-    if not household:
+    if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="가구를 찾을 수 없습니다")
-
-    # 멤버 자격 확인 (탈퇴하지 않은 활성 멤버)
-    member_query = select(HouseholdMember).where(
-        and_(
-            HouseholdMember.household_id == household_id,
-            HouseholdMember.user_id == current_user.id,
-            HouseholdMember.left_at.is_(None),  # 탈퇴하지 않은 멤버만
-        )
-    )
-    result = await db.execute(member_query)
-    member = result.scalar_one_or_none()
-
-    if not member:
+    if row.HouseholdMember is None:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="이 가구에 접근할 권한이 없습니다")
 
-    return member
+    return row.HouseholdMember
 
 
 async def require_household_admin(

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -260,59 +260,58 @@ async def get_user_list(
 
 
 async def get_user_detail(db: AsyncSession, user_id: int) -> AdminUserDetailResponse | None:
-    """사용자 상세 정보 조회"""
-    user_result = await db.execute(select(User).where(User.id == user_id))
-    user = user_result.scalar_one_or_none()
-    if not user:
-        return None
-
-    # 지출/수입 통계
-    expense_stats = await db.execute(
-        select(
-            func.count(Expense.id).label("count"),
-            func.coalesce(func.sum(Expense.amount), 0).label("total"),
-        ).where(Expense.user_id == user_id)
-    )
-    e = expense_stats.one()
-
-    income_stats = await db.execute(
-        select(
-            func.count(Income.id).label("count"),
-            func.coalesce(func.sum(Income.amount), 0).label("total"),
-        ).where(Income.user_id == user_id)
-    )
-    i = income_stats.one()
-
-    # 가구 수
-    household_count_result = await db.execute(
-        select(func.count(HouseholdMember.id)).where(
+    """사용자 상세 정보 조회 — 서브쿼리 단일 쿼리 (#178)"""
+    # 모든 통계를 서브쿼리로 묶어 단일 쿼리로 처리 (6쿼리 → 1쿼리)
+    expense_count_sq = select(func.count(Expense.id)).where(Expense.user_id == user_id).scalar_subquery()
+    expense_total_sq = select(func.coalesce(func.sum(Expense.amount), 0)).where(Expense.user_id == user_id).scalar_subquery()
+    income_count_sq = select(func.count(Income.id)).where(Income.user_id == user_id).scalar_subquery()
+    income_total_sq = select(func.coalesce(func.sum(Income.amount), 0)).where(Income.user_id == user_id).scalar_subquery()
+    household_count_sq = (
+        select(func.count(HouseholdMember.id))
+        .where(
             HouseholdMember.user_id == user_id,
             HouseholdMember.left_at.is_(None),
         )
+        .scalar_subquery()
     )
-    household_count = household_count_result.scalar() or 0
+    last_expense_sq = select(func.max(Expense.created_at)).where(Expense.user_id == user_id).scalar_subquery()
+    last_income_sq = select(func.max(Income.created_at)).where(Income.user_id == user_id).scalar_subquery()
+    last_activity = case(
+        (last_expense_sq.is_(None), last_income_sq),
+        (last_income_sq.is_(None), last_expense_sq),
+        (last_expense_sq > last_income_sq, last_expense_sq),
+        else_=last_income_sq,
+    )
 
-    # 마지막 활동
-    last_expense = await db.execute(select(func.max(Expense.created_at)).where(Expense.user_id == user_id))
-    last_income = await db.execute(select(func.max(Income.created_at)).where(Income.user_id == user_id))
-    le = last_expense.scalar()
-    li = last_income.scalar()
-    last_activity = max(filter(None, [le, li]), default=None)
+    result = await db.execute(
+        select(
+            User,
+            expense_count_sq.label("expense_count"),
+            expense_total_sq.label("total_spent"),
+            income_count_sq.label("income_count"),
+            income_total_sq.label("total_earned"),
+            household_count_sq.label("household_count"),
+            last_activity.label("last_activity_at"),
+        ).where(User.id == user_id)
+    )
+    row = result.one_or_none()
+    if not row:
+        return None
 
     return AdminUserDetailResponse(
-        id=user.id,
-        username=user.username,
-        email=user.email,
-        is_active=user.is_active,
-        created_at=user.created_at,
-        updated_at=user.updated_at,
-        expense_count=e.count,
-        income_count=i.count,
-        total_spent=float(e.total),
-        total_earned=float(i.total),
-        household_count=household_count,
-        is_telegram_linked=user.telegram_chat_id is not None,
-        last_activity_at=last_activity,
+        id=row.User.id,
+        username=row.User.username,
+        email=row.User.email,
+        is_active=row.User.is_active,
+        created_at=row.User.created_at,
+        updated_at=row.User.updated_at,
+        expense_count=row.expense_count,
+        income_count=row.income_count,
+        total_spent=float(row.total_spent),
+        total_earned=float(row.total_earned),
+        household_count=row.household_count,
+        is_telegram_linked=row.User.telegram_chat_id is not None,
+        last_activity_at=row.last_activity_at,
     )
 
 

--- a/backend/app/services/asset_goal_service.py
+++ b/backend/app/services/asset_goal_service.py
@@ -13,18 +13,17 @@ from app.models.user import User
 from app.services.asset_service import get_asset_summary
 
 
-async def get_goal(user_id: int, household_id: int | None, db: AsyncSession) -> AssetGoal | None:
+async def get_goal(user_id: int, household_id: int, db: AsyncSession) -> AssetGoal | None:
     """활성 목표 조회 (사용자/가구 당 최신 1개)"""
-    q = select(AssetGoal).where(AssetGoal.user_id == user_id)
-    q = q.where(AssetGoal.household_id == household_id) if household_id is not None else q.where(AssetGoal.household_id.is_(None))
-    q = q.order_by(AssetGoal.created_at.desc()).limit(1)
-    result = await db.execute(q)
+    result = await db.execute(
+        select(AssetGoal).where(AssetGoal.user_id == user_id, AssetGoal.household_id == household_id).order_by(AssetGoal.created_at.desc()).limit(1)
+    )
     return result.scalar_one_or_none()
 
 
 async def upsert_goal(
     user_id: int,
-    household_id: int | None,
+    household_id: int,
     target_net_worth: float,
     target_date: date,
     db: AsyncSession,
@@ -49,7 +48,7 @@ async def upsert_goal(
     return goal
 
 
-async def delete_goal(user_id: int, household_id: int | None, db: AsyncSession) -> bool:
+async def delete_goal(user_id: int, household_id: int, db: AsyncSession) -> bool:
     """목표 삭제"""
     goal = await get_goal(user_id, household_id, db)
     if not goal:
@@ -60,7 +59,7 @@ async def delete_goal(user_id: int, household_id: int | None, db: AsyncSession) 
 
 async def get_goal_with_insight(
     user: User,
-    household_id: int | None,
+    household_id: int,
     db: AsyncSession,
 ) -> dict | None:
     """목표 + 페이스 인사이트 계산"""
@@ -120,12 +119,14 @@ async def get_goal_with_insight(
     }
 
 
-async def _get_recent_snapshots(user_id: int, household_id: int | None, db: AsyncSession, months: int = 4) -> list[AssetSnapshot]:
+async def _get_recent_snapshots(user_id: int, household_id: int, db: AsyncSession, months: int = 4) -> list[AssetSnapshot]:
     """최근 N개월 스냅샷 조회"""
-    q = select(AssetSnapshot).where(AssetSnapshot.user_id == user_id)
-    q = q.where(AssetSnapshot.household_id == household_id) if household_id is not None else q.where(AssetSnapshot.household_id.is_(None))
-    q = q.order_by(AssetSnapshot.snapshot_date.desc()).limit(months)
-    result = await db.execute(q)
+    result = await db.execute(
+        select(AssetSnapshot)
+        .where(AssetSnapshot.user_id == user_id, AssetSnapshot.household_id == household_id)
+        .order_by(AssetSnapshot.snapshot_date.desc())
+        .limit(months)
+    )
     return list(result.scalars().all())
 
 
@@ -139,30 +140,26 @@ def _calc_avg_monthly_growth(snapshots: list[AssetSnapshot]) -> float | None:
     return (newest - oldest) / months if months > 0 else None
 
 
-async def get_monthly_savings(user_id: int, household_id: int | None, db: AsyncSession) -> dict:
-    """이번 달 수입 - 지출 = 순저축액"""
+async def get_monthly_savings(household_id: int, db: AsyncSession) -> dict:
+    """이번 달 수입 - 지출 = 순저축액 (exclude_from_stats 항목 제외, #182)"""
     today = date.today()
     year = today.year
     month = today.month
 
-    # 이번 달 수입 합산
+    # 이번 달 수입 합산 (통계 제외 항목 제외)
     income_q = select(func.coalesce(func.sum(Income.amount), 0)).where(
         extract("year", Income.date) == year,
         extract("month", Income.date) == month,
+        Income.household_id == household_id,
+        Income.exclude_from_stats.is_(False),
     )
-    # 이번 달 지출 합산
+    # 이번 달 지출 합산 (통계 제외 항목 제외)
     expense_q = select(func.coalesce(func.sum(Expense.amount), 0)).where(
         extract("year", Expense.date) == year,
         extract("month", Expense.date) == month,
+        Expense.household_id == household_id,
+        Expense.exclude_from_stats.is_(False),
     )
-
-    # household_id가 있으면 가구 기반, 없으면 개인 기반 (레거시 폴백)
-    if household_id is not None:
-        income_q = income_q.where(Income.household_id == household_id)
-        expense_q = expense_q.where(Expense.household_id == household_id)
-    else:
-        income_q = income_q.where(Income.user_id == user_id)
-        expense_q = expense_q.where(Expense.user_id == user_id)
 
     income_result = await db.execute(income_q)
     expense_result = await db.execute(expense_q)

--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -3,7 +3,7 @@
 한국 주식/ETF: 한국투자증권 Open API (1차), 네이버 금융 (fallback)
 미국 주식/ETF: Yahoo Finance
 코인: 업비트 공개 API
-환율: exchangerate-api
+환율: exchange_rate 서비스 위임 (USD/KRW 전용, #195)
 """
 
 import asyncio
@@ -13,6 +13,7 @@ import time
 import httpx
 
 from app.core.config import settings
+from app.services.exchange_rate import get_exchange_rate
 
 logger = logging.getLogger(__name__)
 
@@ -156,24 +157,22 @@ async def _get_stock_kr_price_naver(ticker: str) -> float | None:
 
 
 async def get_stock_us_price(ticker: str) -> tuple[float | None, float | None]:
-    """미국 주식/ETF 현재가 조회 (USD + KRW 환산)"""
+    """미국 주식/ETF 현재가 조회 (USD + KRW 환산, #195: USD/KRW는 exchange_rate 서비스 위임)"""
     key = f"us:{ticker}"
     cached_usd = _get_cached(key)
-    exchange_rate = await get_usd_krw_rate()
+    usd_krw = await get_exchange_rate("USD")
 
     if cached_usd is not _CACHE_MISS:
         if cached_usd is None:
             return None, None  # 실패 캐시 hit
-        usd = cached_usd  # type: ignore[assignment]
-        return usd, usd * exchange_rate if exchange_rate else None  # type: ignore[operator]
+        return cached_usd, cached_usd * usd_krw if usd_krw else None
 
     async with _lock_for(key):
         cached_usd = _get_cached(key)
         if cached_usd is not _CACHE_MISS:
             if cached_usd is None:
                 return None, None
-            usd = cached_usd  # type: ignore[assignment]
-            return usd, usd * exchange_rate if exchange_rate else None  # type: ignore[operator]
+            return cached_usd, cached_usd * usd_krw if usd_krw else None
 
         try:
             async with httpx.AsyncClient(timeout=10) as client:
@@ -187,7 +186,7 @@ async def get_stock_us_price(ticker: str) -> tuple[float | None, float | None]:
                     meta = data["chart"]["result"][0]["meta"]
                     price_usd = float(meta["regularMarketPrice"])
                     _set_cached(key, price_usd)
-                    krw_price = price_usd * exchange_rate if exchange_rate else None
+                    krw_price = price_usd * usd_krw if usd_krw else None
                     return price_usd, krw_price
         except Exception:
             pass
@@ -229,30 +228,20 @@ async def get_crypto_price(symbol: str) -> float | None:
     return None
 
 
-# ── 환율 ───────────────────────────────────────────────────────
-
-
-async def get_usd_krw_rate() -> float | None:
-    """USD/KRW 환율 조회"""
-    cached = _get_cached("fx:USDKRW")
-    if cached is not _CACHE_MISS:
-        return cached  # type: ignore[return-value]
-
-    try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.get("https://open.er-api.com/v6/latest/USD")
-            if resp.status_code == 200:
-                data = resp.json()
-                rate = float(data["rates"]["KRW"])
-                _set_cached("fx:USDKRW", rate)
-                return rate
-    except Exception:
-        pass
-    _set_cached("fx:USDKRW", None)  # 실패 캐시 (#159)
-    return None
-
-
 # ── 자산 평가액 계산 ───────────────────────────────────────────
+
+
+def _calc_profit(current_value: float, quantity: float, avg_buy_price: float | None) -> tuple[float | None, float | None]:
+    """수익/손실 계산 헬퍼 (#196)
+
+    Returns: (profit_loss, profit_loss_pct) — avg_buy_price 없으면 (None, None)
+    """
+    if not avg_buy_price:
+        return None, None
+    cost = quantity * avg_buy_price
+    profit_loss = current_value - cost
+    profit_loss_pct = (profit_loss / cost) * 100 if cost > 0 else 0
+    return profit_loss, profit_loss_pct
 
 
 async def get_asset_current_value(asset) -> dict:
@@ -267,30 +256,27 @@ async def get_asset_current_value(asset) -> dict:
         if price:
             result["current_price"] = price
             result["current_value"] = float(asset.quantity) * price
-            if asset.avg_buy_price:
-                cost = float(asset.quantity) * float(asset.avg_buy_price)
-                result["profit_loss"] = result["current_value"] - cost
-                result["profit_loss_pct"] = (result["profit_loss"] / cost) * 100 if cost > 0 else 0
+            result["profit_loss"], result["profit_loss_pct"] = _calc_profit(
+                result["current_value"], float(asset.quantity), float(asset.avg_buy_price) if asset.avg_buy_price else None
+            )
 
     elif asset.type == "stock_us" and asset.ticker and asset.quantity:
         _price_usd, price_krw = await get_stock_us_price(asset.ticker)
         if price_krw:
             result["current_price"] = price_krw
             result["current_value"] = float(asset.quantity) * price_krw
-            if asset.avg_buy_price:
-                cost = float(asset.quantity) * float(asset.avg_buy_price)
-                result["profit_loss"] = result["current_value"] - cost
-                result["profit_loss_pct"] = (result["profit_loss"] / cost) * 100 if cost > 0 else 0
+            result["profit_loss"], result["profit_loss_pct"] = _calc_profit(
+                result["current_value"], float(asset.quantity), float(asset.avg_buy_price) if asset.avg_buy_price else None
+            )
 
     elif asset.type == "crypto" and asset.ticker and asset.quantity:
         price = await get_crypto_price(asset.ticker)
         if price:
             result["current_price"] = price
             result["current_value"] = float(asset.quantity) * price
-            if asset.avg_buy_price:
-                cost = float(asset.quantity) * float(asset.avg_buy_price)
-                result["profit_loss"] = result["current_value"] - cost
-                result["profit_loss_pct"] = (result["profit_loss"] / cost) * 100 if cost > 0 else 0
+            result["profit_loss"], result["profit_loss_pct"] = _calc_profit(
+                result["current_value"], float(asset.quantity), float(asset.avg_buy_price) if asset.avg_buy_price else None
+            )
 
     elif asset.type in ("deposit", "real_estate", "other", "loan"):
         value = float(asset.manual_value) if asset.manual_value else 0


### PR DESCRIPTION
## 변경 사항

### #178 — 쿼리 최적화
- `get_household_member`: Household 존재확인(1) + 멤버확인(1) = 2쿼리 → LEFT JOIN 단일 쿼리로 통합. `row is None`(404) / `row.HouseholdMember is None`(403) 으로 에러 구분
- `admin_service.get_user_detail`: 개별 쿼리 6개 → 서브쿼리 7개를 묶은 단일 SELECT로 통합

### #182 — exclude_from_stats 필터
- `asset_goal_service.get_monthly_savings`: `Income.exclude_from_stats.is_(False)` + `Expense.exclude_from_stats.is_(False)` 필터 추가 (저축/퇴직금 등 비정형 항목 제외)

### #195 — USD/KRW 환율 중복 제거
- `price_service.get_usd_krw_rate()` 제거
- `get_stock_us_price()` 내 환율 조회를 `exchange_rate.get_exchange_rate("USD")` 로 위임 (단일 캐시 사용)

### #196 — 코드 정리
- `price_service._calc_profit()` 헬퍼 추출 (3회 중복 수익 계산 로직 제거)
- `asset_goal_service` 함수 시그니처 `household_id: int | None` → `int` 강화 (API 레이어에서 항상 resolve됨)

## 테스트
- `pytest --ignore=tests/integration/test_api_budget_bulk.py` → 582 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)