### PR TITLE
feat: 배포 후 스모크 테스트 + 프로덕션 자동 롤백

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -100,10 +100,70 @@ jobs:
           REASON=$(grep -iE "error|failed" /tmp/deploy.log 2>/dev/null | tail -3 | sed 's/\x1b\[[0-9;]*m//g' | tr '\n' ' ' | cut -c1-300)
           echo "reason=${REASON:-Cloudflare Pages 배포 실패}" >> $GITHUB_OUTPUT
 
+  # ── 배포 후 스모크 테스트 ──────────────────────────
+  smoke-test:
+    name: 스모크 테스트
+    needs: [deploy-backend, deploy-frontend]
+    if: needs.deploy-backend.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@v1
+
+      - name: BE 헬스체크
+        id: smoke
+        env:
+          BE_URL: https://podo-budget-backend.fly.dev
+          FE_URL: https://budget.podonest.com
+        run: |
+          echo "30초 대기 (서버 부팅 + 마이그레이션)..."
+          sleep 30
+
+          FAILED=0
+
+          # BE /health
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$BE_URL/health" || echo "000")
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ BE /health → $HTTP_CODE"
+          else
+            echo "❌ BE /health → $HTTP_CODE"
+            FAILED=1
+          fi
+
+          # BE / root
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$BE_URL/" || echo "000")
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ BE / → $HTTP_CODE"
+          else
+            echo "❌ BE / → $HTTP_CODE"
+            FAILED=1
+          fi
+
+          # FE 접근 가능 확인
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$FE_URL" || echo "000")
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ FE → $HTTP_CODE"
+          else
+            echo "❌ FE → $HTTP_CODE"
+            FAILED=1
+          fi
+
+          if [ "$FAILED" = "1" ]; then
+            echo "::error::스모크 테스트 실패 — 롤백 시도"
+            exit 1
+          fi
+
+      - name: BE 자동 롤백
+        if: failure()
+        run: |
+          echo "⚠️ 스모크 테스트 실패 — 이전 릴리즈로 롤백"
+          flyctl releases rollback --app podo-budget-backend --yes || echo "롤백 실패 — 수동 확인 필요"
+
   # ── 배포 결과 메시지 빌드 ──────────────────────────
   build-deploy-result-message:
     name: 결과 메시지 빌드
-    needs: [deploy-backend, deploy-frontend]
+    needs: [deploy-backend, deploy-frontend, smoke-test]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     if: always()
@@ -115,6 +175,7 @@ jobs:
         env:
           BACKEND_STATUS: ${{ needs.deploy-backend.result }}
           FRONTEND_STATUS: ${{ needs.deploy-frontend.result }}
+          SMOKE_STATUS: ${{ needs.smoke-test.result }}
           BACKEND_FAILURE: ${{ needs.deploy-backend.outputs.failure_reason }}
           FRONTEND_FAILURE: ${{ needs.deploy-frontend.outputs.failure_reason }}
           COMMIT_MSG: ${{ github.event.head_commit.message || 'Manual trigger' }}
@@ -129,11 +190,13 @@ jobs:
             PR_LINK="https://github.com/${REPO}/pull/${PR_NUM}"
           fi
 
-          if [ "$BACKEND_STATUS" = "success" ] && [ "$FRONTEND_STATUS" = "success" ]; then
+          if [ "$BACKEND_STATUS" = "success" ] && [ "$FRONTEND_STATUS" = "success" ] && [ "$SMOKE_STATUS" != "failure" ]; then
             KST_TIME="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M KST')"
             MESSAGE="$(printf '[PROD] ✅ podo-budget 배포 완료\n📝 %s\n🕐 %s' \
               "${DISPLAY_MSG}" "${KST_TIME}")"
             [ -n "$PR_LINK" ] && MESSAGE="${MESSAGE}"$'\n'"🔗 ${PR_LINK}"
+          elif [ "$SMOKE_STATUS" = "failure" ]; then
+            MESSAGE="[PROD] 🔥 podo-budget 스모크 테스트 실패 — 자동 롤백 시도됨"
           else
             MESSAGE="[PROD] ❌ podo-budget 배포 실패 (backend: ${BACKEND_STATUS}, frontend: ${FRONTEND_STATUS})"
             [ -n "$BACKEND_FAILURE" ] && MESSAGE="${MESSAGE}"$'\n'"🔴 Backend: ${BACKEND_FAILURE}"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -99,10 +99,59 @@ jobs:
           REASON=$(grep -iE "error|failed" /tmp/deploy.log 2>/dev/null | tail -3 | sed 's/\x1b\[[0-9;]*m//g' | tr '\n' ' ' | cut -c1-300)
           echo "reason=${REASON:-Cloudflare Pages 배포 실패}" >> $GITHUB_OUTPUT
 
+  # ── 배포 후 스모크 테스트 ──────────────────────────
+  smoke-test:
+    name: 스모크 테스트
+    needs: [deploy-backend, deploy-frontend]
+    if: needs.deploy-backend.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      result: ${{ steps.smoke.outputs.result }}
+
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: BE 헬스체크 (슬립 깨우기 + 검증)
+        id: smoke
+        env:
+          BE_URL: https://podo-budget-dev.fly.dev
+        run: |
+          echo "30초 대기 (서버 부팅)..."
+          sleep 30
+
+          FAILED=0
+
+          # /health 엔드포인트
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$BE_URL/health" || echo "000")
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ /health → $HTTP_CODE"
+          else
+            echo "❌ /health → $HTTP_CODE"
+            FAILED=1
+          fi
+
+          # / 루트 엔드포인트
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$BE_URL/" || echo "000")
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ / → $HTTP_CODE"
+          else
+            echo "❌ / → $HTTP_CODE"
+            FAILED=1
+          fi
+
+          if [ "$FAILED" = "1" ]; then
+            echo "result=fail" >> "$GITHUB_OUTPUT"
+            echo "::error::스모크 테스트 실패"
+            exit 1
+          else
+            echo "result=pass" >> "$GITHUB_OUTPUT"
+          fi
+
   # ── 배포 결과 알림 ─────────────────────────────────
   notify-deploy-result:
     name: 배포 결과 알림
-    needs: [deploy-backend, deploy-frontend]
+    needs: [deploy-backend, deploy-frontend, smoke-test]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     if: always()


### PR DESCRIPTION
## Summary

### 변경 사항

**CD (Dev) — deploy-dev.yml:**
- 배포 후 30초 대기 → `/health`, `/` 스모크 테스트
- 실패 시 텔레그램 알림에 반영

**CD (Prod) — cd.yml:**
- 배포 후 30초 대기 → BE `/health`, `/` + FE 접근 스모크 테스트
- 스모크 실패 시 `flyctl releases rollback` 자동 롤백
- 텔레그램 알림에 "스모크 실패 → 롤백 시도됨" 메시지 포함

### 동작 흐름

```
배포 완료 → 30초 대기 → 핵심 엔드포인트 확인
  ├─ 성공 → ✅ 배포 완료 알림
  └─ 실패 → 🔥 자동 롤백 → 알림
```

🤖 Generated with Claude Code