### PR TITLE
feat: 텔레그램 알림 대폭 강화 — 모든 워크플로우 리포트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,19 +146,33 @@ jobs:
               });
             }
 
-  # ── 테스트 결과 메시지 빌드 ──────────────────────
-  build-test-result-message:
-    name: 결과 메시지 빌드
+  # ── 테스트 결과 + 커버리지 텔레그램 알림 ────────────
+  notify-test-result:
+    name: 테스트 결과 알림
     needs: [test]
     if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      message: ${{ steps.build.outputs.message }}
+    timeout-minutes: 3
+
     steps:
-      - name: 메시지 빌드
-        id: build
+      - name: BE 커버리지 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-coverage
+          path: ./coverage
+        continue-on-error: true
+
+      - name: FE 커버리지 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-coverage
+          path: ./coverage
+        continue-on-error: true
+
+      - name: 텔레그램 전송
         env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           TEST_STATUS: ${{ needs.test.result }}
           PR_TITLE: ${{ github.event.pull_request.title || 'Manual trigger' }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -168,26 +182,28 @@ jobs:
         run: |
           PR_LINK="https://github.com/${REPO}/pull/${PR_NUMBER}"
 
+          BE_COV=""
+          FE_COV=""
+          if [ -f ./coverage/backend-coverage.json ]; then
+            BE_COV=$(python3 -c "import json; d=json.load(open('./coverage/backend-coverage.json')); print(d['totals']['percent_covered_display'])" 2>/dev/null || echo "")
+          fi
+          if [ -f ./coverage/coverage-summary.json ]; then
+            FE_COV=$(python3 -c "import json; d=json.load(open('./coverage/coverage-summary.json')); print(d['total']['statements']['pct'])" 2>/dev/null || echo "")
+          fi
+
+          COV_LINE=""
+          if [ -n "$BE_COV" ] || [ -n "$FE_COV" ]; then
+            COV_LINE="📈 커버리지: BE ${BE_COV:-?}% / FE ${FE_COV:-?}%"
+          fi
+
           if [ "$TEST_STATUS" = "success" ]; then
-            MESSAGE="$(printf '%s ✅ podo-budget 테스트 통과\n📝 #%s %s\n🔗 %s' \
-              "${ENV_PREFIX}" "${PR_NUMBER}" "${PR_TITLE}" "${PR_LINK}")"
+            MESSAGE="$(printf '%s ✅ 테스트 통과\n📝 #%s %s\n%s\n🔗 %s' \
+              "${ENV_PREFIX}" "${PR_NUMBER}" "${PR_TITLE}" "${COV_LINE}" "${PR_LINK}")"
           else
-            MESSAGE="$(printf '%s ❌ podo-budget 테스트 실패\n📝 #%s %s\n🔗 https://github.com/%s/actions/runs/%s' \
+            MESSAGE="$(printf '%s ❌ 테스트 실패\n📝 #%s %s\n🔗 https://github.com/%s/actions/runs/%s' \
               "${ENV_PREFIX}" "${PR_NUMBER}" "${PR_TITLE}" "${REPO}" "${RUN_ID}")"
           fi
 
-          echo "message<<EOF" >> "$GITHUB_OUTPUT"
-          echo "${MESSAGE}" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-
-  # ── 테스트 결과 알림 ─────────────────────────────
-  notify-test-result:
-    name: 테스트 결과 알림
-    needs: [build-test-result-message]
-    if: always()
-    uses: ./.github/workflows/notify.yml
-    with:
-      message: ${{ needs.build-test-result-message.outputs.message }}
-    secrets:
-      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" || true

--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -18,6 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: 오래된 머지 브랜치 정리
+        id: cleanup
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -46,3 +47,20 @@ jobs:
 
           echo "---"
           echo "총 ${DELETED}개 브랜치 삭제 완료"
+          echo "deleted=$DELETED" >> "$GITHUB_OUTPUT"
+
+      - name: 텔레그램 알림
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          DELETED="${{ steps.cleanup.outputs.deleted || '0' }}"
+          if [ "$DELETED" != "0" ]; then
+            MESSAGE="[주간] 🧹 브랜치 정리: ${DELETED}개 삭제"
+          else
+            MESSAGE="[주간] ✅ 정리할 브랜치 없음"
+          fi
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" || true

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -97,3 +97,20 @@ jobs:
       - name: 깨끗함 로그
         if: env.be_count == '0' && env.fe_count == '0'
         run: echo "✅ Dead code 없음"
+
+      - name: 텔레그램 알림
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          BE="${{ env.be_count }}"
+          FE="${{ env.fe_count }}"
+          if [ "$BE" != "0" ] || [ "$FE" != "0" ]; then
+            MESSAGE="[월간] 🧟 Dead code 감지: BE ${BE}건, FE ${FE}건 → 이슈 생성됨"
+          else
+            MESSAGE="[월간] ✅ Dead code 없음"
+          fi
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" || true

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -156,12 +156,17 @@ jobs:
     timeout-minutes: 2
     if: always()
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 20  # 최근 커밋 목록용
+
       - name: 텔레그램 전송
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           BACKEND_STATUS: ${{ needs.deploy-backend.result }}
           FRONTEND_STATUS: ${{ needs.deploy-frontend.result }}
+          SMOKE_STATUS: ${{ needs.smoke-test.result }}
           BACKEND_FAILURE: ${{ needs.deploy-backend.outputs.failure_reason }}
           FRONTEND_FAILURE: ${{ needs.deploy-frontend.outputs.failure_reason }}
           COMMIT_MSG: ${{ github.event.head_commit.message || 'Manual trigger' }}
@@ -171,23 +176,36 @@ jobs:
         run: |
           DISPLAY_MSG="$(echo "$COMMIT_MSG" | head -1)"
 
-          # 커밋 메시지에서 PR 번호 추출 (예: (#38) → 38)
           PR_NUM="$(echo "$DISPLAY_MSG" | grep -oE '#[0-9]+' | tail -1 | tr -d '#')"
           if [ -n "$PR_NUM" ]; then
             PR_LINK="https://github.com/${REPO}/pull/${PR_NUM}"
           fi
 
+          # 최근 커밋 3개 요약
+          COMMITS=$(git log --oneline -3 --format="• %s" 2>/dev/null | head -3)
+
           if [ "$BACKEND_STATUS" = "success" ] && [ "$FRONTEND_STATUS" = "success" ]; then
             KST_TIME="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M KST')"
-            MESSAGE="$(printf '%s ✅ podo-budget 배포 완료\n📝 %s\n🕐 %s' \
+
+            # 스모크 테스트 결과
+            SMOKE_ICON="🟢"
+            [ "$SMOKE_STATUS" = "failure" ] && SMOKE_ICON="🔴"
+            [ "$SMOKE_STATUS" = "skipped" ] && SMOKE_ICON="⏭️"
+
+            MESSAGE="$(printf '%s ✅ 배포 완료\n📝 %s\n🏥 스모크: %s\n🕐 %s\n\n📋 최근 변경:\n%s' \
               "${ENV_PREFIX}" \
               "${DISPLAY_MSG}" \
-              "${KST_TIME}")"
+              "${SMOKE_ICON}" \
+              "${KST_TIME}" \
+              "${COMMITS}")"
             [ -n "$PR_LINK" ] && MESSAGE="${MESSAGE}"$'\n'"🔗 ${PR_LINK}"
+          elif [ "$SMOKE_STATUS" = "failure" ]; then
+            MESSAGE="${ENV_PREFIX} 🔥 스모크 테스트 실패 — 배포는 완료됐으나 헬스체크 실패"
+            MESSAGE="${MESSAGE}"$'\n'"🔗 https://github.com/${REPO}/actions/runs/${RUN_ID}"
           else
-            MESSAGE="${ENV_PREFIX} ❌ podo-budget 배포 실패 (backend: ${BACKEND_STATUS}, frontend: ${FRONTEND_STATUS})"
-            [ -n "$BACKEND_FAILURE" ] && MESSAGE="${MESSAGE}"$'\n'"🔴 Backend: ${BACKEND_FAILURE}"
-            [ -n "$FRONTEND_FAILURE" ] && MESSAGE="${MESSAGE}"$'\n'"🔴 Frontend: ${FRONTEND_FAILURE}"
+            MESSAGE="${ENV_PREFIX} ❌ 배포 실패 (BE: ${BACKEND_STATUS}, FE: ${FRONTEND_STATUS})"
+            [ -n "$BACKEND_FAILURE" ] && MESSAGE="${MESSAGE}"$'\n'"🔴 BE: ${BACKEND_FAILURE}"
+            [ -n "$FRONTEND_FAILURE" ] && MESSAGE="${MESSAGE}"$'\n'"🔴 FE: ${FRONTEND_FAILURE}"
             MESSAGE="${MESSAGE}"$'\n'"🔗 https://github.com/${REPO}/actions/runs/${RUN_ID}"
           fi
 

--- a/.github/workflows/radon-weekly.yml
+++ b/.github/workflows/radon-weekly.yml
@@ -89,3 +89,24 @@ jobs:
       - name: 변화 없음 로그
         if: steps.scan.outputs.worsened == '0' && steps.scan.outputs.new == '0'
         run: echo "✅ 복잡도 변화 없음 (고복잡도 함수 ${{ steps.scan.outputs.total }}개 유지)"
+
+      - name: 텔레그램 알림
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          TOTAL="${{ steps.scan.outputs.total }}"
+          WORSENED="${{ steps.scan.outputs.worsened }}"
+          NEW="${{ steps.scan.outputs.new }}"
+
+          if [ "$WORSENED" != "0" ] || [ "$NEW" != "0" ]; then
+            MESSAGE="$(printf '[주간] 🔍 Radon 코드 품질 스캔\n⚠️ 변화 감지: 악화 %s개, 신규 %s개\n📊 고복잡도 함수: %s개\n→ GitHub 이슈 생성됨' \
+              "$WORSENED" "$NEW" "$TOTAL")"
+          else
+            MESSAGE="$(printf '[주간] ✅ Radon 코드 품질 양호\n📊 고복잡도 함수: %s개 (변화 없음)' "$TOTAL")"
+          fi
+
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" || true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
       - uses: actions/stale@v9
+        id: stale
         with:
           # 60일 미활동 → stale 라벨
           days-before-stale: 60
@@ -39,3 +40,21 @@ jobs:
 
           # Phase 라벨 있는 것도 면제 (로드맵 항목)
           exempt-all-issue-assignees: true
+
+      - name: 텔레그램 알림
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          STALED="${{ steps.stale.outputs.staled-issues-prs }}"
+          CLOSED="${{ steps.stale.outputs.closed-issues-prs }}"
+          if [ -n "$STALED" ] || [ -n "$CLOSED" ]; then
+            MESSAGE="$(printf '[주간] 📋 Stale 이슈 관리\n⏰ stale 라벨: %s개\n🔒 자동 close: %s개' \
+              "${STALED:-0}" "${CLOSED:-0}")"
+          else
+            MESSAGE="[주간] ✅ Stale 이슈 없음"
+          fi
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" || true

--- a/.github/workflows/todo-tracker.yml
+++ b/.github/workflows/todo-tracker.yml
@@ -79,3 +79,19 @@ jobs:
       - name: 깨끗함 로그
         if: steps.scan.outputs.count == '0'
         run: echo "✅ 3개월 이상 된 TODO/FIXME 없음"
+
+      - name: 텔레그램 알림
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          COUNT="${{ steps.scan.outputs.count }}"
+          if [ "$COUNT" != "0" ]; then
+            MESSAGE="[월간] 📝 오래된 TODO/FIXME ${COUNT}개 발견 → 이슈 생성됨"
+          else
+            MESSAGE="[월간] ✅ 오래된 TODO/FIXME 없음"
+          fi
+          curl -sf -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d chat_id="${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MESSAGE}" || true


### PR DESCRIPTION
## Summary

모든 GitHub Actions 워크플로우에서 텔레그램으로 상세 리포트를 받습니다.

### CI 테스트 결과
**Before:** `✅ 테스트 통과 / ❌ 실패`
**After:** `✅ 테스트 통과 + 📈 커버리지: BE 72% / FE 45%`

### CD 배포 결과
**Before:** `✅ 배포 완료 + 커밋 메시지`
**After:**
```
✅ 배포 완료
📝 커밋 메시지
🏥 스모크: 🟢
🕐 시간
📋 최근 변경:
• 커밋1
• 커밋2
• 커밋3
```

### 주간 (금요일)
- Radon: `✅ 양호` 또는 `⚠️ 악화 N개, 신규 N개`
- 브랜치 정리: `🧹 N개 삭제` 또는 `✅ 없음`
- Stale 이슈: `⏰ stale N개, 🔒 close N개`

### 월간 (매월 1일)
- TODO: `📝 오래된 TODO N개` 또는 `✅ 없음`
- Dead code: `🧟 BE N건, FE N건` 또는 `✅ 없음`

🤖 Generated with Claude Code