### PR TITLE
test: 미테스트 API/서비스 통합·단위 테스트 추가 (#246, #247, #248)

### DIFF
--- a/backend/tests/integration/test_api_admin.py
+++ b/backend/tests/integration/test_api_admin.py
@@ -1,0 +1,196 @@
+"""Admin API 통합 테스트
+
+- GET /api/admin/stats/dashboard — 대시보드 (관리자 전용)
+- GET /api/admin/users — 사용자 목록
+- GET /api/admin/users/{id} — 사용자 상세
+- PATCH /api/admin/users/{id} — 사용자 수정 (활성/비활성)
+
+보안 검증:
+- 비관리자 접근 시 403 반환
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core.config import settings
+from app.models.household import Household
+from app.models.household_member import HouseholdMember
+from app.models.user import User
+
+# ──────────────────────────────────────────────
+# 관리자 클라이언트 fixture
+# ──────────────────────────────────────────────
+
+
+@pytest.fixture
+async def admin_user(db_session):
+    """ADMIN_USER_ID로 등록된 관리자 사용자"""
+    user = User(
+        auth_user_id=7000000000001,
+        username="admin_user",
+        email="admin@example.com",
+        hashed_password=None,
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    # 가구 필요 (관리자도 가구 소속 필요)
+    household = Household(name="관리자 가구")
+    db_session.add(household)
+    await db_session.flush()
+
+    member = HouseholdMember(household_id=household.id, user_id=user.id, role="owner")
+    db_session.add(member)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+async def admin_client(db_session, admin_user):
+    """관리자 JWT 인증 클라이언트"""
+
+    from httpx import ASGITransport, AsyncClient
+
+    from app.core.database import get_db
+    from app.main import app
+    from tests.conftest import _db_override, create_test_token
+
+    token = create_test_token(
+        auth_user_id=admin_user.auth_user_id,
+        email=admin_user.email,
+        name=admin_user.username,
+    )
+
+    app.dependency_overrides[get_db] = _db_override(db_session)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            headers={"Authorization": f"Bearer {token}"},
+        ) as ac:
+            # ADMIN_USER_ID를 admin_user.id로 오버라이드
+            with patch.object(settings, "ADMIN_USER_ID", admin_user.id):
+                yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ──────────────────────────────────────────────
+# 권한 거부 테스트 (일반 사용자)
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dashboard_stats_non_admin(authenticated_client):
+    """비관리자 접근 → 403"""
+    response = await authenticated_client.get("/api/admin/stats/dashboard")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_user_list_non_admin(authenticated_client):
+    """비관리자 사용자 목록 접근 → 403"""
+    response = await authenticated_client.get("/api/admin/users")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_user_detail_non_admin(authenticated_client, test_user: User):
+    """비관리자 사용자 상세 접근 → 403"""
+    response = await authenticated_client.get(f"/api/admin/users/{test_user.id}")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_admin(client):
+    """미인증 관리자 접근 → 401"""
+    response = await client.get("/api/admin/stats/dashboard")
+    assert response.status_code == 401
+
+
+# ──────────────────────────────────────────────
+# 관리자 접근 성공 테스트
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dashboard_stats_admin(admin_client):
+    """관리자 대시보드 조회 성공"""
+    response = await admin_client.get("/api/admin/stats/dashboard")
+    assert response.status_code == 200
+
+    data = response.json()
+    # DashboardStatsResponse 필드 확인
+    assert "total_users" in data
+    assert "active_users" in data
+    assert isinstance(data["total_users"], int)
+
+
+@pytest.mark.asyncio
+async def test_user_list_admin(admin_client, test_user: User):
+    """관리자 사용자 목록 조회"""
+    response = await admin_client.get("/api/admin/users")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "users" in data
+    assert "total" in data
+    assert isinstance(data["users"], list)
+
+
+@pytest.mark.asyncio
+async def test_user_list_pagination(admin_client):
+    """사용자 목록 페이지네이션"""
+    response = await admin_client.get("/api/admin/users?page=1&page_size=10")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_user_detail_admin(admin_client, test_user: User):
+    """관리자 사용자 상세 조회"""
+    response = await admin_client.get(f"/api/admin/users/{test_user.id}")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["id"] == test_user.id
+    assert data["email"] == test_user.email
+
+
+@pytest.mark.asyncio
+async def test_user_detail_not_found(admin_client):
+    """존재하지 않는 사용자 → 404"""
+    response = await admin_client.get("/api/admin/users/99999")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_user_deactivate(admin_client, test_user: User):
+    """사용자 비활성화"""
+    response = await admin_client.patch(
+        f"/api/admin/users/{test_user.id}",
+        json={"is_active": False},
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["is_active"] is False
+
+
+@pytest.mark.asyncio
+async def test_update_user_not_found(admin_client):
+    """존재하지 않는 사용자 수정 → 404"""
+    response = await admin_client.patch("/api/admin/users/99999", json={"is_active": True})
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_user_list_search(admin_client, test_user: User):
+    """사용자 목록 검색 필터"""
+    response = await admin_client.get(f"/api/admin/users?search={test_user.username}")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert isinstance(data["users"], list)

--- a/backend/tests/integration/test_api_assets.py
+++ b/backend/tests/integration/test_api_assets.py
@@ -1,0 +1,324 @@
+"""자산 API 통합 테스트
+
+- POST /api/assets — 자산 생성
+- GET /api/assets — 자산 목록 (시세 포함)
+- GET /api/assets/summary — 순자산 요약
+- GET /api/assets/{id} — 자산 상세
+- PUT /api/assets/{id} — 자산 수정
+- DELETE /api/assets/{id} — 자산 삭제
+- GET /api/assets/goal — 목표 조회 (없을 때 null)
+"""
+
+import pytest
+
+from app.models.asset import Asset
+from app.models.household import Household
+from app.models.user import User
+
+# ──────────────────────────────────────────────
+# POST /api/assets — 자산 생성
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_asset_deposit(authenticated_client, test_user: User, test_household: Household, db_session):
+    """예금 자산 생성 성공"""
+    payload = {
+        "name": "카카오뱅크 통장",
+        "type": "deposit",
+        "is_liability": False,
+        "manual_value": 5000000.0,
+        "household_id": test_household.id,
+    }
+    response = await authenticated_client.post("/api/assets", json=payload)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["name"] == "카카오뱅크 통장"
+    assert data["type"] == "deposit"
+    assert data["manual_value"] == 5000000.0
+    assert data["is_liability"] is False
+    assert "id" in data
+
+
+@pytest.mark.asyncio
+async def test_create_asset_loan(authenticated_client, test_user: User, test_household: Household, db_session):
+    """대출(부채) 자산 생성"""
+    payload = {
+        "name": "전세 대출",
+        "type": "loan",
+        "is_liability": True,
+        "manual_value": 100000000.0,
+        "household_id": test_household.id,
+    }
+    response = await authenticated_client.post("/api/assets", json=payload)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["is_liability"] is True
+    assert data["type"] == "loan"
+
+
+@pytest.mark.asyncio
+async def test_create_asset_invalid_type(authenticated_client, test_household: Household):
+    """유효하지 않은 type → 422"""
+    payload = {
+        "name": "잘못된 자산",
+        "type": "invalid_type",
+        "household_id": test_household.id,
+    }
+    response = await authenticated_client.post("/api/assets", json=payload)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_asset_unauthenticated(client):
+    """미인증 요청 → 401"""
+    payload = {"name": "통장", "type": "deposit"}
+    response = await client.post("/api/assets", json=payload)
+    assert response.status_code == 401
+
+
+# ──────────────────────────────────────────────
+# GET /api/assets — 자산 목록
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_assets_empty(authenticated_client, test_user: User, db_session):
+    """자산 없을 때 빈 목록"""
+    response = await authenticated_client.get("/api/assets")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_get_assets_list(authenticated_client, test_user: User, test_household: Household, db_session):
+    """자산 목록 조회"""
+    asset1 = Asset(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="신한 통장",
+        type="deposit",
+        is_liability=False,
+        manual_value=1000000,
+    )
+    asset2 = Asset(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="주택담보대출",
+        type="loan",
+        is_liability=True,
+        manual_value=50000000,
+    )
+    db_session.add_all([asset1, asset2])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/assets")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 2
+
+
+# ──────────────────────────────────────────────
+# GET /api/assets/summary — 순자산 요약
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_asset_summary_empty(authenticated_client, test_user: User, db_session):
+    """자산 없을 때 순자산 요약 — 모두 0"""
+    response = await authenticated_client.get("/api/assets/summary")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total_assets"] == 0.0
+    assert data["total_liabilities"] == 0.0
+    assert data["net_worth"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_asset_summary_with_data(authenticated_client, test_user: User, test_household: Household, db_session):
+    """자산+부채 존재 시 순자산 계산"""
+    asset = Asset(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="예금",
+        type="deposit",
+        is_liability=False,
+        manual_value=10000000,
+    )
+    liability = Asset(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="대출",
+        type="loan",
+        is_liability=True,
+        manual_value=3000000,
+    )
+    db_session.add_all([asset, liability])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/assets/summary")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total_assets"] == 10000000.0
+    assert data["total_liabilities"] == 3000000.0
+    assert data["net_worth"] == 7000000.0
+
+
+# ──────────────────────────────────────────────
+# GET /api/assets/{id} — 자산 상세 & IDOR 방지
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_asset_detail(authenticated_client, test_user: User, test_household: Household, db_session):
+    """자산 상세 조회"""
+    asset = Asset(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="부동산",
+        type="real_estate",
+        is_liability=False,
+        manual_value=300000000,
+    )
+    db_session.add(asset)
+    await db_session.commit()
+    await db_session.refresh(asset)
+
+    response = await authenticated_client.get(f"/api/assets/{asset.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "부동산"
+
+
+@pytest.mark.asyncio
+async def test_get_asset_idor(
+    authenticated_client,
+    authenticated_client2,
+    test_user: User,
+    test_user2: User,
+    test_household: Household,
+    test_household2: Household,
+    db_session,
+):
+    """다른 가구 자산 접근 시 404 (IDOR 방지)"""
+    # test_user2의 가구에 자산 생성
+    other_asset = Asset(
+        household_id=test_household2.id,
+        created_by=test_user2.id,
+        name="타인 자산",
+        type="deposit",
+        is_liability=False,
+        manual_value=1000000,
+    )
+    db_session.add(other_asset)
+    await db_session.commit()
+    await db_session.refresh(other_asset)
+
+    # test_user(authenticated_client)로 test_user2의 자산 접근 시도
+    response = await authenticated_client.get(f"/api/assets/{other_asset.id}")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_asset_not_found(authenticated_client):
+    """존재하지 않는 자산 → 404"""
+    response = await authenticated_client.get("/api/assets/99999")
+    assert response.status_code == 404
+
+
+# ──────────────────────────────────────────────
+# PUT /api/assets/{id} — 자산 수정
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_asset(authenticated_client, test_user: User, test_household: Household, db_session):
+    """자산 수정 성공"""
+    asset = Asset(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="구 이름",
+        type="deposit",
+        is_liability=False,
+        manual_value=1000000,
+    )
+    db_session.add(asset)
+    await db_session.commit()
+    await db_session.refresh(asset)
+
+    response = await authenticated_client.put(
+        f"/api/assets/{asset.id}",
+        json={"name": "새 이름", "manual_value": 2000000.0},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "새 이름"
+    assert data["manual_value"] == 2000000.0
+
+
+# ──────────────────────────────────────────────
+# DELETE /api/assets/{id} — 자산 삭제
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_asset(authenticated_client, test_user: User, test_household: Household, db_session):
+    """자산 삭제 성공"""
+    asset = Asset(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="삭제할 자산",
+        type="other",
+        is_liability=False,
+        manual_value=500000,
+    )
+    db_session.add(asset)
+    await db_session.commit()
+    await db_session.refresh(asset)
+
+    response = await authenticated_client.delete(f"/api/assets/{asset.id}")
+    assert response.status_code == 204
+
+    # 삭제 후 조회 시 404
+    response = await authenticated_client.get(f"/api/assets/{asset.id}")
+    assert response.status_code == 404
+
+
+# ──────────────────────────────────────────────
+# GET /api/assets/goal — 순자산 목표
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_goal_none(authenticated_client, test_user: User, db_session):
+    """목표 미설정 시 null 반환"""
+    response = await authenticated_client.get("/api/assets/goal")
+    assert response.status_code == 200
+    assert response.json() is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get_goal(authenticated_client, test_user: User, test_household: Household, db_session):
+    """목표 설정 후 조회"""
+    payload = {
+        "household_id": test_household.id,
+        "target_net_worth": 100000000.0,
+        "target_date": "2030-12-31",
+    }
+    response = await authenticated_client.post("/api/assets/goal", json=payload)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["target_net_worth"] == 100000000.0
+
+
+@pytest.mark.asyncio
+async def test_delete_goal_not_found(authenticated_client, test_user: User, db_session):
+    """목표 없을 때 삭제 시도 → 404"""
+    response = await authenticated_client.delete("/api/assets/goal")
+    assert response.status_code == 404

--- a/backend/tests/integration/test_api_auth.py
+++ b/backend/tests/integration/test_api_auth.py
@@ -134,6 +134,61 @@ async def test_removed_endpoints_return_404(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_telegram_link_code_format(authenticated_client: AsyncClient):
+    """텔레그램 연동 코드 — 6자리 대문자+숫자 형식 확인"""
+    response = await authenticated_client.post("/api/auth/telegram-link-code")
+    assert response.status_code == 200
+
+    data = response.json()
+    code = data["code"]
+    assert len(code) == 6
+    # 대문자 알파벳 + 숫자만 허용
+    assert code.isalnum()
+    assert code == code.upper()
+    assert "expires_at" in data
+
+
+@pytest.mark.asyncio
+async def test_kakao_link_code_format(authenticated_client: AsyncClient):
+    """카카오 연동 코드 — 6자리 대문자+숫자 형식 확인"""
+    response = await authenticated_client.post("/api/auth/kakao-link-code")
+    assert response.status_code == 200
+
+    data = response.json()
+    code = data["code"]
+    assert len(code) == 6
+    assert code.isalnum()
+    assert code == code.upper()
+    assert "expires_at" in data
+
+
+@pytest.mark.asyncio
+async def test_kakao_unlink(authenticated_client: AsyncClient):
+    """카카오 연동 해제 성공"""
+    response = await authenticated_client.delete("/api/auth/kakao/link")
+    assert response.status_code == 200
+    assert "메시지" in response.json() or "message" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_get_me_returns_is_telegram_linked_false(authenticated_client: AsyncClient, test_user: User):
+    """텔레그램 미연동 사용자 — is_telegram_linked=False"""
+    response = await authenticated_client.get("/api/auth/me")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_telegram_linked"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_me_returns_is_kakao_linked_false(authenticated_client: AsyncClient, test_user: User):
+    """카카오 미연동 사용자 — is_kakao_linked=False"""
+    response = await authenticated_client.get("/api/auth/me")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_kakao_linked"] is False
+
+
+@pytest.mark.asyncio
 async def test_inactive_user_returns_403(client: AsyncClient, db_session: AsyncSession):
     """is_active=False 계정으로 접근 시 403 반환 (#183)"""
     from app.models.household import Household

--- a/backend/tests/integration/test_api_onboarding.py
+++ b/backend/tests/integration/test_api_onboarding.py
@@ -1,0 +1,136 @@
+"""온보딩 API 통합 테스트
+
+- GET /api/onboarding/status — 온보딩 상태 조회
+- POST /api/onboarding/create-household — 기본 가구 생성
+"""
+
+import pytest
+
+from app.models.household import Household
+from app.models.user import User
+from tests.conftest import create_test_token
+
+# ──────────────────────────────────────────────
+# GET /api/onboarding/status
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_onboarding_status_has_household(authenticated_client, test_user: User, test_household: Household):
+    """가구 소속 사용자 — has_household=True"""
+    response = await authenticated_client.get("/api/onboarding/status")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["has_household"] is True
+    assert data["household_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_onboarding_status_no_household(client, db_session):
+    """가구 미소속 사용자 — has_household=False"""
+    # 가구 없는 새 사용자 생성
+    new_auth_id = 6000000000001
+    user = User(
+        auth_user_id=new_auth_id,
+        username="no_household_user",
+        email="nohousehold@example.com",
+        hashed_password=None,
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    token = create_test_token(auth_user_id=new_auth_id, email="nohousehold@example.com", name="가구없는유저")
+    response = await client.get("/api/onboarding/status", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["has_household"] is False
+    assert data["household_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_onboarding_status_unauthenticated(client):
+    """미인증 접근 → 401"""
+    response = await client.get("/api/onboarding/status")
+    assert response.status_code == 401
+
+
+# ──────────────────────────────────────────────
+# POST /api/onboarding/create-household
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_household_success(client, db_session):
+    """가구 없는 사용자가 기본 가구 생성"""
+    new_auth_id = 6000000000002
+    user = User(
+        auth_user_id=new_auth_id,
+        username="new_onboard_user",
+        email="newonboard@example.com",
+        hashed_password=None,
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    token = create_test_token(auth_user_id=new_auth_id, email="newonboard@example.com", name="신규유저")
+
+    response = await client.post(
+        "/api/onboarding/create-household",
+        json={"name": "우리집 가계부"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["name"] == "우리집 가계부"
+    assert "id" in data
+
+
+@pytest.mark.asyncio
+async def test_create_household_default_name(client, db_session):
+    """이름 미지정 시 기본 이름 생성 ({username}님의 가계부)"""
+    new_auth_id = 6000000000003
+    user = User(
+        auth_user_id=new_auth_id,
+        username="autoname_user",
+        email="autoname@example.com",
+        hashed_password=None,
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    token = create_test_token(auth_user_id=new_auth_id, email="autoname@example.com", name="autoname_user")
+
+    response = await client.post(
+        "/api/onboarding/create-household",
+        json={},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 201
+
+    data = response.json()
+    assert "autoname_user" in data["name"]
+    assert "가계부" in data["name"]
+
+
+@pytest.mark.asyncio
+async def test_create_household_already_has_one(authenticated_client, test_user: User, test_household: Household):
+    """이미 가구 소속인 사용자가 가구 생성 시도 → 409 Conflict"""
+    response = await authenticated_client.post(
+        "/api/onboarding/create-household",
+        json={"name": "중복 가구"},
+    )
+    assert response.status_code == 409
+    assert "이미 가구에 소속" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_household_unauthenticated(client):
+    """미인증 접근 → 401"""
+    response = await client.post("/api/onboarding/create-household", json={"name": "테스트 가구"})
+    assert response.status_code == 401

--- a/backend/tests/integration/test_api_shadow_user.py
+++ b/backend/tests/integration/test_api_shadow_user.py
@@ -1,0 +1,159 @@
+"""Shadow User 3단계 조회 로직 통합 테스트
+
+podo-auth SSO 기반 Shadow User 패턴 검증:
+  1단계: auth_user_id로 기존 유저 조회
+  2단계: email 매칭으로 기존 유저 연결
+  3단계: 완전히 새로운 유저 자동 생성
+
+테스트 방식: GET /api/auth/me — JWT 검증 후 Shadow User 반환
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+from tests.conftest import create_test_token
+
+
+@pytest.mark.asyncio
+async def test_step1_auth_user_id_lookup(authenticated_client, test_user: User, db_session: AsyncSession):
+    """1단계: auth_user_id로 기존 Shadow User 조회"""
+    # test_user는 이미 TEST_AUTH_USER_ID_1로 등록됨
+    response = await authenticated_client.get("/api/auth/me")
+    assert response.status_code == 200
+
+    data = response.json()
+    # 기존 유저 ID를 그대로 반환해야 함 (새 유저 생성 X)
+    assert data["id"] == test_user.id
+    assert data["email"] == test_user.email
+
+
+@pytest.mark.asyncio
+async def test_step2_email_matching(client: AsyncClient, db_session: AsyncSession):
+    """2단계: email 매칭으로 기존 유저에 auth_user_id 연결"""
+    # auth_user_id 없는 기존 유저
+    existing_user = User(
+        username="legacy_user",
+        email="legacy@example.com",
+        hashed_password="hashed",
+        is_active=True,
+    )
+    db_session.add(existing_user)
+    await db_session.commit()
+    await db_session.refresh(existing_user)
+
+    original_id = existing_user.id
+    new_auth_id = 5500000000001
+
+    # 같은 이메일로 podo-auth SSO 로그인
+    token = create_test_token(
+        auth_user_id=new_auth_id,
+        email="legacy@example.com",
+        name="레거시유저",
+    )
+
+    response = await client.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+
+    data = response.json()
+    # 새 유저가 아닌 기존 유저 ID를 반환
+    assert data["id"] == original_id
+
+    # DB에서 auth_user_id가 연결됐는지 확인
+    result = await db_session.execute(select(User).where(User.id == original_id))
+    updated_user = result.scalar_one()
+    assert updated_user.auth_user_id == new_auth_id
+
+
+@pytest.mark.asyncio
+async def test_step3_new_user_creation(client, db_session: AsyncSession):
+    """3단계: 완전히 새로운 유저 자동 생성"""
+    brand_new_auth_id = 5500000000002
+
+    # 이 auth_user_id도, 이메일도 DB에 없는 상태
+    token = create_test_token(
+        auth_user_id=brand_new_auth_id,
+        email="brandnew@example.com",
+        name="브랜드뉴",
+    )
+
+    response = await client.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["email"] == "brandnew@example.com"
+    assert "id" in data
+
+    # DB에 실제로 생성됐는지 확인
+    result = await db_session.execute(select(User).where(User.auth_user_id == brand_new_auth_id))
+    new_user = result.scalar_one_or_none()
+    assert new_user is not None
+    assert new_user.email == "brandnew@example.com"
+
+
+@pytest.mark.asyncio
+async def test_step3_new_user_name_from_email_prefix(client, db_session: AsyncSession):
+    """3단계: name이 없을 때 이메일 prefix를 username으로 사용"""
+    auth_id = 5500000000003
+
+    # name을 빈 문자열로 설정
+    from datetime import UTC, datetime, timedelta
+
+    from jose import jwt
+
+    from app.core.config import settings
+
+    expire = datetime.now(UTC) + timedelta(days=7)
+    payload = {
+        "sub": str(auth_id),
+        "email": "prefix.test@example.com",
+        "name": "",  # 빈 이름
+        "iss": "podo-auth",
+        "exp": expire,
+    }
+    token = jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+    response = await client.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+
+    data = response.json()
+    # username이 이메일 prefix(prefix.test)로 설정되어야 함
+    assert "prefix" in data["username"] or data["username"] == "prefix.test"
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_returns_same_user(authenticated_client, test_user: User):
+    """캐시 히트 시에도 동일한 사용자 반환 (auth_user_id 캐시 검증)"""
+    # 같은 토큰으로 두 번 요청 → 캐시 히트
+    r1 = await authenticated_client.get("/api/auth/me")
+    r2 = await authenticated_client.get("/api/auth/me")
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json()["id"] == r2.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_step2_email_matching_updates_in_db(client, db_session: AsyncSession):
+    """2단계 매칭 후 auth_user_id가 DB에 영속적으로 저장됨"""
+    old_user = User(
+        username="old_sso_user",
+        email="old_sso@example.com",
+        hashed_password=None,
+        is_active=True,
+    )
+    db_session.add(old_user)
+    await db_session.commit()
+    await db_session.refresh(old_user)
+
+    new_auth_id = 5500000000004
+    token = create_test_token(auth_user_id=new_auth_id, email="old_sso@example.com", name="구유저")
+
+    # 로그인 → 2단계 매칭 트리거
+    await client.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+
+    # 세션 갱신 후 확인
+    await db_session.refresh(old_user)
+    assert old_user.auth_user_id == new_auth_id

--- a/backend/tests/unit/test_category_mapping_service.py
+++ b/backend/tests/unit/test_category_mapping_service.py
@@ -1,0 +1,192 @@
+"""카테고리 매핑 서비스 단위 테스트
+
+LLM 매핑 저장/조회 로직 검증:
+- save_category_mapping() — 새 매핑 생성
+- get_mapped_category() — 매핑된 카테고리 조회
+- get_category_mappings_for_prompt() — 프롬프트용 dict 반환
+- 가구 스코프 vs 개인 스코프 우선순위
+- 기존 매핑 업데이트 (덮어쓰기)
+"""
+
+import pytest
+
+from app.models.category import Category
+from app.models.category_mapping import CategoryMapping
+from app.models.household import Household
+from app.models.user import User
+from app.services.category_mapping_service import (
+    get_category_mappings_for_prompt,
+    get_mapped_category,
+    save_category_mapping,
+)
+
+
+@pytest.fixture
+async def setup_data(db_session, test_user, test_household):
+    """테스트용 카테고리 생성"""
+    cat_food = Category(user_id=test_user.id, name="외식비")
+    cat_transport = Category(user_id=test_user.id, name="대중교통")
+    db_session.add_all([cat_food, cat_transport])
+    await db_session.commit()
+    await db_session.refresh(cat_food)
+    await db_session.refresh(cat_transport)
+    return cat_food, cat_transport
+
+
+@pytest.mark.asyncio
+async def test_save_and_get_mapping(db_session, test_user: User, test_household: Household, setup_data):
+    """매핑 저장 후 조회 성공"""
+    cat_food, _ = setup_data
+
+    # "식비" → "외식비" 매핑 저장
+    await save_category_mapping(
+        db=db_session,
+        source_name="식비",
+        target_category_id=cat_food.id,
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    await db_session.commit()
+
+    # 조회
+    result = await get_mapped_category(
+        db=db_session,
+        source_name="식비",
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    assert result is not None
+    assert result.name == "외식비"
+
+
+@pytest.mark.asyncio
+async def test_get_mapping_not_found(db_session, test_user: User, test_household: Household):
+    """매핑 없으면 None 반환"""
+    result = await get_mapped_category(
+        db=db_session,
+        source_name="존재하지않는카테고리",
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_update_existing_mapping(db_session, test_user: User, test_household: Household, setup_data):
+    """기존 매핑 덮어쓰기"""
+    cat_food, cat_transport = setup_data
+
+    # 초기 매핑: "교통" → "외식비"
+    await save_category_mapping(
+        db=db_session,
+        source_name="교통",
+        target_category_id=cat_food.id,
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    await db_session.commit()
+
+    # 업데이트: "교통" → "대중교통"
+    await save_category_mapping(
+        db=db_session,
+        source_name="교통",
+        target_category_id=cat_transport.id,
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    await db_session.commit()
+
+    result = await get_mapped_category(
+        db=db_session,
+        source_name="교통",
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    assert result is not None
+    assert result.name == "대중교통"
+
+
+@pytest.mark.asyncio
+async def test_household_scope_mapping(db_session, test_user: User, test_household: Household, setup_data):
+    """가구 스코프 매핑 — household_id로 저장/조회"""
+    cat_food, cat_transport = setup_data
+
+    # 가구 스코프 매핑: "식비" → "대중교통" (의미상 이상하지만 테스트용)
+    household_mapping = CategoryMapping(
+        user_id=None,
+        household_id=test_household.id,  # 가구 스코프
+        source_name="식비",
+        target_category_id=cat_transport.id,
+    )
+    db_session.add(household_mapping)
+    await db_session.commit()
+
+    result = await get_mapped_category(
+        db=db_session,
+        source_name="식비",
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    assert result is not None
+    assert result.name == "대중교통"
+
+
+@pytest.mark.asyncio
+async def test_get_category_mappings_for_prompt(db_session, test_user: User, test_household: Household, setup_data):
+    """프롬프트용 매핑 dict 반환"""
+    cat_food, cat_transport = setup_data
+
+    await save_category_mapping(
+        db=db_session,
+        source_name="식비",
+        target_category_id=cat_food.id,
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    await save_category_mapping(
+        db=db_session,
+        source_name="교통",
+        target_category_id=cat_transport.id,
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    await db_session.commit()
+
+    mappings = await get_category_mappings_for_prompt(
+        db=db_session,
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    assert isinstance(mappings, dict)
+    assert mappings.get("식비") == "외식비"
+    assert mappings.get("교통") == "대중교통"
+
+
+@pytest.mark.asyncio
+async def test_get_mappings_empty(db_session, test_user: User, test_household: Household):
+    """매핑 없을 때 빈 dict 반환"""
+    mappings = await get_category_mappings_for_prompt(
+        db=db_session,
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    assert mappings == {}
+
+
+@pytest.mark.asyncio
+async def test_save_with_household_scope(db_session, test_user: User, test_household: Household, setup_data):
+    """가구 스코프 매핑 저장 — user_id=None, household_id 설정"""
+    cat_food, _ = setup_data
+
+    mapping = await save_category_mapping(
+        db=db_session,
+        source_name="먹거리",
+        target_category_id=cat_food.id,
+        user_id=test_user.id,
+        household_id=test_household.id,
+    )
+    await db_session.commit()
+
+    assert mapping is not None
+    assert mapping.source_name == "먹거리"
+    assert mapping.household_id == test_household.id

--- a/backend/tests/unit/test_exchange_rate_service.py
+++ b/backend/tests/unit/test_exchange_rate_service.py
@@ -1,0 +1,162 @@
+"""환율 서비스 단위 테스트
+
+get_exchange_rate() 캐시 로직 검증:
+- KRW는 항상 1.0 반환 (API 호출 없음)
+- 캐시 히트 시 API 호출 스킵
+- 캐시 만료 후 재조회
+- API 실패 시 None + negative 캐시
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.exchange_rate import (
+    CACHE_TTL,
+    NEGATIVE_CACHE_TTL,
+    _rate_cache,
+    clear_rate_cache,
+    get_exchange_rate,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache_before_each():
+    """각 테스트 전 캐시 초기화"""
+    clear_rate_cache()
+    yield
+    clear_rate_cache()
+
+
+@pytest.mark.asyncio
+async def test_krw_returns_1():
+    """KRW는 항상 1.0 반환 (API 호출 없음)"""
+    result = await get_exchange_rate("KRW")
+    assert result == 1.0
+
+
+@pytest.mark.asyncio
+async def test_krw_lowercase():
+    """소문자 krw도 1.0 반환"""
+    result = await get_exchange_rate("krw")
+    assert result == 1.0
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_skips_api():
+    """캐시 히트 시 외부 API 호출 없음"""
+    # 캐시에 직접 삽입
+    _rate_cache["USD"] = (1300.0, datetime.now())
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        result = await get_exchange_rate("USD")
+        # API 호출이 없어야 함
+        mock_client_cls.assert_not_called()
+
+    assert result == 1300.0
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_calls_api():
+    """캐시 없을 때 API 호출"""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"rates": {"KRW": 1320.5}}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await get_exchange_rate("USD")
+
+    assert result == 1320.5
+    # 캐시에 저장됐는지 확인
+    assert "USD" in _rate_cache
+    assert _rate_cache["USD"][0] == 1320.5
+
+
+@pytest.mark.asyncio
+async def test_expired_cache_recalls_api():
+    """만료된 캐시는 API 재호출"""
+    # 만료된 캐시 삽입 (CACHE_TTL + 1초 전)
+    expired_time = datetime.now() - CACHE_TTL - timedelta(seconds=1)
+    _rate_cache["EUR"] = (1200.0, expired_time)
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"rates": {"KRW": 1250.0}}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await get_exchange_rate("EUR")
+
+    assert result == 1250.0
+
+
+@pytest.mark.asyncio
+async def test_api_failure_returns_none_and_caches_negative():
+    """API 실패 → None 반환 + negative 캐시 저장"""
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = Exception("네트워크 오류")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await get_exchange_rate("JPY")
+
+    assert result is None
+    # negative 캐시에 None이 저장됨
+    assert "JPY" in _rate_cache
+    assert _rate_cache["JPY"][0] is None
+
+
+@pytest.mark.asyncio
+async def test_negative_cache_hit_returns_none():
+    """negative 캐시 히트 시 API 재호출 없이 None 반환"""
+    # 최근에 실패한 캐시
+    _rate_cache["CNY"] = (None, datetime.now())
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        result = await get_exchange_rate("CNY")
+        mock_client_cls.assert_not_called()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_expired_negative_cache_recalls_api():
+    """만료된 negative 캐시 → API 재호출"""
+    # 만료된 negative 캐시 (NEGATIVE_CACHE_TTL + 1초 전)
+    expired_time = datetime.now() - NEGATIVE_CACHE_TTL - timedelta(seconds=1)
+    _rate_cache["GBP"] = (None, expired_time)
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"rates": {"KRW": 1700.0}}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await get_exchange_rate("GBP")
+
+    assert result == 1700.0
+
+
+def test_clear_rate_cache():
+    """캐시 초기화 확인"""
+    _rate_cache["USD"] = (1300.0, datetime.now())
+    _rate_cache["EUR"] = (1250.0, datetime.now())
+    assert len(_rate_cache) == 2
+
+    clear_rate_cache()
+    assert len(_rate_cache) == 0

--- a/backend/tests/unit/test_llm_service_extra.py
+++ b/backend/tests/unit/test_llm_service_extra.py
@@ -1,0 +1,162 @@
+"""LLM 서비스 추가 단위 테스트
+
+- LocalLLMProvider 모든 메서드 NotImplementedError 검증
+- _extract_json_text() 다양한 포맷 처리
+- GoogleProvider NotImplementedError 검증
+"""
+
+import pytest
+
+from app.services.llm_service import (
+    GoogleProvider,
+    LocalLLMProvider,
+    _extract_json_text,
+)
+
+# ──────────────────────────────────────────────
+# _extract_json_text() 테스트
+# ──────────────────────────────────────────────
+
+
+def test_extract_json_text_plain():
+    """순수 JSON 텍스트는 그대로 반환"""
+    text = '{"amount": 8000, "category": "식비"}'
+    result = _extract_json_text(text)
+    assert result == text
+
+
+def test_extract_json_text_json_block():
+    """```json 블록에서 JSON 추출"""
+    text = '```json\n{"amount": 8000}\n```'
+    result = _extract_json_text(text)
+    assert result == '{"amount": 8000}'
+
+
+def test_extract_json_text_plain_block():
+    """``` 블록(json 없음)에서 JSON 추출"""
+    text = '```\n{"amount": 8000}\n```'
+    result = _extract_json_text(text)
+    assert result == '{"amount": 8000}'
+
+
+def test_extract_json_text_with_whitespace():
+    """앞뒤 공백 제거"""
+    text = '  \n  {"amount": 8000}  \n  '
+    result = _extract_json_text(text)
+    assert result == '{"amount": 8000}'
+
+
+def test_extract_json_text_json_block_with_extra_text():
+    """```json 블록 앞뒤에 다른 텍스트가 있는 경우"""
+    text = '다음은 파싱 결과입니다:\n```json\n{"amount": 5000}\n```\n감사합니다.'
+    result = _extract_json_text(text)
+    assert result == '{"amount": 5000}'
+
+
+def test_extract_json_text_array():
+    """배열 형태의 JSON도 정상 처리"""
+    text = '```json\n[{"amount": 1000}, {"amount": 2000}]\n```'
+    result = _extract_json_text(text)
+    assert result == '[{"amount": 1000}, {"amount": 2000}]'
+
+
+# ──────────────────────────────────────────────
+# LocalLLMProvider — 모든 메서드 NotImplementedError
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_local_llm_parse_expense_not_implemented():
+    """LocalLLMProvider.parse_expense() → NotImplementedError"""
+    provider = LocalLLMProvider()
+    with pytest.raises(NotImplementedError):
+        await provider.parse_expense("테스트 입력")
+
+
+@pytest.mark.asyncio
+async def test_local_llm_parse_image_not_implemented():
+    """LocalLLMProvider.parse_image() → NotImplementedError"""
+    provider = LocalLLMProvider()
+    with pytest.raises(NotImplementedError):
+        await provider.parse_image(b"fake_image", "image/jpeg")
+
+
+@pytest.mark.asyncio
+async def test_local_llm_generate_insights_not_implemented():
+    """LocalLLMProvider.generate_insights() → NotImplementedError"""
+    provider = LocalLLMProvider()
+    with pytest.raises(NotImplementedError):
+        await provider.generate_insights({"total": 50000})
+
+
+@pytest.mark.asyncio
+async def test_local_llm_generate_not_implemented():
+    """LocalLLMProvider.generate() → NotImplementedError"""
+    provider = LocalLLMProvider()
+    with pytest.raises(NotImplementedError):
+        await provider.generate("임의 프롬프트")
+
+
+@pytest.mark.asyncio
+async def test_local_llm_generate_comprehensive_insights_not_implemented():
+    """LocalLLMProvider.generate_comprehensive_insights() → NotImplementedError"""
+    provider = LocalLLMProvider()
+    with pytest.raises(NotImplementedError):
+        await provider.generate_comprehensive_insights({"month": "2026-02"})
+
+
+def test_local_llm_default_model():
+    """LocalLLMProvider 기본 모델 이름 확인"""
+    provider = LocalLLMProvider()
+    assert provider.model == "llama3"
+
+
+def test_local_llm_custom_model():
+    """LocalLLMProvider 커스텀 모델 설정"""
+    provider = LocalLLMProvider(model="llama3.1")
+    assert provider.model == "llama3.1"
+
+
+# ──────────────────────────────────────────────
+# GoogleProvider — NotImplementedError
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_google_parse_expense_not_implemented():
+    """GoogleProvider.parse_expense() → NotImplementedError"""
+    provider = GoogleProvider()
+    with pytest.raises(NotImplementedError):
+        await provider.parse_expense("테스트")
+
+
+@pytest.mark.asyncio
+async def test_google_parse_image_not_implemented():
+    """GoogleProvider.parse_image() → NotImplementedError"""
+    provider = GoogleProvider()
+    with pytest.raises(NotImplementedError):
+        await provider.parse_image(b"image", "image/png")
+
+
+@pytest.mark.asyncio
+async def test_google_generate_insights_not_implemented():
+    """GoogleProvider.generate_insights() → NotImplementedError"""
+    provider = GoogleProvider()
+    with pytest.raises(NotImplementedError):
+        await provider.generate_insights({})
+
+
+@pytest.mark.asyncio
+async def test_google_generate_not_implemented():
+    """GoogleProvider.generate() → NotImplementedError"""
+    provider = GoogleProvider()
+    with pytest.raises(NotImplementedError):
+        await provider.generate("프롬프트")
+
+
+@pytest.mark.asyncio
+async def test_google_generate_comprehensive_insights_not_implemented():
+    """GoogleProvider.generate_comprehensive_insights() → NotImplementedError"""
+    provider = GoogleProvider()
+    with pytest.raises(NotImplementedError):
+        await provider.generate_comprehensive_insights({})


### PR DESCRIPTION
## 변경 내용

### #246 통합 테스트 추가 (미테스트 API)
- **Assets**: CRUD, 순자산 계산, 목표 upsert/delete, IDOR 보호 (16개)
- **Admin**: 대시보드 통계, 유저 목록/상세/수정, 비관리자 403, 비인증 401 (12개)
- **Onboarding**: 가구 유무 조회, 첫 가구 생성, 409 중복 방지, 401 (7개)
- **test_api_auth.py 확장**: Telegram/Kakao 링크코드 포맷, is_linked 플래그 (+5개)

### #247 핵심 로직 테스트
- **Shadow User**: auth_user_id → email fallback → 신규 생성 3단계 조회 검증 (6개)

### #248 서비스 단위 테스트
- **exchange_rate**: positive 30분 캐시, negative 30초 캐시, KRW 단축, TTL 만료 (9개)
- **category_mapping_service**: 저장·조회·업데이트·household 스코프 격리, 프롬프트 생성 (7개)
- **llm_service**: `_extract_json_text()` (5개), `LocalLLMProvider`/`GoogleProvider` NotImplementedError (13개)

## 결과
- **신규 테스트 80개**
- **총 724개 통과** (5 skip, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)