### PR TITLE
feat: FE 렌더링 최적화 + 상태관리 개선 (#240, #245)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,10 +10,8 @@
       "dependencies": {
         "@sentry/react": "^9.0.0",
         "axios": "^1.13.5",
-        "chart.js": "^4.5.1",
         "lucide-react": "^0.564.0",
         "react": "^19.2.0",
-        "react-chartjs-2": "^5.3.1",
         "react-dom": "^19.2.0",
         "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.13.0",
@@ -2641,12 +2639,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
-    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.2",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.2.tgz",
@@ -4763,18 +4755,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
       }
     },
     "node_modules/cli-width": {
@@ -8254,16 +8234,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-chartjs-2": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
-      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "chart.js": "^4.1.1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,10 +16,8 @@
   "dependencies": {
     "@sentry/react": "^9.0.0",
     "axios": "^1.13.5",
-    "chart.js": "^4.5.1",
     "lucide-react": "^0.564.0",
     "react": "^19.2.0",
-    "react-chartjs-2": "^5.3.1",
     "react-dom": "^19.2.0",
     "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.13.0",

--- a/frontend/src/components/MiniCalendar.tsx
+++ b/frontend/src/components/MiniCalendar.tsx
@@ -3,7 +3,7 @@
  * @description 미니 캘린더 — 날짜별 지출/수입 금액 표시, 날짜 탭 시 콜백
  */
 
-import { useMemo } from 'react'
+import { memo, useMemo } from 'react'
 import { getCalendarGrid } from '../utils/calendar'
 import { formatCompactAmount } from '../utils/format'
 
@@ -22,7 +22,7 @@ interface MiniCalendarProps {
 
 const WEEKDAY_LABELS = ['일', '월', '화', '수', '목', '금', '토']
 
-export default function MiniCalendar({
+function MiniCalendar({
   year,
   month,
   daySummaries,
@@ -95,3 +95,6 @@ export default function MiniCalendar({
     </div>
   )
 }
+
+// React.memo로 year/month/daySummaries/today 변경 시에만 리렌더 (#240)
+export default memo(MiniCalendar)

--- a/frontend/src/components/TransactionItem.tsx
+++ b/frontend/src/components/TransactionItem.tsx
@@ -3,6 +3,7 @@
  * @description 2줄 구조 거래 항목 — 설명+금액 / 카테고리뱃지
  */
 
+import { memo } from 'react'
 import { Link } from 'react-router-dom'
 import { formatAmount } from '../utils/format'
 import type { Category } from '../types'
@@ -17,10 +18,11 @@ interface TransactionItemProps {
   categoryMap: Map<number, Category>
   excludeFromStats?: boolean
   rawInput?: string | null
-  onCategoryClick: (e: React.MouseEvent) => void
+  /** 안정적 콜백 — TransactionList에서 useMemo로 생성된 핸들러 전달 (#240) */
+  onCategoryClick: () => void
 }
 
-export default function TransactionItem({
+function TransactionItem({
   id,
   type,
   description,
@@ -60,7 +62,7 @@ export default function TransactionItem({
           onClick={(e) => {
             e.preventDefault()
             e.stopPropagation()
-            onCategoryClick(e)
+            onCategoryClick()
           }}
           className={`text-xs px-2 py-0.5 rounded-full transition-colors ${
             type === 'income'
@@ -80,3 +82,6 @@ export default function TransactionItem({
     </Link>
   )
 }
+
+// React.memo로 불필요한 리렌더 방지 — onCategoryClick은 TransactionList에서 useMemo로 안정화 (#240)
+export default memo(TransactionItem)

--- a/frontend/src/pages/AssetDashboard.tsx
+++ b/frontend/src/pages/AssetDashboard.tsx
@@ -7,17 +7,14 @@ import {
   ChevronRight, ChevronDown, ChevronUp, Target, Bell, Building2, X,
 } from 'lucide-react'
 import {
-  Chart as ChartJS, LineElement, PointElement, CategoryScale,
-  LinearScale, Filler, Tooltip as ChartTooltip, Legend,
-} from 'chart.js'
-import { Line } from 'react-chartjs-2'
+  LineChart, Line, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer,
+} from 'recharts'
 import { assetApi } from '../api/assets'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import LoadingSpinner from '../components/LoadingSpinner'
 import type { Asset, AssetSummary, AssetSnapshot, AssetGoal, MonthlySavings } from '../types'
 import { formatAmount } from '../utils/format'
 
-ChartJS.register(LineElement, PointElement, CategoryScale, LinearScale, Filler, ChartTooltip, Legend)
 
 function formatPct(pct: number | null): string {
   if (pct == null) return ''
@@ -192,30 +189,12 @@ export default function AssetDashboard() {
   const prevMonthNW = snapshots.length >= 2 ? snapshots[snapshots.length - 2].net_worth : null
   const prevMonthDiff = prevMonthNW != null ? netWorth - prevMonthNW : null
 
-  /* 순자산 추이 라인차트 */
-  const lineLabels = snapshots.map(s => s.snapshot_date.slice(0, 7))
-  const lineDatasets = [
-    {
-      label: '순자산',
-      data: snapshots.map(s => s.net_worth),
-      borderColor: '#9333EA',
-      backgroundColor: 'rgba(147,51,234,0.08)',
-      fill: true,
-      tension: 0.3,
-      pointRadius: 4,
-    },
-    // 목표 기준선
-    ...(goal ? [{
-      label: '목표',
-      data: snapshots.map(() => goal.target_net_worth),
-      borderColor: '#D1D5DB',
-      borderDash: [5, 5],
-      fill: false,
-      tension: 0,
-      pointRadius: 0,
-    }] : []),
-  ]
-  const lineData = { labels: lineLabels, datasets: lineDatasets }
+  /* 순자산 추이 recharts 데이터 (#240) */
+  const chartData = snapshots.map(s => ({
+    month: s.snapshot_date.slice(0, 7),
+    순자산: s.net_worth,
+    ...(goal ? { 목표: goal.target_net_worth } : {}),
+  }))
 
   /* 유형별 그룹 구성 */
   const groupedAssets = TYPE_GROUPS.map(group => {
@@ -338,22 +317,42 @@ export default function AssetDashboard() {
         </button>
       )}
 
-      {/* 3. 순자산 추이 차트 */}
+      {/* 3. 순자산 추이 차트 (#240: chart.js → recharts) */}
       {snapshots.length > 1 && (
         <div className="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)]/60 shadow-sm p-5">
           <h2 className="text-sm font-semibold text-[var(--text-secondary)] mb-4">순자산 추이</h2>
           <div className="h-56">
-            <Line
-              data={lineData}
-              options={{
-                responsive: true,
-                maintainAspectRatio: false,
-                plugins: { legend: { display: !!goal } },
-                scales: {
-                  y: { ticks: { callback: (v) => `₩${Number(v).toLocaleString()}` } },
-                },
-              }}
-            />
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+                <XAxis dataKey="month" tick={{ fontSize: 10 }} />
+                <YAxis
+                  tickFormatter={(v) => `₩${Number(v).toLocaleString()}`}
+                  tick={{ fontSize: 9 }}
+                  width={72}
+                />
+                <Tooltip formatter={(v) => `₩${Number(v).toLocaleString()}`} />
+                {goal && <Legend />}
+                <Line
+                  type="monotone"
+                  dataKey="순자산"
+                  stroke="#9333EA"
+                  strokeWidth={2}
+                  dot={{ r: 4, fill: '#9333EA' }}
+                  activeDot={{ r: 5 }}
+                />
+                {goal && (
+                  <Line
+                    type="monotone"
+                    dataKey="목표"
+                    stroke="#D1D5DB"
+                    strokeWidth={1.5}
+                    strokeDasharray="5 5"
+                    dot={false}
+                    activeDot={false}
+                  />
+                )}
+              </LineChart>
+            </ResponsiveContainer>
           </div>
         </div>
       )}

--- a/frontend/src/pages/TransactionList.tsx
+++ b/frontend/src/pages/TransactionList.tsx
@@ -186,6 +186,20 @@ export default function TransactionList() {
     return { grouped, totalExpense, totalIncome, daySummaries }
   }, [expenses, incomes, filter])
 
+  // TransactionItem.onCategoryClick 안정화 — 데이터 변경 시에만 재생성 (#240)
+  const categoryClickHandlers = useMemo(() => {
+    const handlers = new Map<string, () => void>()
+    for (const txs of grouped.values()) {
+      for (const tx of txs) {
+        handlers.set(`${tx.type}-${tx.id}`, () => {
+          setSheetTarget(tx)
+          setSheetOpen(true)
+        })
+      }
+    }
+    return handlers
+  }, [grouped])
+
   // 캘린더 날짜 클릭 → 스크롤
   const handleDateClick = useCallback((dateString: string) => {
     const ref = dateRefs.current.get(dateString)
@@ -354,10 +368,7 @@ export default function TransactionList() {
                     categoryMap={categoryMap}
                     excludeFromStats={tx.exclude_from_stats}
                     rawInput={tx.raw_input}
-                    onCategoryClick={() => {
-                      setSheetTarget(tx)
-                      setSheetOpen(true)
-                    }}
+                    onCategoryClick={categoryClickHandlers.get(`${tx.type}-${tx.id}`)!}
                   />
                 ))}
               </div>

--- a/frontend/src/stores/useHouseholdStore.ts
+++ b/frontend/src/stores/useHouseholdStore.ts
@@ -5,6 +5,7 @@
  */
 
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 import type {
   Household,
   HouseholdDetail,
@@ -105,7 +106,10 @@ let _initializeAppPromise: Promise<void> | null = null
 /**
  * Household 관리를 위한 Zustand 스토어
  */
-export const useHouseholdStore = create<HouseholdStore>((set, get) => ({
+export const useHouseholdStore = create<HouseholdStore>()(
+  // activeHouseholdId를 localStorage에 유지 — 새로고침 후에도 선택된 가구 복원 (#245)
+  persist(
+    (set, get) => ({
   // ============================================================
   // 초기 상태
   // ============================================================
@@ -441,4 +445,10 @@ export const useHouseholdStore = create<HouseholdStore>((set, get) => ({
     if (id === null) return
     set({ activeHouseholdId: id })
   },
-}))
+    }),
+    {
+      name: 'podo-household',   // localStorage 키
+      partialize: (state) => ({ activeHouseholdId: state.activeHouseholdId }),
+    }
+  )
+)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -174,6 +174,12 @@ export interface ParsedExpenseItem {
   date: string
   memo: string
   type: string
+  /** 원본 통화 코드 (예: USD, JPY) — 해외 지출 지원 (#245) */
+  currency?: string | null
+  /** 원본 통화 금액 */
+  original_amount?: number | null
+  /** 환율 (원본 통화 → KRW) */
+  exchange_rate?: number | null
 }
 
 export interface ChatResponse {


### PR DESCRIPTION
## 변경 내용

### #240 FE 렌더링 최적화
- **AssetDashboard**: `chart.js`/`react-chartjs-2` 제거 → `recharts` `LineChart`로 교체 (bundle 경량화, 의존성 단일화)
- **TransactionItem**: `React.memo` 적용, `onCategoryClick: () => void`으로 시그니처 정리
- **TransactionList**: `useMemo` 기반 `categoryClickHandlers` Map 구성 — 데이터 변경 시에만 핸들러 재생성, 불필요한 TransactionItem 리렌더 방지
- **MiniCalendar**: `React.memo` 적용

### #245 상태관리 개선
- **useHouseholdStore**: `persist` 미들웨어로 `activeHouseholdId` localStorage 유지 — 새로고침 후에도 선택된 가구 복원
- **ParsedExpenseItem**: `currency`, `original_amount`, `exchange_rate` 필드 추가 (해외 지출 파싱 지원)

## 테스트
- `npm run lint` — 0 errors (기존 warning 유지)
- `npm run test:run` — 61 files, 566 tests passed
- `npm run build` — 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)