### PR TITLE
test: FE 테스트 커버리지 추가 (#183, #190, #198, #201)

### DIFF
--- a/frontend/src/api/__tests__/auth.test.ts
+++ b/frontend/src/api/__tests__/auth.test.ts
@@ -40,5 +40,25 @@ describe('authApi', () => {
       expect(response.data.id).toBe(1)
       expect(response.data.username).toBe('test')
     })
+
+    it('401 에러 응답 시 예외를 던진다', async () => {
+      server.use(
+        http.get(`${BASE_URL}/auth/me`, () =>
+          HttpResponse.json({ detail: 'Unauthorized' }, { status: 401 })
+        )
+      )
+
+      await expect(authApi.getCurrentUser()).rejects.toThrow()
+    })
+
+    it('네트워크 에러 시 예외를 던진다', async () => {
+      server.use(
+        http.get(`${BASE_URL}/auth/me`, () => {
+          throw new Error('Network Error')
+        })
+      )
+
+      await expect(authApi.getCurrentUser()).rejects.toThrow()
+    })
   })
 })

--- a/frontend/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/__tests__/ProtectedRoute.test.tsx
@@ -5,7 +5,7 @@
  * isAuthenticated (토큰 기반, 동기적)를 사용하는 새 구조 기준.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import ProtectedRoute from '../ProtectedRoute'
@@ -17,7 +17,13 @@ vi.mock('../../contexts/AuthContext', () => ({
 }))
 
 // useHouseholdStore 모킹 — 기본적으로 가구 있는 상태 + 초기화 완료
-const mockHouseholdState = {
+const mockHouseholdState: {
+  households: { id: number; name: string }[]
+  isLoading: boolean
+  hasInitialized: boolean
+  initError: string | null
+  initializeApp: ReturnType<typeof vi.fn>
+} = {
   households: [{ id: 1, name: '테스트 가계부' }],
   isLoading: false,
   hasInitialized: true,
@@ -48,9 +54,31 @@ const renderProtectedRoute = () => {
   )
 }
 
+/** /onboarding 라우트도 포함된 렌더 헬퍼 */
+const renderProtectedRouteWithOnboarding = () => {
+  return render(
+    <MemoryRouter initialEntries={['/protected']}>
+      <Routes>
+        <Route element={<ProtectedRoute />}>
+          <Route path="/protected" element={<div>보호된 페이지</div>} />
+          <Route path="/onboarding" element={<div>온보딩 페이지</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
 describe('ProtectedRoute', () => {
   beforeEach(() => {
     mockLocationHref.mockClear()
+    // 각 테스트 전에 기본 상태로 초기화
+    mockHouseholdState.households = [{ id: 1, name: '테스트 가계부' }]
+    mockHouseholdState.hasInitialized = true
+    mockHouseholdState.initError = null
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('인증된 사용자일 때 자식 라우트를 렌더링한다', () => {
@@ -86,5 +114,43 @@ describe('ProtectedRoute', () => {
     const { container } = renderProtectedRoute()
 
     expect(container.firstChild).toBeNull()
+  })
+
+  it('hasInitialized=false (초기화 중) 상태에서는 로딩 UI를 표시하고 보호된 페이지는 숨긴다', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true })
+    mockHouseholdState.hasInitialized = false
+
+    renderProtectedRoute()
+
+    // 로딩 스피너가 보여야 한다
+    const spinner = document.querySelector('.animate-spin')
+    expect(spinner).toBeInTheDocument()
+    // 보호된 페이지 내용은 보이지 않아야 한다
+    expect(screen.queryByText('보호된 페이지')).not.toBeInTheDocument()
+  })
+
+  it('initError 상태에서는 재시도 버튼이 표시된다', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true })
+    // hasInitialized=true이지만 initError가 있는 상태 — 현재 컴포넌트 로직: initError가 있으면 에러 UI
+    mockHouseholdState.hasInitialized = true
+    mockHouseholdState.initError = '서버 에러'
+
+    renderProtectedRoute()
+
+    expect(screen.getByText('다시 시도')).toBeInTheDocument()
+    expect(screen.queryByText('보호된 페이지')).not.toBeInTheDocument()
+  })
+
+  it('가구가 없으면 /onboarding으로 navigate한다', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true })
+    mockHouseholdState.hasInitialized = true
+    mockHouseholdState.initError = null
+    mockHouseholdState.households = []
+
+    renderProtectedRouteWithOnboarding()
+
+    await waitFor(() => {
+      expect(screen.getByText('온보딩 페이지')).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/contexts/__tests__/ThemeContext.test.tsx
+++ b/frontend/src/contexts/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * @file ThemeContext.test.tsx
+ * @description ThemeContext(ThemeProvider + useTheme) 테스트
+ *
+ * - localStorage 기반 테마 초기화
+ * - classList 부수효과 (.dark 클래스 토글)
+ * - matchMedia prefers-color-scheme 처리
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ThemeProvider, useTheme } from '../ThemeContext'
+
+// matchMedia mock 헬퍼
+function mockMatchMedia(prefersDark: boolean) {
+  const listeners: ((e: Partial<MediaQueryListEvent>) => void)[] = []
+  const mql = {
+    matches: prefersDark,
+    addEventListener: (_: string, fn: (e: Partial<MediaQueryListEvent>) => void) => {
+      listeners.push(fn)
+    },
+    removeEventListener: (_: string, fn: (e: Partial<MediaQueryListEvent>) => void) => {
+      const idx = listeners.indexOf(fn)
+      if (idx >= 0) listeners.splice(idx, 1)
+    },
+    dispatchChange: (matches: boolean) => {
+      listeners.forEach((fn) => fn({ matches }))
+    },
+  }
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue(mql),
+  })
+  return mql
+}
+
+/** ThemeProvider 내부 상태를 노출하는 테스트용 컴포넌트 */
+function ThemeConsumer() {
+  const { mode, resolvedTheme, setMode } = useTheme()
+  return (
+    <div>
+      <span data-testid="mode">{mode}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
+      <button onClick={() => setMode('dark')}>다크로</button>
+      <button onClick={() => setMode('light')}>라이트로</button>
+      <button onClick={() => setMode('system')}>시스템으로</button>
+    </div>
+  )
+}
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    // 기본적으로 light 선호로 초기화
+    mockMatchMedia(false)
+    // html 클래스 초기화
+    document.documentElement.classList.remove('dark')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('localStorage 기반 초기화', () => {
+    it('localStorage에 저장값이 없으면 system 모드로 초기화된다', () => {
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      expect(screen.getByTestId('mode').textContent).toBe('system')
+    })
+
+    it('localStorage에 "dark"가 저장되어 있으면 dark 모드로 초기화된다', () => {
+      localStorage.setItem('theme', 'dark')
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      expect(screen.getByTestId('mode').textContent).toBe('dark')
+      expect(screen.getByTestId('resolved').textContent).toBe('dark')
+    })
+
+    it('localStorage에 "light"가 저장되어 있으면 light 모드로 초기화된다', () => {
+      localStorage.setItem('theme', 'light')
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      expect(screen.getByTestId('mode').textContent).toBe('light')
+      expect(screen.getByTestId('resolved').textContent).toBe('light')
+    })
+
+    it('localStorage에 유효하지 않은 값이 있으면 system 모드로 초기화된다', () => {
+      localStorage.setItem('theme', 'invalid-value')
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      expect(screen.getByTestId('mode').textContent).toBe('system')
+    })
+  })
+
+  describe('classList 부수효과', () => {
+    it('dark 모드로 전환하면 html에 .dark 클래스가 추가된다', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      await user.click(screen.getByText('다크로'))
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+
+    it('light 모드로 전환하면 html에서 .dark 클래스가 제거된다', async () => {
+      localStorage.setItem('theme', 'dark')
+      document.documentElement.classList.add('dark')
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      await user.click(screen.getByText('라이트로'))
+      expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
+
+    it('setMode 호출 시 localStorage에 선택한 모드가 저장된다', async () => {
+      const user = userEvent.setup()
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      await user.click(screen.getByText('다크로'))
+      expect(localStorage.getItem('theme')).toBe('dark')
+
+      await user.click(screen.getByText('라이트로'))
+      expect(localStorage.getItem('theme')).toBe('light')
+    })
+  })
+
+  describe('matchMedia prefers-color-scheme 처리', () => {
+    it('system 모드에서 OS가 dark 선호이면 resolvedTheme이 dark다', () => {
+      mockMatchMedia(true)
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      expect(screen.getByTestId('mode').textContent).toBe('system')
+      expect(screen.getByTestId('resolved').textContent).toBe('dark')
+    })
+
+    it('system 모드에서 OS가 light 선호이면 resolvedTheme이 light다', () => {
+      mockMatchMedia(false)
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      expect(screen.getByTestId('resolved').textContent).toBe('light')
+    })
+
+    it('system 모드에서 OS prefers-color-scheme 변경 이벤트에 반응한다', async () => {
+      const mql = mockMatchMedia(false)
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      // 초기에는 light
+      expect(screen.getByTestId('resolved').textContent).toBe('light')
+
+      // OS가 dark로 변경되면 resolvedTheme도 dark로 변경
+      act(() => {
+        mql.dispatchChange(true)
+      })
+      expect(screen.getByTestId('resolved').textContent).toBe('dark')
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+
+    it('light 고정 모드에서는 OS 변경 이벤트를 무시한다', async () => {
+      localStorage.setItem('theme', 'light')
+      const mql = mockMatchMedia(false)
+      render(
+        <ThemeProvider>
+          <ThemeConsumer />
+        </ThemeProvider>
+      )
+      // light 모드에서는 이벤트 리스너가 등록되지 않아야 함
+      act(() => {
+        mql.dispatchChange(true)
+      })
+      // light 모드이므로 여전히 light
+      expect(screen.getByTestId('resolved').textContent).toBe('light')
+    })
+  })
+})

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -5,11 +5,17 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../mocks/server'
 import SettingsPage from '../SettingsPage'
 import { ThemeProvider } from '../../contexts/ThemeContext'
 import { changelogs } from '../../data/changelogs'
+
+// refreshUser는 테스트마다 호출 여부를 검증할 수 있도록 vi.fn()으로 분리
+const mockRefreshUser = vi.fn()
 
 // useAuth 모킹
 vi.mock('../../contexts/AuthContext', () => ({
@@ -24,7 +30,7 @@ vi.mock('../../contexts/AuthContext', () => ({
     },
     isAuthenticated: true,
     loading: false,
-    refreshUser: vi.fn(),
+    refreshUser: mockRefreshUser,
     logout: vi.fn(),
   }),
 }))
@@ -56,6 +62,8 @@ describe('SettingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+    // window.confirm 기본 동작 (연동 해제 confirm 대화상자 자동 승인)
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
 
   describe('메뉴 목록 (메인)', () => {
@@ -148,6 +156,43 @@ describe('SettingsPage', () => {
       renderSettingsPage('/settings/changelog')
       const firstTag = changelogs[0].items[0].tag
       expect(screen.getAllByText(firstTag).length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('텔레그램 연동 (내 계정 서브 페이지)', () => {
+    it('텔레그램 연동 코드 발급 버튼 클릭 시 코드가 화면에 표시된다', async () => {
+      // MSW에 텔레그램 코드 발급 핸들러 등록
+      server.use(
+        http.post('/api/auth/telegram-link-code', () =>
+          HttpResponse.json({
+            code: 'ABC123',
+            expires_at: '2026-03-19T12:00:00Z',
+          })
+        )
+      )
+
+      const user = userEvent.setup()
+      renderSettingsPage('/settings/my-account')
+
+      // "연동 코드 발급" 버튼이 여럿 있으므로 (텔레그램 + 카카오) 첫 번째(텔레그램) 클릭
+      const codeBtns = await screen.findAllByRole('button', { name: '연동 코드 발급' })
+      await user.click(codeBtns[0]) // 첫 번째가 텔레그램
+
+      // 발급된 코드가 화면에 표시되어야 한다
+      await waitFor(() => {
+        expect(screen.getByText('ABC123')).toBeInTheDocument()
+      })
+    })
+
+    it('미연동 상태에서는 연동 해제 버튼 없이 코드 발급 버튼이 표시된다', () => {
+      // useAuth mock에서 is_telegram_linked=false가 기본값
+      renderSettingsPage('/settings/my-account')
+
+      // 미연동 상태: "연동 코드 발급" 버튼들이 존재 (텔레그램 + 카카오 각 1개)
+      const codeBtns = screen.getAllByRole('button', { name: '연동 코드 발급' })
+      expect(codeBtns.length).toBeGreaterThanOrEqual(1)
+      // 연동 해제 버튼은 없어야 한다 (is_linked=false 상태이므로)
+      expect(screen.queryByRole('button', { name: '연동 해제' })).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/__tests__/TransactionList.test.tsx
+++ b/frontend/src/pages/__tests__/TransactionList.test.tsx
@@ -7,6 +7,8 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../mocks/server'
 import TransactionList from '../TransactionList'
 
 vi.mock('../../hooks/useToast', () => ({
@@ -23,6 +25,50 @@ function renderPage(initialRoute = '/') {
     <MemoryRouter initialEntries={[initialRoute]}>
       <TransactionList />
     </MemoryRouter>,
+  )
+}
+
+/** 현재 월 날짜 기준의 mock 거래 데이터를 MSW로 제공하는 헬퍼 */
+function setupCurrentMonthHandlers() {
+  const now = new Date()
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const todayDate = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+  const currentMonthISO = `${todayDate}T12:00:00Z`
+
+  server.use(
+    http.get('/api/expenses', () =>
+      HttpResponse.json([
+        {
+          id: 101,
+          amount: 8000,
+          description: '김치찌개',
+          category_id: 1,
+          raw_input: null,
+          memo: null,
+          household_id: 1,
+          user_id: null,
+          exclude_from_stats: false,
+          date: currentMonthISO,
+          created_at: currentMonthISO,
+          updated_at: currentMonthISO,
+        },
+        {
+          id: 102,
+          amount: 3500,
+          description: '버스',
+          category_id: 2,
+          raw_input: null,
+          memo: null,
+          household_id: 1,
+          user_id: null,
+          exclude_from_stats: false,
+          date: currentMonthISO,
+          created_at: currentMonthISO,
+          updated_at: currentMonthISO,
+        },
+      ])
+    ),
+    http.get('/api/income', () => HttpResponse.json([])),
   )
 }
 
@@ -95,6 +141,80 @@ describe('TransactionList', () => {
     await waitFor(() => {
       expect(screen.getByText('일')).toBeInTheDocument()
       expect(screen.getByText('토')).toBeInTheDocument()
+    })
+  })
+
+  describe('MSW 데이터 표시 검증', () => {
+    it('MSW가 반환한 지출 description이 화면에 표시된다', async () => {
+      setupCurrentMonthHandlers()
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByText('김치찌개')).toBeInTheDocument()
+        expect(screen.getByText('버스')).toBeInTheDocument()
+      })
+    })
+
+    it('지출 필터 클릭 후 수입만 있을 때 지출 항목이 숨겨진다', async () => {
+      // 수입 1건, 지출 1건 반환하도록 설정
+      const now = new Date()
+      const pad = (n: number) => String(n).padStart(2, '0')
+      const currentMonthISO = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T12:00:00Z`
+
+      server.use(
+        http.get('/api/expenses', () =>
+          HttpResponse.json([
+            {
+              id: 201,
+              amount: 8000,
+              description: '점심식사',
+              category_id: 1,
+              raw_input: null,
+              memo: null,
+              household_id: 1,
+              user_id: null,
+              exclude_from_stats: false,
+              date: currentMonthISO,
+              created_at: currentMonthISO,
+              updated_at: currentMonthISO,
+            },
+          ])
+        ),
+        http.get('/api/income', () =>
+          HttpResponse.json([
+            {
+              id: 301,
+              amount: 3000000,
+              description: '월급',
+              category_id: null,
+              raw_input: null,
+              memo: null,
+              household_id: 1,
+              user_id: null,
+              date: currentMonthISO,
+              created_at: currentMonthISO,
+              updated_at: currentMonthISO,
+            },
+          ])
+        ),
+      )
+
+      const user = userEvent.setup()
+      renderPage()
+
+      // 데이터 로드 대기
+      await waitFor(() => {
+        expect(screen.getByText('점심식사')).toBeInTheDocument()
+      })
+
+      // 수입 필터 클릭 → 수입 항목만 표시
+      const incomeBtn = screen.getByText('수입')
+      await user.click(incomeBtn)
+
+      await waitFor(() => {
+        expect(screen.getByText('월급')).toBeInTheDocument()
+        expect(screen.queryByText('점심식사')).not.toBeInTheDocument()
+      })
     })
   })
 })

--- a/frontend/src/utils/__tests__/format.test.ts
+++ b/frontend/src/utils/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatCompactAmount } from '../format'
+import { formatAmount, formatAmountWithSign, formatCompactAmount } from '../format'
 
 describe('formatCompactAmount', () => {
   it('1만 미만은 그대로 표시', () => {
@@ -24,5 +24,34 @@ describe('formatCompactAmount', () => {
   it('소수점 불필요 시 제거', () => {
     expect(formatCompactAmount(20000)).toBe('2만')
     expect(formatCompactAmount(3000000)).toBe('300만')
+  })
+})
+
+describe('formatAmount', () => {
+  it('₩ 기호와 쉼표 형식으로 포맷한다', () => {
+    expect(formatAmount(8000)).toBe('₩8,000')
+    expect(formatAmount(1000000)).toBe('₩1,000,000')
+    expect(formatAmount(0)).toBe('₩0')
+  })
+
+  it('소수점은 반올림하여 표시한다', () => {
+    expect(formatAmount(8000.7)).toBe('₩8,001')
+    expect(formatAmount(8000.3)).toBe('₩8,000')
+  })
+
+  it('음수 금액도 포맷한다', () => {
+    expect(formatAmount(-5000)).toBe('₩-5,000')
+  })
+})
+
+describe('formatAmountWithSign', () => {
+  it('수입(income)이면 + 접두사를 추가한다', () => {
+    expect(formatAmountWithSign(50000, 'income')).toBe('+₩50,000')
+    expect(formatAmountWithSign(0, 'income')).toBe('+₩0')
+  })
+
+  it('지출(expense)이면 접두사 없이 표시한다', () => {
+    expect(formatAmountWithSign(8000, 'expense')).toBe('₩8,000')
+    expect(formatAmountWithSign(100000, 'expense')).toBe('₩100,000')
   })
 })

--- a/frontend/src/utils/__tests__/healthScore.test.ts
+++ b/frontend/src/utils/__tests__/healthScore.test.ts
@@ -54,4 +54,86 @@ describe('calculateHealthScore', () => {
     })
     expect(grades).toContain(score.grade)
   })
+
+  it('spending: 예산 사용률 80% 구간 경계 (정확히 80%) → 100점', () => {
+    const score = calculateHealthScore({
+      incomeTotal: 5000000,
+      expenseTotal: 3200000,
+      budgetTotal: 4000000,
+      budgetSpent: 3200000, // 80% 정확히
+    })
+    expect(score.spending).toBe(100)
+  })
+
+  it('spending: 예산 사용률 90% 구간 → 75점 부근', () => {
+    // usageRate = 0.9 → 100 - (0.9 - 0.8) * 250 = 75
+    const score = calculateHealthScore({
+      incomeTotal: 5000000,
+      expenseTotal: 3600000,
+      budgetTotal: 4000000,
+      budgetSpent: 3600000, // 90%
+    })
+    expect(score.spending).toBe(75)
+  })
+
+  it('spending: 예산 사용률 100% 구간 경계 → 50점', () => {
+    // usageRate = 1.0 → 100 - (1.0 - 0.8) * 250 = 50
+    const score = calculateHealthScore({
+      incomeTotal: 5000000,
+      expenseTotal: 4000000,
+      budgetTotal: 4000000,
+      budgetSpent: 4000000, // 100%
+    })
+    expect(score.spending).toBe(50)
+  })
+
+  it('totalAssets=0이어도 부채 점수를 계산한다 (부채비율 2 적용)', () => {
+    // totalAssets=0이면 debtRatio=2 → ratioScore=20
+    const score = calculateHealthScore({
+      incomeTotal: 3000000,
+      expenseTotal: 2000000,
+      totalLiabilities: 10000000,
+      totalAssets: 0,
+      avgLoanRate: 0,
+    })
+    // ratioScore=20, rateScore=100 → debt = 20*0.6 + 100*0.4 = 52
+    expect(score.debt).toBe(52)
+  })
+
+  it('점수 범위는 항상 0-100 사이다', () => {
+    // 극단적 케이스: 수입 없이 지출만 있음
+    const worst = calculateHealthScore({
+      incomeTotal: 100,
+      expenseTotal: 10000000,
+      budgetTotal: 1000,
+      budgetSpent: 10000000,
+      totalLiabilities: 100000000,
+      totalAssets: 1,
+      avgLoanRate: 20,
+    })
+    expect(worst.savings).toBeGreaterThanOrEqual(0)
+    expect(worst.savings).toBeLessThanOrEqual(100)
+    expect(worst.spending).toBeGreaterThanOrEqual(0)
+    expect(worst.spending).toBeLessThanOrEqual(100)
+    expect(worst.debt).toBeGreaterThanOrEqual(0)
+    expect(worst.debt).toBeLessThanOrEqual(100)
+    expect(worst.overall).toBeGreaterThanOrEqual(0)
+    expect(worst.overall).toBeLessThanOrEqual(100)
+
+    // 극단적 케이스: 모든 조건 완벽
+    const best = calculateHealthScore({
+      incomeTotal: 5000000,
+      expenseTotal: 0,
+      budgetTotal: 5000000,
+      budgetSpent: 0,
+      totalLiabilities: 0,
+      totalAssets: 100000000,
+      avgLoanRate: 0,
+    })
+    expect(best.savings).toBeGreaterThanOrEqual(0)
+    expect(best.savings).toBeLessThanOrEqual(100)
+    expect(best.spending).toBe(100)
+    expect(best.debt).toBe(100)
+    expect(best.overall).toBeLessThanOrEqual(100)
+  })
 })


### PR DESCRIPTION
## Summary

- **#198** `format.test.ts`에 `formatAmount`, `formatAmountWithSign` 테스트 추가 / `healthScore.test.ts`에 경계값 테스트 추가 (spending 80-100% 구간, totalAssets=0, 점수 범위 0-100 보장)
- **#198** `ThemeContext.test.tsx` 신규 생성 — localStorage 기반 테마 초기화, classList .dark 토글, matchMedia prefers-color-scheme 이벤트 반응 테스트
- **#190** `TransactionList.test.tsx`에 MSW 데이터 description 표시 확인 및 필터 클릭 후 항목 수 변경 검증 추가
- **#183** `ProtectedRoute.test.tsx`에 `hasInitialized=false` 로딩 UI, `initError` 재시도 UI, 가구 없을 때 /onboarding navigate 케이스 추가
- **#183** `auth.test.ts`에 401 에러 및 네트워크 에러 케이스 추가
- **#201** `SettingsPage.test.tsx`에 텔레그램 연동 코드 발급 버튼 동작 및 미연동 상태 UI 검증 추가

## Test plan

- [x] `npm run lint` — 에러 없음 (기존 warning만)
- [x] `npm run test:run` — 550 tests passed (59 test files)
- [x] `npm run build` — 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)