### PR TITLE
fix: LLM 수입 항목 type 기반 레이블 및 토큰 인터벌 축소 (#148, #149, #150, #153)

### DIFF
--- a/frontend/src/components/__tests__/ParsedItemPreviewCard.test.tsx
+++ b/frontend/src/components/__tests__/ParsedItemPreviewCard.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @file ParsedItemPreviewCard.test.tsx
+ * @description ParsedItemPreviewCard 컴포넌트 테스트 (#148)
+ *
+ * label/colorScheme prop이 항목 타입에 따라 올바르게 렌더링되는지 검증한다.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ParsedItemPreviewCard from '../ParsedItemPreviewCard'
+import type { PreviewItem } from '../ParsedItemPreviewCard'
+
+const mockItem: PreviewItem = {
+  amount: 8000,
+  date: '2026-03-19',
+  description: '김치찌개',
+  category: '식비',
+  category_id: null,
+  memo: null,
+}
+
+const defaultProps = {
+  item: mockItem,
+  index: 0,
+  totalCount: 1,
+  categories: [],
+  onUpdate: vi.fn(),
+  onRemove: vi.fn(),
+  showNewCategoryFor: null,
+  newCategoryName: '',
+  creatingCategory: false,
+  onSetShowNewCategory: vi.fn(),
+  onSetNewCategoryName: vi.fn(),
+  onCreateCategory: vi.fn(),
+}
+
+describe('ParsedItemPreviewCard', () => {
+  describe('label prop 렌더링', () => {
+    it('지출 label을 표시한다', () => {
+      render(
+        <ParsedItemPreviewCard
+          {...defaultProps}
+          colorScheme="grape"
+          label="지출"
+        />
+      )
+      expect(screen.getByText('지출 #1')).toBeInTheDocument()
+    })
+
+    it('수입 label을 표시한다 (#148)', () => {
+      render(
+        <ParsedItemPreviewCard
+          {...defaultProps}
+          index={1}
+          totalCount={3}
+          colorScheme="leaf"
+          label="수입"
+        />
+      )
+      expect(screen.getByText('수입 #2')).toBeInTheDocument()
+    })
+
+    it('임의의 label과 index를 표시한다', () => {
+      render(
+        <ParsedItemPreviewCard
+          {...defaultProps}
+          index={2}
+          colorScheme="grape"
+          label="지출"
+        />
+      )
+      expect(screen.getByText('지출 #3')).toBeInTheDocument()
+    })
+  })
+
+  describe('항목 삭제 버튼', () => {
+    it('totalCount > 1이면 삭제 버튼이 표시된다', () => {
+      render(
+        <ParsedItemPreviewCard
+          {...defaultProps}
+          totalCount={2}
+          colorScheme="grape"
+          label="지출"
+        />
+      )
+      expect(screen.getByText('삭제')).toBeInTheDocument()
+    })
+
+    it('totalCount === 1이면 삭제 버튼이 없다', () => {
+      render(
+        <ParsedItemPreviewCard
+          {...defaultProps}
+          totalCount={1}
+          colorScheme="grape"
+          label="지출"
+        />
+      )
+      expect(screen.queryByText('삭제')).not.toBeInTheDocument()
+    })
+
+    it('삭제 버튼 클릭 시 onRemove(index)를 호출한다', () => {
+      const onRemove = vi.fn()
+      render(
+        <ParsedItemPreviewCard
+          {...defaultProps}
+          index={1}
+          totalCount={2}
+          colorScheme="grape"
+          label="지출"
+          onRemove={onRemove}
+        />
+      )
+      fireEvent.click(screen.getByText('삭제'))
+      expect(onRemove).toHaveBeenCalledWith(1)
+    })
+  })
+
+  describe('필드 업데이트', () => {
+    it('금액 입력 변경 시 onUpdate를 호출한다', () => {
+      const onUpdate = vi.fn()
+      render(
+        <ParsedItemPreviewCard
+          {...defaultProps}
+          colorScheme="grape"
+          label="지출"
+          onUpdate={onUpdate}
+        />
+      )
+      const amountInput = screen.getByDisplayValue('8000')
+      fireEvent.change(amountInput, { target: { value: '10000' } })
+      expect(onUpdate).toHaveBeenCalledWith(0, 'amount', 10000)
+    })
+
+    it('설명 입력 변경 시 onUpdate를 호출한다', () => {
+      const onUpdate = vi.fn()
+      render(
+        <ParsedItemPreviewCard
+          {...defaultProps}
+          colorScheme="grape"
+          label="지출"
+          onUpdate={onUpdate}
+        />
+      )
+      const descInput = screen.getByDisplayValue('김치찌개')
+      fireEvent.change(descInput, { target: { value: '스타벅스' } })
+      expect(onUpdate).toHaveBeenCalledWith(0, 'description', '스타벅스')
+    })
+  })
+})

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -169,7 +169,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => { active = false }
   }, [token, loadedToken])
 
-  // 주기적으로 토큰 만료 체크 (5분마다, podo-bookshelf 패턴)
+  // 주기적으로 토큰 만료 체크 (30초마다 — #153: 5분에서 축소, 만료 후 최대 30초 이내 감지)
   useEffect(() => {
     const checkToken = () => {
       const current = getCookieToken()
@@ -179,7 +179,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setToken(current)
       }
     }
-    const interval = setInterval(checkToken, 5 * 60 * 1000)
+    const interval = setInterval(checkToken, 30 * 1000)
     return () => clearInterval(interval)
   }, [token])
 

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @file AuthContext.test.tsx
+ * @description AuthContext 테스트 (#153)
+ *
+ * isTokenExpired 함수의 base64url 처리와
+ * 토큰 만료 체크 인터벌(30초)을 검증한다.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { AuthProvider, useAuth } from '../AuthContext'
+
+/** authApi 모킹 — AuthProvider 내부 getCurrentUser 호출 대응 */
+vi.mock('../../api/auth', () => ({
+  default: {
+    getCurrentUser: vi.fn().mockResolvedValue({ data: { id: 1, username: 'testuser', email: null, is_active: true } }),
+    logout: vi.fn(),
+  },
+}))
+
+/** JWT 토큰 생성 헬퍼 (base64url 인코딩, Unicode 안전) */
+function makeJwt(payload: Record<string, unknown>): string {
+  // TextEncoder를 사용해 한국어 등 유니코드 문자를 UTF-8 바이트로 안전하게 인코딩 (#153)
+  const encodeBase64Url = (obj: Record<string, unknown>) => {
+    const json = JSON.stringify(obj)
+    const bytes = new TextEncoder().encode(json)
+    let binary = ''
+    bytes.forEach((b) => { binary += String.fromCharCode(b) })
+    return btoa(binary)
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '')
+  }
+  const header = encodeBase64Url({ alg: 'HS256', typ: 'JWT' })
+  const body = encodeBase64Url(payload)
+  return `${header}.${body}.fake-signature`
+}
+
+/** AuthContext를 소비하는 테스트용 컴포넌트 */
+function TestConsumer() {
+  const { isAuthenticated } = useAuth()
+  return <div data-testid="auth-status">{isAuthenticated ? 'authenticated' : 'unauthenticated'}</div>
+}
+
+describe('AuthContext', () => {
+  beforeEach(() => {
+    document.cookie = 'podo_access_token=; Max-Age=0; Path=/'
+    try { localStorage.removeItem('podo_access_token') } catch { /* 무시 */ }
+  })
+
+  afterEach(() => {
+    document.cookie = 'podo_access_token=; Max-Age=0; Path=/'
+    try { localStorage.removeItem('podo_access_token') } catch { /* 무시 */ }
+  })
+
+  describe('isTokenExpired — base64url 디코딩 (#153)', () => {
+    it('미래 exp를 가진 base64url JWT를 유효한 토큰으로 인식한다', () => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600
+      const token = makeJwt({ sub: '1', exp: futureExp, username: 'testuser' })
+      document.cookie = `podo_access_token=${token}; Path=/`
+
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>
+      )
+
+      expect(screen.getByTestId('auth-status')).toHaveTextContent('authenticated')
+    })
+
+    it('만료된 exp를 가진 토큰은 미인증으로 처리한다', () => {
+      const pastExp = Math.floor(Date.now() / 1000) - 1
+      const token = makeJwt({ sub: '1', exp: pastExp })
+      document.cookie = `podo_access_token=${token}; Path=/`
+
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>
+      )
+
+      expect(screen.getByTestId('auth-status')).toHaveTextContent('unauthenticated')
+    })
+
+    /**
+     * 핵심 버그 재현 (#153): 한국어 username이 포함된 JWT
+     * atob()만 사용하면 base64url 패딩 없이 디코딩 실패 → 예외 → 유효 토큰을 만료로 오인
+     * 수정 후: base64url → base64 변환 후 디코딩 → 정상 처리
+     */
+    it('한국어 username이 포함된 base64url JWT를 유효한 토큰으로 인식한다 (#153)', () => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600
+      const token = makeJwt({ sub: '1', exp: futureExp, username: '홍길동' })
+      document.cookie = `podo_access_token=${token}; Path=/`
+
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>
+      )
+
+      // 한국어 username이 있어도 base64url 처리 후 유효한 토큰으로 인식해야 함
+      expect(screen.getByTestId('auth-status')).toHaveTextContent('authenticated')
+    })
+
+    it('손상된 토큰은 미인증으로 처리한다', () => {
+      document.cookie = 'podo_access_token=not.a.valid.jwt; Path=/'
+
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>
+      )
+
+      expect(screen.getByTestId('auth-status')).toHaveTextContent('unauthenticated')
+    })
+  })
+
+  describe('토큰 만료 체크 인터벌 (#153)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    /**
+     * 30초 인터벌 검증: 쿠키가 제거된 상태에서 30초 후 미인증으로 전환
+     * 5분 인터벌이면 30초에는 체크가 발생하지 않아 인증 상태가 유지됨
+     */
+    it('쿠키 제거 후 30초 이내에 미인증으로 전환된다 (#153)', async () => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600
+      const token = makeJwt({ sub: '1', exp: futureExp })
+      document.cookie = `podo_access_token=${token}; Path=/`
+
+      render(
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>
+      )
+
+      // 초기: 인증 상태
+      expect(screen.getByTestId('auth-status')).toHaveTextContent('authenticated')
+
+      // 쿠키 제거 (만료 시뮬레이션)
+      document.cookie = 'podo_access_token=; Max-Age=0; Path=/'
+
+      // 30초 인터벌 시뮬레이션
+      await act(async () => {
+        vi.advanceTimersByTime(30_000)
+      })
+
+      // 30초 후: 미인증 상태
+      expect(screen.getByTestId('auth-status')).toHaveTextContent('unauthenticated')
+    })
+  })
+})

--- a/frontend/src/pages/ExpenseForm.tsx
+++ b/frontend/src/pages/ExpenseForm.tsx
@@ -462,8 +462,8 @@ export default function ExpenseForm() {
               index={index}
               totalCount={previewItems.length}
               categories={categories}
-              colorScheme="grape"
-              label="지출"
+              colorScheme={item.type === 'income' ? 'leaf' : 'grape'}
+              label={item.type === 'income' ? '수입' : '지출'}
               onUpdate={updatePreviewItem}
               onRemove={removePreviewItem}
               showNewCategoryFor={showNewCategoryFor}
@@ -510,8 +510,8 @@ export default function ExpenseForm() {
               index={index}
               totalCount={previewItems.length}
               categories={categories}
-              colorScheme="grape"
-              label="지출"
+              colorScheme={item.type === 'income' ? 'leaf' : 'grape'}
+              label={item.type === 'income' ? '수입' : '지출'}
               onUpdate={updatePreviewItem}
               onRemove={removePreviewItem}
               showNewCategoryFor={showNewCategoryFor}

--- a/frontend/src/pages/__tests__/ExpenseForm.test.tsx
+++ b/frontend/src/pages/__tests__/ExpenseForm.test.tsx
@@ -434,5 +434,151 @@ describe('ExpenseForm', () => {
         expect(mockAddToast).toHaveBeenCalledWith('error', expect.any(String))
       })
     })
+
+    /**
+     * #148: LLM이 type:'income' 항목 반환 시 프리뷰 카드 레이블이 "수입"으로 표시되어야 한다
+     * 기존 버그: label="지출" 하드코딩으로 수입 항목도 "지출 #N"으로 표시
+     */
+    it('income 타입 항목은 "수입" 레이블로 표시한다 (#148)', async () => {
+      server.use(
+        http.post('/api/chat', () => {
+          return HttpResponse.json({
+            message: '파싱 완료',
+            parsed_expenses: [
+              {
+                amount: 3500000,
+                description: '월급',
+                category: '급여',
+                date: '2026-03-19',
+                memo: '',
+                type: 'income',
+              },
+            ],
+            parsed_items: null,
+            expenses_created: null,
+            incomes_created: null,
+            insights: null,
+          })
+        })
+      )
+
+      const user = userEvent.setup()
+      renderExpenseForm()
+
+      const textarea = screen.getByPlaceholderText(/오늘 점심/)
+      await user.type(textarea, '월급 350만원')
+      await user.click(screen.getByText('분석하기'))
+
+      await waitFor(() => {
+        // income 타입은 "수입 #1"로 표시되어야 함 (하드코딩 "지출 #1"이면 실패)
+        expect(screen.getByText('수입 #1')).toBeInTheDocument()
+      })
+    })
+
+    /**
+     * #148: LLM이 type:'expense' 항목 반환 시 프리뷰 카드 레이블이 "지출"로 표시되어야 한다
+     */
+    it('expense 타입 항목은 "지출" 레이블로 표시한다 (#148)', async () => {
+      server.use(
+        http.post('/api/chat', () => {
+          return HttpResponse.json({
+            message: '파싱 완료',
+            parsed_expenses: [
+              {
+                amount: 8000,
+                description: '점심',
+                category: '식비',
+                date: '2026-03-19',
+                memo: '',
+                type: 'expense',
+              },
+            ],
+            parsed_items: null,
+            expenses_created: null,
+            incomes_created: null,
+            insights: null,
+          })
+        })
+      )
+
+      const user = userEvent.setup()
+      renderExpenseForm()
+
+      const textarea = screen.getByPlaceholderText(/오늘 점심/)
+      await user.type(textarea, '점심 8000원')
+      await user.click(screen.getByText('분석하기'))
+
+      await waitFor(() => {
+        expect(screen.getByText('지출 #1')).toBeInTheDocument()
+      })
+    })
+
+    /**
+     * #148: income 항목은 incomeApi로, expense 항목은 expenseApi로 저장된다
+     * 기존 버그: 모든 항목을 expenseApi로 저장
+     */
+    it('income 항목은 incomeApi.create로 저장된다 (#148)', async () => {
+      let incomeApiCalled = false
+      let expenseApiCalled = false
+
+      server.use(
+        http.post('/api/chat', () => {
+          return HttpResponse.json({
+            message: '파싱 완료',
+            parsed_expenses: [
+              {
+                amount: 3500000,
+                description: '월급',
+                category: '급여',
+                date: '2026-03-19',
+                memo: '',
+                type: 'income',
+              },
+            ],
+            parsed_items: null,
+            expenses_created: null,
+            incomes_created: null,
+            insights: null,
+          })
+        }),
+        http.post('/api/income', async () => {
+          incomeApiCalled = true
+          return HttpResponse.json(
+            {
+              id: 1, amount: 3500000, description: '월급',
+              category_id: null, household_id: null, user_id: null,
+              raw_input: null, memo: null,
+              date: '2026-03-19T00:00:00',
+              created_at: '2026-03-19T00:00:00',
+              updated_at: '2026-03-19T00:00:00',
+            },
+            { status: 201 }
+          )
+        }),
+        http.post('/api/expenses', async () => {
+          expenseApiCalled = true
+          return HttpResponse.json({}, { status: 201 })
+        })
+      )
+
+      const user = userEvent.setup()
+      renderExpenseForm()
+
+      const textarea = screen.getByPlaceholderText(/오늘 점심/)
+      await user.type(textarea, '월급 350만원')
+      await user.click(screen.getByText('분석하기'))
+
+      await waitFor(() => {
+        expect(screen.getByText(/1건 저장하기/)).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText(/1건 저장하기/))
+
+      await waitFor(() => {
+        // income 타입은 incomeApi로 저장되어야 함
+        expect(incomeApiCalled).toBe(true)
+        expect(expenseApiCalled).toBe(false)
+      })
+    })
   })
 })


### PR DESCRIPTION
## 변경 사항

### #148 — ExpenseForm 수입/지출 type 기반 프리뷰 레이블 분기
- `ParsedItemPreviewCard`에 전달하는 `label`, `colorScheme`을 `item.type`에 따라 동적 결정
  - `type === 'income'` → `label="수입"`, `colorScheme="leaf"`
  - 그 외 → `label="지출"`, `colorScheme="grape"`
- 자연어 입력 모드 + OCR 모드 프리뷰 카드 모두 적용
- `handleConfirmSave`에서 `item.type === 'income'` 분기는 이미 develop에 있었음

### #149 — TransactionList `activeHouseholdId` null 가드
- develop에 이미 `if (!activeHouseholdId) return` 포함 — 추가 작업 불필요

### #150 — `updateMemberRole` PUT → PATCH
- develop에 이미 `apiClient.patch` 사용 — 추가 작업 불필요

### #153 — JWT base64url 디코딩 + 토큰 만료 인터벌 축소
- `isTokenExpired` base64url 처리(`-`→`+`, `_`→`/`, 패딩)는 develop에 이미 구현됨
- 토큰 만료 체크 인터벌: **5분 → 30초** 축소
  - 만료 후 최대 30초 이내 미인증 상태 전환

## 테스트

- `ParsedItemPreviewCard.test.tsx` — label prop 렌더링 검증 (8개 테스트)
- `ExpenseForm.test.tsx` — income 타입 레이블/저장 분기 검증 추가 (3개 테스트)
- `AuthContext.test.tsx` — base64url 처리, 30초 인터벌 검증 (5개 테스트)

```
Tests: 566 passed (61 files)
```

## 관련 이슈
Closes #148
Closes #149
Closes #150
Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)