### PR TITLE
feat: CI 테스트 커버리지 리포팅 + PR 자동 코멘트

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -50,13 +50,24 @@ jobs:
         # CVE-2024-23342(ecdsa): python-jose의 transitive dep, 최신 버전(0.19.1)에도 수정 없음 — ignore (#237)
         run: uv run pip-audit --ignore-vuln CVE-2024-23342
 
-      - name: 테스트 실행
+      - name: 테스트 + 커버리지
         env:
           DATABASE_URL: sqlite+aiosqlite:///./test.db
           SECRET_KEY: test-secret-key  # pragma: allowlist secret
           LLM_PROVIDER: anthropic
           ANTHROPIC_API_KEY: test-key  # pragma: allowlist secret
-        run: PYTHONPATH=backend uv run pytest backend/tests/ --ignore=backend/tests/integration/test_api_budget_bulk.py
+        run: |
+          PYTHONPATH=backend uv run pytest backend/tests/ \
+            --ignore=backend/tests/integration/test_api_budget_bulk.py \
+            --cov=app --cov-report=term --cov-report=json:backend-coverage.json
+
+      - name: 커버리지 리포트 업로드
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: backend-coverage.json
+          retention-days: 5
 
   test-frontend:
     name: 프론트엔드
@@ -82,8 +93,16 @@ jobs:
       - name: 의존성 취약점 스캔
         run: cd frontend && npm audit --audit-level=high --omit=dev  # 런타임 의존성만 심각(high+) CVE 탐지 (#237)
 
-      - name: 테스트 실행
-        run: cd frontend && npm run test:run
+      - name: 테스트 + 커버리지
+        run: cd frontend && npm run test:coverage
+
+      - name: 커버리지 리포트 업로드
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/coverage-summary.json
+          retention-days: 5
 
       - name: 빌드 검증
         if: inputs.frontend_build_check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,88 @@ jobs:
     with:
       frontend_build_check: true
 
+  # ── 커버리지 PR 코멘트 ─────────────────────────────
+  coverage-comment:
+    name: 커버리지 리포트
+    needs: [test]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: BE 커버리지 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-coverage
+          path: ./coverage
+        continue-on-error: true
+
+      - name: FE 커버리지 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-coverage
+          path: ./coverage
+        continue-on-error: true
+
+      - name: 커버리지 코멘트 작성
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let comment = '## 📊 테스트 커버리지 리포트\n\n';
+
+            // BE 커버리지 파싱
+            try {
+              const be = JSON.parse(fs.readFileSync('./coverage/backend-coverage.json', 'utf8'));
+              const total = be.totals;
+              comment += `### Backend (pytest-cov)\n`;
+              comment += `| 항목 | 커버리지 |\n|------|----------|\n`;
+              comment += `| **Statements** | ${total.percent_covered_display}% |\n`;
+              comment += `| Lines | ${total.covered_lines} / ${total.num_statements} |\n\n`;
+            } catch (e) {
+              comment += '### Backend\n⚠️ 커버리지 데이터 없음\n\n';
+            }
+
+            // FE 커버리지 파싱
+            try {
+              const fe = JSON.parse(fs.readFileSync('./coverage/coverage-summary.json', 'utf8'));
+              const total = fe.total;
+              comment += `### Frontend (vitest)\n`;
+              comment += `| 항목 | 커버리지 |\n|------|----------|\n`;
+              comment += `| **Statements** | ${total.statements.pct}% |\n`;
+              comment += `| **Branches** | ${total.branches.pct}% |\n`;
+              comment += `| **Functions** | ${total.functions.pct}% |\n`;
+              comment += `| **Lines** | ${total.lines.pct}% |\n\n`;
+            } catch (e) {
+              comment += '### Frontend\n⚠️ 커버리지 데이터 없음\n\n';
+            }
+
+            // 기존 커버리지 코멘트 찾아서 업데이트 (중복 방지)
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes('📊 테스트 커버리지 리포트'));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: comment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: comment,
+              });
+            }
+
   # ── 테스트 결과 메시지 빌드 ──────────────────────
   build-test-result-message:
     name: 결과 메시지 빌드

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     css: true,
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json-summary', 'html'],
       exclude: [
         'node_modules/',
         'src/__tests__/',


### PR DESCRIPTION
## Summary

- close #252

### 변경 사항
- BE: `pytest --cov=app` 커버리지 수집 + JSON 리포트 생성
- FE: `vitest --coverage` + json-summary 리포터 추가
- CI: 커버리지 artifact 업로드 → PR에 자동 코멘트 (Statements/Branches/Functions/Lines)
- 기존 커버리지 코멘트 있으면 업데이트 (중복 방지)

### 동작 방식
1. `ci-test.yml`: BE/FE 테스트 시 커버리지 수집 → artifact 업로드
2. `ci.yml`: artifact 다운로드 → `actions/github-script`로 PR 코멘트 작성

### 커버리지 게이트 (추후)
현재는 리포팅만 적용. 기준선 확보 후 하락 차단 게이트 추가 예정.

🤖 Generated with Claude Code