### PR TITLE
refactor: household_id 결정 로직을 API 레이어로 이동 (#180, #193)

### DIFF
--- a/backend/app/api/accounts.py
+++ b/backend/app/api/accounts.py
@@ -21,7 +21,11 @@ async def create_account(
 ):
     """계좌 등록"""
     account_data = account.model_dump()
-    return await account_service.create_account(db, account_data, current_user)
+    household_id = account_data.get("household_id")
+    if household_id is None:
+        household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)
+    return await account_service.create_account(db, account_data, current_user, household_id)
 
 
 @router.get("", response_model=list[AccountResponse])
@@ -34,7 +38,7 @@ async def get_accounts(
     if household_id is None:
         household_id = await get_user_active_household_id(current_user, db)
     await get_household_member(household_id, current_user, db)
-    return await account_service.get_accounts(db, current_user, household_id)
+    return await account_service.get_accounts(db, household_id)
 
 
 @router.get("/{account_id}", response_model=AccountResponse)

--- a/backend/app/api/assets.py
+++ b/backend/app/api/assets.py
@@ -34,7 +34,11 @@ async def create_asset(
 ):
     """자산/부채 등록"""
     asset_data = asset.model_dump()
-    result = await asset_service.create_asset(db, asset_data, current_user)
+    household_id = asset_data.get("household_id")
+    if household_id is None:
+        household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)
+    result = await asset_service.create_asset(db, asset_data, current_user, household_id)
     return result
 
 

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -7,19 +7,9 @@ from app.models.account import Account
 from app.models.user import User
 
 
-async def get_user_active_household_id(user: User, db: AsyncSession) -> int:
-    """사용자의 활성 household_id 가져오기 (필수)"""
-    from app.api.dependencies import get_user_active_household_id as _get
-
-    return await _get(user, db)
-
-
-async def create_account(db: AsyncSession, account_data: dict, user: User) -> Account:
-    """계좌 생성"""
-    household_id = account_data.pop("household_id", None)
-    if household_id is None:
-        household_id = await get_user_active_household_id(user, db)
-
+async def create_account(db: AsyncSession, account_data: dict, user: User, household_id: int) -> Account:
+    """계좌 생성 — household_id는 API 레이어에서 resolve 후 전달 (#193)"""
+    account_data.pop("household_id", None)  # schema에 포함된 경우 제거
     account = Account(**account_data, created_by=user.id, household_id=household_id)
     db.add(account)
     await db.commit()
@@ -27,10 +17,9 @@ async def create_account(db: AsyncSession, account_data: dict, user: User) -> Ac
     return account
 
 
-async def get_accounts(db: AsyncSession, user: User, household_id: int | None = None) -> list[Account]:
-    """계좌 목록 조회"""
-    query = select(Account).where(Account.household_id == household_id) if household_id is not None else select(Account).where(Account.created_by == user.id)
-    query = query.order_by(Account.type, Account.name)
+async def get_accounts(db: AsyncSession, household_id: int) -> list[Account]:
+    """계좌 목록 조회 — household_id는 API 레이어에서 resolve 후 전달 (#193)"""
+    query = select(Account).where(Account.household_id == household_id).order_by(Account.type, Account.name)
     result = await db.execute(query)
     return list(result.scalars().all())
 

--- a/backend/app/services/asset_service.py
+++ b/backend/app/services/asset_service.py
@@ -12,19 +12,9 @@ from app.models.user import User
 from app.services.price_service import get_asset_current_value
 
 
-async def get_user_active_household_id(user: User, db: AsyncSession) -> int:
-    """사용자의 활성 household_id 가져오기 (필수)"""
-    from app.api.dependencies import get_user_active_household_id as _get
-
-    return await _get(user, db)
-
-
-async def create_asset(db: AsyncSession, asset_data: dict, user: User) -> Asset:
-    """자산 생성"""
-    household_id = asset_data.pop("household_id", None)
-    if household_id is None:
-        household_id = await get_user_active_household_id(user, db)
-
+async def create_asset(db: AsyncSession, asset_data: dict, user: User, household_id: int) -> Asset:
+    """자산 생성 — household_id는 API 레이어에서 resolve 후 전달 (#180)"""
+    asset_data.pop("household_id", None)  # schema에 포함된 경우 제거
     asset = Asset(**asset_data, created_by=user.id, household_id=household_id)
     db.add(asset)
     await db.commit()


### PR DESCRIPTION
## Summary

- **#193** `account_service.py`: `get_user_active_household_id` 래퍼 제거, `create_account`에 `household_id: int` 직접 수용, `get_accounts`에서 `user` 파라미터 제거 및 `household_id` 필수화
- **#180** `asset_service.py`: `get_user_active_household_id` 래퍼 제거, `create_asset`에 `household_id: int` 직접 수용
- `accounts.py` / `assets.py` API: `create_account`/`create_asset` 호출 전 household_id resolve + 권한 검증 추가

서비스 레이어에서 `api.dependencies` 역방향 import(`services → api`) 완전 제거.

## Test plan

- [ ] `pytest --ignore=tests/integration/test_api_budget_bulk.py` 582 passed, 5 skipped ✅
- [ ] `ruff check --fix` + `ruff format` 이상 없음 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)