### PR TITLE
perf: TransactionItem 카테고리 O(1) Map 조회 최적화 (#180)

### DIFF
--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -13,7 +13,8 @@ interface TransactionItemProps {
   description: string
   amount: number
   categoryId: number | null
-  categories: Category[]
+  /** O(1) 카테고리 조회를 위해 Map으로 전달 (#180) */
+  categoryMap: Map<number, Category>
   excludeFromStats?: boolean
   rawInput?: string | null
   onCategoryClick: (e: React.MouseEvent) => void
@@ -25,12 +26,13 @@ export default function TransactionItem({
   description,
   amount,
   categoryId,
-  categories,
+  categoryMap,
   excludeFromStats,
   rawInput,
   onCategoryClick,
 }: TransactionItemProps) {
-  const category = categoryId != null ? categories.find(c => c.id === categoryId) : null
+  // O(1) 조회 — 이전 O(n) find 대비 300건×20카테고리=6,000비교 → 300번 해시 조회 (#180)
+  const category = categoryId != null ? categoryMap.get(categoryId) : null
   const detailPath = type === 'expense' ? `/expenses/${id}` : `/income/${id}`
   const isRecurring = rawInput?.startsWith('[정기]')
 

--- a/frontend/src/components/__tests__/TransactionItem.test.tsx
+++ b/frontend/src/components/__tests__/TransactionItem.test.tsx
@@ -10,6 +10,9 @@ import { MemoryRouter } from 'react-router-dom'
 import TransactionItem from '../TransactionItem'
 import { mockCategories } from '../../mocks/fixtures'
 
+// O(1) 조회용 Map (#180)
+const mockCategoryMap = new Map(mockCategories.map(c => [c.id, c]))
+
 function renderItem(props: Partial<React.ComponentProps<typeof TransactionItem>> = {}) {
   const defaultProps = {
     id: 1,
@@ -17,7 +20,7 @@ function renderItem(props: Partial<React.ComponentProps<typeof TransactionItem>>
     description: '김치찌개',
     amount: 8000,
     categoryId: 1,
-    categories: mockCategories,
+    categoryMap: mockCategoryMap,
     onCategoryClick: vi.fn(),
     ...props,
   }

--- a/frontend/src/pages/TransactionList.tsx
+++ b/frontend/src/pages/TransactionList.tsx
@@ -137,6 +137,9 @@ export default function TransactionList() {
 
   useEffect(() => { fetchData() }, [fetchData])
 
+  // 카테고리 O(1) 조회용 Map — TransactionItem에 배열 대신 전달 (#180)
+  const categoryMap = useMemo(() => new Map(categories.map(c => [c.id, c])), [categories])
+
   // 통합 + 정렬 + 그룹핑
   const { grouped, totalExpense, totalIncome, daySummaries } = useMemo(() => {
     const all: UnifiedTransaction[] = [
@@ -348,7 +351,7 @@ export default function TransactionList() {
                     description={tx.description}
                     amount={tx.amount}
                     categoryId={tx.category_id}
-                    categories={categories}
+                    categoryMap={categoryMap}
                     excludeFromStats={tx.exclude_from_stats}
                     rawInput={tx.raw_input}
                     onCategoryClick={() => {


### PR DESCRIPTION
## 변경 사항

### #180 — TransactionItem 카테고리 O(n) → O(1) Map 최적화

**문제:** `categories.find()` O(n) 탐색 반복 — 300건 × 20카테고리 = 6,000번 비교

**수정:**
- `TransactionItem` props: `categories: Category[]` → `categoryMap: Map<number, Category>`
- `TransactionList`: `useMemo(() => new Map(categories.map(c => [c.id, c])), [categories])` 생성
- 카테고리 조회: `categories.find()` → `categoryMap.get()` (O(1) 해시 조회)

**성능:** Map은 한 번만 생성(useMemo), categories 변경 시에만 재생성

## 이미 수정된 이슈 (develop 반영 확인 후 닫음)
- #155: Sentry webhook sha256 prefix 파싱 + console.warn DEV guard ✓
- #156: ThemeContext FOUC 방지 + budget.py date 타입 통일 ✓
- #160: format.ts Math.floor + healthScore.ts 0 처리 + Toast.tsx stale closure ✓
- #184: Pydantic v2 model_config 전환 ✓
- #185: APP_NAME = "포도가계부" ✓
- #188: useToast addToast 통일 ✓
- #206: pyproject.toml name = "podo-budget" ✓

## 테스트
```
Tests: 550 passed (59 files)
```

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)