### PR TITLE
feat: FE 접근성(a11y) 개선 (#257)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import jsxA11y from 'eslint-plugin-jsx-a11y'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
@@ -14,6 +15,7 @@ export default defineConfig([
       tseslint.configs.recommended,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
+      jsxA11y.flatConfigs.recommended,
     ],
     languageOptions: {
       ecmaVersion: 2020,
@@ -23,6 +25,11 @@ export default defineConfig([
       'react-refresh/only-export-components': [
         'warn',
         { allowExportNames: ['useAuth', 'useToast'] },
+      ],
+      // 커스텀 토글(label > div > input.sr-only + div + div > span) 구조 지원 — depth 4
+      'jsx-a11y/label-has-associated-control': [
+        'error',
+        { depth: 4 },
       ],
     },
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "@vitest/coverage-v8": "^4.0.18",
         "@vitest/ui": "^4.0.18",
         "eslint": "^9.39.1",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
@@ -4418,6 +4419,67 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
@@ -4449,6 +4511,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ast-v8-to-istanbul": {
       "version": "0.3.11",
@@ -4518,6 +4587,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.13.5",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
@@ -4527,6 +4606,16 @@
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -5098,6 +5187,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -5479,6 +5575,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
@@ -5631,6 +5740,53 @@
           "optional": true
         }
       }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.0.1",
@@ -7255,6 +7411,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7263,6 +7435,26 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/leven": {
@@ -7886,6 +8078,44 @@
         "es-object-atoms": "^1.0.0",
         "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9067,6 +9297,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string.prototype.matchall": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.18",
     "eslint": "^9.39.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",

--- a/frontend/src/components/CategoryBottomSheet.tsx
+++ b/frontend/src/components/CategoryBottomSheet.tsx
@@ -58,7 +58,8 @@ export default function CategoryBottomSheet({
     : 'bg-grape-50 text-grape-600 font-medium'
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center">
+    <div className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center" role="dialog" aria-modal="true" aria-label="카테고리 변경">
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- 모달 배경 오버레이: Escape 키로 닫기 지원됨 */}
       <div
         className="absolute inset-0 bg-black/40 transition-opacity"
         onClick={onClose}
@@ -69,7 +70,7 @@ export default function CategoryBottomSheet({
       >
         <div className="flex items-center justify-between px-4 pt-4 pb-2 border-b border-[var(--border-subtle)]">
           <h3 className="text-sm font-semibold text-[var(--text-primary)]">카테고리 변경</h3>
-          <button onClick={onClose} className="p-1 rounded-lg hover:bg-[var(--surface-hover)]">
+          <button onClick={onClose} className="p-1 rounded-lg hover:bg-[var(--surface-hover)]" aria-label="닫기">
             <X className="w-4 h-4 text-[var(--text-muted)]" />
           </button>
         </div>

--- a/frontend/src/components/CreateHouseholdModal.tsx
+++ b/frontend/src/components/CreateHouseholdModal.tsx
@@ -74,9 +74,9 @@ export default function CreateHouseholdModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" role="dialog" aria-modal="true" aria-labelledby="create-household-title">
       <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl max-w-md w-full p-6">
-        <h2 className="text-xl font-bold text-[var(--text-primary)] mb-4">
+        <h2 id="create-household-title" className="text-xl font-bold text-[var(--text-primary)] mb-4">
           새 가구 만들기
         </h2>
 

--- a/frontend/src/components/InviteMemberModal.tsx
+++ b/frontend/src/components/InviteMemberModal.tsx
@@ -87,9 +87,9 @@ export default function InviteMemberModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" role="dialog" aria-modal="true" aria-labelledby="invite-member-title">
       <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl max-w-md w-full p-6">
-        <h2 className="text-xl font-bold text-[var(--text-primary)] mb-4">
+        <h2 id="invite-member-title" className="text-xl font-bold text-[var(--text-primary)] mb-4">
           멤버 초대
         </h2>
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -144,7 +144,7 @@ export default function Layout() {
           </div>
 
           {/* 네비게이션 */}
-          <nav className="space-y-1 flex-1 overflow-y-auto">
+          <nav aria-label="사이드바 메뉴" className="space-y-1 flex-1 overflow-y-auto">
             {navItems.map(item => {
               const active = isActive(item.path)
               const Icon = item.icon
@@ -204,7 +204,7 @@ export default function Layout() {
       </div>
 
       {/* 모바일 하단 탭 바 */}
-      <nav className="md:hidden fixed bottom-0 left-0 right-0 z-30 bg-[var(--surface-card)] border-t border-[var(--border-default)] safe-area-bottom">
+      <nav aria-label="하단 탭 메뉴" className="md:hidden fixed bottom-0 left-0 right-0 z-30 bg-[var(--surface-card)] border-t border-[var(--border-default)] safe-area-bottom">
         <div className="flex items-center justify-around h-14 pwa-nav-container">
           {navItems.map(item => {
             const active = isActive(item.path)

--- a/frontend/src/components/ParsedItemPreviewCard.tsx
+++ b/frontend/src/components/ParsedItemPreviewCard.tsx
@@ -98,10 +98,11 @@ export default function ParsedItemPreviewCard({
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {/* 금액 */}
         <div>
-          <label className="block text-xs text-[var(--text-tertiary)] mb-1">금액</label>
+          <label htmlFor={`preview-amount-${index}`} className="block text-xs text-[var(--text-tertiary)] mb-1">금액</label>
           <div className="relative">
             <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] text-sm">₩</span>
             <input
+              id={`preview-amount-${index}`}
               type="number"
               value={item.amount}
               onChange={(e) => onUpdate(index, 'amount', Number(e.target.value))}
@@ -113,8 +114,9 @@ export default function ParsedItemPreviewCard({
 
         {/* 날짜 */}
         <div>
-          <label className="block text-xs text-[var(--text-tertiary)] mb-1">날짜</label>
+          <label htmlFor={`preview-date-${index}`} className="block text-xs text-[var(--text-tertiary)] mb-1">날짜</label>
           <input
+            id={`preview-date-${index}`}
             type="date"
             value={item.date.slice(0, 10)}
             onChange={(e) => onUpdate(index, 'date', e.target.value)}
@@ -124,8 +126,9 @@ export default function ParsedItemPreviewCard({
 
         {/* 설명 */}
         <div>
-          <label className="block text-xs text-[var(--text-tertiary)] mb-1">설명</label>
+          <label htmlFor={`preview-desc-${index}`} className="block text-xs text-[var(--text-tertiary)] mb-1">설명</label>
           <input
+            id={`preview-desc-${index}`}
             type="text"
             value={item.description}
             onChange={(e) => onUpdate(index, 'description', e.target.value)}
@@ -135,8 +138,9 @@ export default function ParsedItemPreviewCard({
 
         {/* 카테고리 */}
         <div>
-          <label className="block text-xs text-[var(--text-tertiary)] mb-1">카테고리</label>
+          <label htmlFor={`preview-category-${index}`} className="block text-xs text-[var(--text-tertiary)] mb-1">카테고리</label>
           <select
+            id={`preview-category-${index}`}
             value={item.category_id ?? ''}
             onChange={(e) =>
               onUpdate(index, 'category_id', e.target.value ? Number(e.target.value) : null)
@@ -164,6 +168,7 @@ export default function ParsedItemPreviewCard({
                     onCreateCategory(index)
                   }
                 }}
+                // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus
               />
               <button
@@ -201,8 +206,9 @@ export default function ParsedItemPreviewCard({
 
         {/* 메모 (선택) */}
         <div className="sm:col-span-2">
-          <label className="block text-xs text-[var(--text-tertiary)] mb-1">메모 (선택)</label>
+          <label htmlFor={`preview-memo-${index}`} className="block text-xs text-[var(--text-tertiary)] mb-1">메모 (선택)</label>
           <input
+            id={`preview-memo-${index}`}
             type="text"
             value={item.memo ?? ''}
             onChange={(e) => onUpdate(index, 'memo', e.target.value)}

--- a/frontend/src/components/RegisterRecurringModal.tsx
+++ b/frontend/src/components/RegisterRecurringModal.tsx
@@ -91,11 +91,11 @@ export default function RegisterRecurringModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true" aria-labelledby="register-recurring-title">
       <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between p-5 border-b border-[var(--border-subtle)]">
-          <h2 className="text-lg font-semibold text-[var(--text-primary)]">반복 거래 등록</h2>
-          <button onClick={onClose} className="p-1 rounded-md hover:bg-[var(--surface-hover)]">
+          <h2 id="register-recurring-title" className="text-lg font-semibold text-[var(--text-primary)]">반복 거래 등록</h2>
+          <button onClick={onClose} className="p-1 rounded-md hover:bg-[var(--surface-hover)]" aria-label="닫기">
             <X className="w-5 h-5 text-[var(--text-tertiary)]" />
           </button>
         </div>
@@ -129,8 +129,9 @@ export default function RegisterRecurringModal({
 
           {/* 반복 빈도 */}
           <div>
-            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 빈도</label>
+            <label htmlFor="recurring-frequency" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 빈도</label>
             <select
+              id="recurring-frequency"
               value={formData.frequency}
               onChange={(e) =>
                 setFormData({ ...formData, frequency: e.target.value as typeof formData.frequency })
@@ -147,9 +148,10 @@ export default function RegisterRecurringModal({
           {/* 빈도별 추가 필드 */}
           {(formData.frequency === 'monthly' || formData.frequency === 'yearly') && (
             <div>
-              <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 날짜</label>
+              <label htmlFor="recurring-day-of-month" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 날짜</label>
               <div className="flex items-center gap-2">
                 <input
+                  id="recurring-day-of-month"
                   type="number"
                   value={formData.day_of_month}
                   onChange={(e) => setFormData({ ...formData, day_of_month: e.target.value })}
@@ -164,8 +166,9 @@ export default function RegisterRecurringModal({
 
           {formData.frequency === 'weekly' && (
             <div>
-              <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">요일</label>
+              <label htmlFor="recurring-day-of-week" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">요일</label>
               <select
+                id="recurring-day-of-week"
                 value={formData.day_of_week}
                 onChange={(e) => setFormData({ ...formData, day_of_week: e.target.value })}
                 className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
@@ -179,8 +182,9 @@ export default function RegisterRecurringModal({
 
           {formData.frequency === 'yearly' && (
             <div>
-              <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 월</label>
+              <label htmlFor="recurring-month-of-year" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 월</label>
               <select
+                id="recurring-month-of-year"
                 value={formData.month_of_year}
                 onChange={(e) => setFormData({ ...formData, month_of_year: e.target.value })}
                 className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
@@ -194,9 +198,10 @@ export default function RegisterRecurringModal({
 
           {formData.frequency === 'custom' && (
             <div>
-              <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 주기</label>
+              <label htmlFor="recurring-interval" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 주기</label>
               <div className="flex items-center gap-2">
                 <input
+                  id="recurring-interval"
                   type="number"
                   value={formData.interval}
                   onChange={(e) => setFormData({ ...formData, interval: e.target.value })}
@@ -210,8 +215,9 @@ export default function RegisterRecurringModal({
 
           {/* 시작일 */}
           <div>
-            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">시작일</label>
+            <label htmlFor="recurring-start-date" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">시작일</label>
             <input
+              id="recurring-start-date"
               type="date"
               value={formData.start_date}
               onChange={(e) => setFormData({ ...formData, start_date: e.target.value })}
@@ -221,8 +227,9 @@ export default function RegisterRecurringModal({
 
           {/* 종료일 */}
           <div>
-            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">종료일 (선택)</label>
+            <label htmlFor="recurring-end-date" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">종료일 (선택)</label>
             <input
+              id="recurring-end-date"
               type="date"
               value={formData.end_date}
               onChange={(e) => setFormData({ ...formData, end_date: e.target.value })}

--- a/frontend/src/components/admin/AdminOverview.tsx
+++ b/frontend/src/components/admin/AdminOverview.tsx
@@ -18,7 +18,10 @@ function StatCard({ icon: Icon, label, value, sub, onClick }: {
   return (
     <div
       className={`bg-[var(--surface-card)] rounded-xl p-4 border border-[var(--border-default)] ${onClick ? 'cursor-pointer hover:border-grape-300 transition-colors' : ''}`}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
       onClick={onClick}
+      onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } } : undefined}
     >
       <div className="flex items-center gap-2 text-[var(--text-tertiary)] mb-1">
         <Icon className="w-4 h-4" />

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -59,8 +59,8 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={contextValue}>
       {children}
-      {/* 토스트 컨테이너: 화면 하단 중앙에 고정 */}
-      <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 pointer-events-none">
+      {/* 토스트 컨테이너: 화면 하단 중앙에 고정 — aria-live로 스크린 리더에 알림 전달 */}
+      <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 pointer-events-none" role="status" aria-live="polite">
         <div className="pointer-events-auto">
           {toasts.map((toast) => (
             <Toast

--- a/frontend/src/pages/AccountManager.tsx
+++ b/frontend/src/pages/AccountManager.tsx
@@ -89,8 +89,9 @@ export default function AccountManager() {
         <form onSubmit={handleCreate} className="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)]/60 shadow-sm p-5 space-y-3">
           <h2 className="text-sm font-semibold text-[var(--text-secondary)]">새 계좌</h2>
           <div>
-            <label className="block text-xs font-medium text-[var(--text-secondary)] mb-1">계좌 유형</label>
+            <label htmlFor="account-type" className="block text-xs font-medium text-[var(--text-secondary)] mb-1">계좌 유형</label>
             <select
+              id="account-type"
               value={form.type}
               onChange={e => setForm(f => ({ ...f, type: e.target.value as AccountType }))}
               className="w-full border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
@@ -101,13 +102,15 @@ export default function AccountManager() {
             </select>
           </div>
           <div>
-            <label className="block text-xs font-medium text-[var(--text-secondary)] mb-1">계좌명</label>
+            <label htmlFor="account-name" className="block text-xs font-medium text-[var(--text-secondary)] mb-1">계좌명</label>
             <input
+              id="account-name"
               type="text"
               value={form.name}
               onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
               placeholder="예) 키움증권, KB국민은행, 업비트"
               className="w-full border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-grape-300"
+              // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus
             />
           </div>

--- a/frontend/src/pages/AssetDashboard.tsx
+++ b/frontend/src/pages/AssetDashboard.tsx
@@ -321,7 +321,7 @@ export default function AssetDashboard() {
       {snapshots.length > 1 && (
         <div className="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)]/60 shadow-sm p-5">
           <h2 className="text-sm font-semibold text-[var(--text-secondary)] mb-4">순자산 추이</h2>
-          <div className="h-56">
+          <div className="h-56" role="img" aria-label="순자산 추이 차트">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={chartData} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
                 <XAxis dataKey="month" tick={{ fontSize: 10 }} />
@@ -430,8 +430,9 @@ export default function AssetDashboard() {
 
       {/* 6. 목표 설정 모달 */}
       {showGoalModal && (
-        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center" role="dialog" aria-modal="true" aria-labelledby="goal-modal-title">
           {/* 배경 오버레이 */}
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- 모달 배경 오버레이 */}
           <div
             className="absolute inset-0 bg-black/40"
             onClick={() => setShowGoalModal(false)}
@@ -439,16 +440,17 @@ export default function AssetDashboard() {
           {/* 모달 본체 */}
           <div className="relative bg-[var(--surface-card)] w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-6 space-y-5 animate-in slide-in-from-bottom sm:slide-in-from-bottom-0">
             <div className="flex items-center justify-between">
-              <h2 className="text-lg font-bold text-[var(--text-primary)]">순자산 목표 설정</h2>
-              <button onClick={() => setShowGoalModal(false)} className="text-[var(--text-muted)] hover:text-[var(--text-secondary)]">
+              <h2 id="goal-modal-title" className="text-lg font-bold text-[var(--text-primary)]">순자산 목표 설정</h2>
+              <button onClick={() => setShowGoalModal(false)} className="text-[var(--text-muted)] hover:text-[var(--text-secondary)]" aria-label="닫기">
                 <X className="w-5 h-5" />
               </button>
             </div>
 
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-[var(--text-secondary)] mb-1">목표 금액</label>
+                <label htmlFor="goal-amount" className="block text-sm font-medium text-[var(--text-secondary)] mb-1">목표 금액</label>
                 <input
+                  id="goal-amount"
                   type="number"
                   value={goalAmount}
                   onChange={e => setGoalAmount(e.target.value)}
@@ -457,8 +459,9 @@ export default function AssetDashboard() {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-[var(--text-secondary)] mb-1">목표 날짜</label>
+                <label htmlFor="goal-date" className="block text-sm font-medium text-[var(--text-secondary)] mb-1">목표 날짜</label>
                 <input
+                  id="goal-date"
                   type="date"
                   value={goalDate}
                   onChange={e => setGoalDate(e.target.value)}

--- a/frontend/src/pages/AssetForm.tsx
+++ b/frontend/src/pages/AssetForm.tsx
@@ -374,8 +374,9 @@ export default function AssetForm() {
         <form onSubmit={handleDirectSave} className="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)]/60 shadow-sm p-6 space-y-5">
           {/* 자산 유형 선택 */}
           <div>
-            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">자산 유형</label>
+            <label htmlFor="asset-type" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">자산 유형</label>
             <select
+              id="asset-type"
               value={assetType}
               onChange={e => {
                 const t = e.target.value as AssetType
@@ -393,8 +394,9 @@ export default function AssetForm() {
           {/* 자산명 (수동형에서만) */}
           {!isInvestmentType && (
             <div>
-              <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">자산명</label>
+              <label htmlFor="asset-name" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">자산명</label>
               <input
+                id="asset-name"
                 type="text"
                 value={form.name ?? ''}
                 onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
@@ -409,7 +411,7 @@ export default function AssetForm() {
           {isInvestmentType && (
             <>
               <div className="relative" ref={dropdownRef}>
-                <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">종목명</label>
+                <label htmlFor="asset-ticker-search" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">종목명</label>
                 {form.ticker && !manualMode ? (
                   /* 선택된 상태 */
                   <div className="flex items-center gap-2 p-2.5 border border-grape-200 bg-grape-50 rounded-lg">
@@ -473,6 +475,7 @@ export default function AssetForm() {
                       onChange={e => setSearchQuery(e.target.value)}
                       onFocus={() => { if (searchResults.length > 0 || searchError) setShowDropdown(true) }}
                       onKeyDown={e => { if (e.key === 'Enter') e.preventDefault() }}
+                      id="asset-ticker-search"
                       placeholder={assetType === 'crypto' ? 'BTC, 비트코인...' : '종목명 또는 코드 검색'}
                       className="w-full border border-[var(--input-border)] rounded-xl pl-9 pr-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                     />
@@ -528,8 +531,9 @@ export default function AssetForm() {
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">수량</label>
+                  <label htmlFor="asset-quantity" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">수량</label>
                   <input
+                    id="asset-quantity"
                     type="number"
                     step="any"
                     value={form.quantity ?? ''}
@@ -539,8 +543,9 @@ export default function AssetForm() {
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">매입 평균가 (원)</label>
+                  <label htmlFor="asset-avg-buy-price" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">매입 평균가 (원)</label>
                   <input
+                    id="asset-avg-buy-price"
                     type="number"
                     step="any"
                     value={form.avg_buy_price ?? ''}
@@ -557,10 +562,11 @@ export default function AssetForm() {
           {isManualType && (
             <>
               <div>
-                <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+                <label htmlFor="asset-manual-value" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
                   {assetType === 'loan' ? '대출 잔액 (원)' : '금액 (원)'}
                 </label>
                 <input
+                  id="asset-manual-value"
                   type="number"
                   step="any"
                   value={form.manual_value ?? ''}
@@ -571,8 +577,9 @@ export default function AssetForm() {
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">이율 (%)</label>
+                  <label htmlFor="asset-interest-rate" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">이율 (%)</label>
                   <input
+                    id="asset-interest-rate"
                     type="number"
                     step="0.01"
                     value={form.interest_rate ?? ''}
@@ -582,8 +589,9 @@ export default function AssetForm() {
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">만기일</label>
+                  <label htmlFor="asset-maturity-date" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">만기일</label>
                   <input
+                    id="asset-maturity-date"
                     type="date"
                     value={form.maturity_date ?? ''}
                     onChange={e => setForm(f => ({ ...f, maturity_date: e.target.value || null }))}
@@ -594,8 +602,9 @@ export default function AssetForm() {
               {assetType === 'loan' && (
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
-                    <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">상환방식</label>
+                    <label htmlFor="asset-repayment-type" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">상환방식</label>
                     <select
+                      id="asset-repayment-type"
                       value={form.repayment_type ?? ''}
                       onChange={e => setForm(f => ({ ...f, repayment_type: e.target.value || null }))}
                       className="w-full border border-[var(--input-border)] rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
@@ -607,8 +616,9 @@ export default function AssetForm() {
                     </select>
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">월 상환액 (원)</label>
+                    <label htmlFor="asset-monthly-payment" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">월 상환액 (원)</label>
                     <input
+                      id="asset-monthly-payment"
                       type="number"
                       step="any"
                       value={form.monthly_payment ?? ''}
@@ -625,8 +635,9 @@ export default function AssetForm() {
           {/* 계좌 선택 (선택) */}
           {accounts.length > 0 && (
             <div>
-              <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">계좌 (선택)</label>
+              <label htmlFor="asset-account" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">계좌 (선택)</label>
               <select
+                id="asset-account"
                 value={form.account_id ?? ''}
                 onChange={e => setForm(f => ({ ...f, account_id: e.target.value ? Number(e.target.value) : null }))}
                 className="w-full border border-[var(--input-border)] rounded-xl px-4 py-3 text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
@@ -641,8 +652,9 @@ export default function AssetForm() {
 
           {/* 메모 */}
           <div>
-            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">메모 (선택)</label>
+            <label htmlFor="asset-memo" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">메모 (선택)</label>
             <input
+              id="asset-memo"
               type="text"
               value={form.memo ?? ''}
               onChange={e => setForm(f => ({ ...f, memo: e.target.value || null }))}

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -223,6 +223,7 @@ export default function CategoryManager() {
                     onChange={(e) => setNewName(e.target.value)}
                     placeholder="카테고리 이름"
                     className="w-full px-3 py-2 border border-[var(--input-border)] rounded-lg focus:ring-2 focus:ring-grape-500 focus:border-transparent"
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus
                   />
                 </td>
@@ -301,6 +302,7 @@ export default function CategoryManager() {
                             setEditForm({ ...editForm, name: e.target.value })
                           }
                           className="w-full px-3 py-2 border border-[var(--input-border)] rounded-lg focus:ring-2 focus:ring-grape-500 focus:border-transparent"
+                          // eslint-disable-next-line jsx-a11y/no-autofocus
                           autoFocus
                         />
                       ) : (

--- a/frontend/src/pages/ExpenseDetail.tsx
+++ b/frontend/src/pages/ExpenseDetail.tsx
@@ -217,11 +217,12 @@ export default function ExpenseDetail() {
       <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-4 sm:p-6 space-y-5">
         {/* 금액 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
+          <label htmlFor="expense-edit-amount" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
             금액
           </label>
           {isEditing ? (
             <input
+              id="expense-edit-amount"
               type="number"
               value={editForm.amount}
               onChange={(e) =>
@@ -239,11 +240,12 @@ export default function ExpenseDetail() {
 
         {/* 설명 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
+          <label htmlFor="expense-edit-description" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
             설명
           </label>
           {isEditing ? (
             <input
+              id="expense-edit-description"
               type="text"
               value={editForm.description}
               onChange={(e) =>
@@ -259,11 +261,12 @@ export default function ExpenseDetail() {
 
         {/* 카테고리 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
+          <label htmlFor="expense-edit-category" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
             카테고리
           </label>
           {isEditing ? (
             <select
+              id="expense-edit-category"
               value={editForm.category_id ?? ''}
               onChange={(e) =>
                 setEditForm({
@@ -287,11 +290,12 @@ export default function ExpenseDetail() {
 
         {/* 날짜 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
+          <label htmlFor="expense-edit-date" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
             날짜
           </label>
           {isEditing ? (
             <input
+              id="expense-edit-date"
               type="date"
               value={editForm.date}
               onChange={(e) =>
@@ -306,11 +310,12 @@ export default function ExpenseDetail() {
 
         {/* 메모 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
+          <label htmlFor="expense-edit-memo" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
             메모
           </label>
           {isEditing ? (
             <input
+              id="expense-edit-memo"
               type="text"
               value={editForm.memo}
               onChange={(e) =>
@@ -328,9 +333,9 @@ export default function ExpenseDetail() {
 
         {/* 통계 제외 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
+          <span className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
             통계 제외
-          </label>
+          </span>
           {isEditing ? (
             <label className="flex items-center gap-3 cursor-pointer select-none">
               <div className="relative">
@@ -353,9 +358,9 @@ export default function ExpenseDetail() {
         {/* 원본 입력 (읽기 전용) */}
         {expense.raw_input && (
           <div>
-            <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
+            <span className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">
               원본 입력
-            </label>
+            </span>
             <p className="text-sm text-[var(--text-secondary)] bg-[var(--surface-elevated)] rounded-lg p-3 font-mono">
               {expense.raw_input}
             </p>
@@ -385,9 +390,9 @@ export default function ExpenseDetail() {
 
       {/* 삭제 확인 모달 */}
       {showDeleteModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" role="dialog" aria-modal="true" aria-labelledby="expense-delete-title">
           <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-2">
+            <h3 id="expense-delete-title" className="text-lg font-semibold text-[var(--text-primary)] mb-2">
               지출 내역 삭제
             </h3>
             <p className="text-[var(--text-secondary)] mb-6">

--- a/frontend/src/pages/ExpenseForm.tsx
+++ b/frontend/src/pages/ExpenseForm.tsx
@@ -348,10 +348,11 @@ export default function ExpenseForm() {
       {mode === 'natural' && !previewItems && (
         <form onSubmit={handlePreview} className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-6 space-y-4">
           <div>
-            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            <label htmlFor="expense-natural-input" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
               말하듯이 지출 입력하기
             </label>
             <textarea
+              id="expense-natural-input"
               value={naturalInput}
               onChange={(e) => setNaturalInput(e.target.value)}
               placeholder="예: 오늘 점심에 김치찌개 8000원 먹었어&#10;어제 스타벅스에서 아메리카노 4500원"
@@ -378,9 +379,9 @@ export default function ExpenseForm() {
       {mode === 'ocr' && !previewItems && (
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-6 space-y-4">
           <div>
-            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            <span className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
               결제 화면 이미지 인식
-            </label>
+            </span>
             <p className="text-xs text-[var(--text-muted)] mb-4">
               토스, 카카오페이, 카드사 앱 결제 화면이나 영수증 사진을 업로드하면 AI가 자동으로 금액과 가맹점을 인식합니다.
             </p>
@@ -394,8 +395,11 @@ export default function ExpenseForm() {
 
             {/* 업로드 버튼 영역 */}
             <div
+              role="button"
+              tabIndex={0}
               className="border-2 border-dashed border-[var(--input-border)] rounded-xl p-8 text-center cursor-pointer hover:border-grape-400 hover:bg-grape-50/30 transition-all"
               onClick={() => fileInputRef.current?.click()}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); fileInputRef.current?.click() } }}
             >
               <Camera className="w-10 h-10 text-[var(--text-muted)] mx-auto mb-3" />
               <p className="text-sm font-medium text-[var(--text-secondary)]">
@@ -611,6 +615,7 @@ export default function ExpenseForm() {
                   placeholder="새 카테고리 이름"
                   className="flex-1 px-3 py-2 border border-grape-300 rounded-lg text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
                   onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleCreateCategoryForForm() } }}
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
                   autoFocus
                 />
                 <button
@@ -672,9 +677,10 @@ export default function ExpenseForm() {
           </div>
 
           {/* 통계 제외 */}
-          <label className="flex items-center gap-3 cursor-pointer select-none">
+          <label htmlFor="expense-exclude-stats" className="flex items-center gap-3 cursor-pointer select-none">
             <div className="relative">
               <input
+                id="expense-exclude-stats"
                 type="checkbox"
                 checked={formData.exclude_from_stats}
                 onChange={(e) => setFormData({ ...formData, exclude_from_stats: e.target.checked })}

--- a/frontend/src/pages/HouseholdListPage.tsx
+++ b/frontend/src/pages/HouseholdListPage.tsx
@@ -137,7 +137,10 @@ export default function HouseholdListPage() {
           {households.map((household) => (
             <div
               key={household.id}
+              role="button"
+              tabIndex={0}
               onClick={() => handleCardClick(household.id)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleCardClick(household.id) } }}
               className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-5 hover:shadow-md hover:border-grape-300 transition-all cursor-pointer"
             >
               {/* 가구 이름 및 역할 */}

--- a/frontend/src/pages/IncomeDetail.tsx
+++ b/frontend/src/pages/IncomeDetail.tsx
@@ -203,9 +203,10 @@ export default function IncomeDetail() {
       <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-4 sm:p-6 space-y-5">
         {/* 금액 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">금액</label>
+          <label htmlFor="income-edit-amount" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">금액</label>
           {isEditing ? (
             <input
+              id="income-edit-amount"
               type="number"
               value={editForm.amount}
               onChange={(e) => setEditForm({ ...editForm, amount: Number(e.target.value) })}
@@ -221,9 +222,10 @@ export default function IncomeDetail() {
 
         {/* 설명 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">설명</label>
+          <label htmlFor="income-edit-description" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">설명</label>
           {isEditing ? (
             <input
+              id="income-edit-description"
               type="text"
               value={editForm.description}
               onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
@@ -237,9 +239,10 @@ export default function IncomeDetail() {
 
         {/* 카테고리 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">카테고리</label>
+          <label htmlFor="income-edit-category" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">카테고리</label>
           {isEditing ? (
             <select
+              id="income-edit-category"
               value={editForm.category_id ?? ''}
               onChange={(e) =>
                 setEditForm({
@@ -263,9 +266,10 @@ export default function IncomeDetail() {
 
         {/* 날짜 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">날짜</label>
+          <label htmlFor="income-edit-date" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">날짜</label>
           {isEditing ? (
             <input
+              id="income-edit-date"
               type="date"
               value={editForm.date}
               onChange={(e) => setEditForm({ ...editForm, date: e.target.value })}
@@ -278,9 +282,10 @@ export default function IncomeDetail() {
 
         {/* 메모 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">메모</label>
+          <label htmlFor="income-edit-memo" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">메모</label>
           {isEditing ? (
             <input
+              id="income-edit-memo"
               type="text"
               value={editForm.memo}
               onChange={(e) => setEditForm({ ...editForm, memo: e.target.value })}
@@ -296,7 +301,7 @@ export default function IncomeDetail() {
 
         {/* 통계 제외 */}
         <div>
-          <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">통계 제외</label>
+          <span className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">통계 제외</span>
           {isEditing ? (
             <label className="flex items-center gap-3 cursor-pointer select-none">
               <div className="relative">
@@ -319,7 +324,7 @@ export default function IncomeDetail() {
         {/* 원본 입력 */}
         {income.raw_input && (
           <div>
-            <label className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">원본 입력</label>
+            <span className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">원본 입력</span>
             <p className="text-sm text-[var(--text-secondary)] bg-[var(--surface-elevated)] rounded-lg p-3 font-mono">
               {income.raw_input}
             </p>
@@ -349,9 +354,9 @@ export default function IncomeDetail() {
 
       {/* 삭제 확인 모달 */}
       {showDeleteModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" role="dialog" aria-modal="true" aria-labelledby="income-delete-title">
           <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-2">수입 내역 삭제</h3>
+            <h3 id="income-delete-title" className="text-lg font-semibold text-[var(--text-primary)] mb-2">수입 내역 삭제</h3>
             <p className="text-[var(--text-secondary)] mb-6">
               정말로 이 수입 내역을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
             </p>

--- a/frontend/src/pages/IncomeForm.tsx
+++ b/frontend/src/pages/IncomeForm.tsx
@@ -298,10 +298,11 @@ export default function IncomeForm() {
       {mode === 'natural' && !previewItems && (
         <form onSubmit={handlePreview} className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-6 space-y-4">
           <div>
-            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+            <label htmlFor="income-natural-input" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
               말하듯이 수입 입력하기
             </label>
             <textarea
+              id="income-natural-input"
               value={naturalInput}
               onChange={(e) => setNaturalInput(e.target.value)}
               placeholder={"예: 이번 달 월급 350만원 들어왔어\n부업으로 50만원 받았어"}
@@ -446,6 +447,7 @@ export default function IncomeForm() {
                   placeholder="새 카테고리 이름"
                   className="flex-1 px-3 py-2 border border-leaf-300 rounded-lg text-sm focus:ring-2 focus:ring-leaf-500/30 focus:border-leaf-500"
                   onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleCreateCategoryForForm() } }}
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
                   autoFocus
                 />
                 <button
@@ -507,9 +509,10 @@ export default function IncomeForm() {
           </div>
 
           {/* 통계 제외 */}
-          <label className="flex items-center gap-3 cursor-pointer select-none">
+          <label htmlFor="income-exclude-stats" className="flex items-center gap-3 cursor-pointer select-none">
             <div className="relative">
               <input
+                id="income-exclude-stats"
                 type="checkbox"
                 checked={formData.exclude_from_stats}
                 onChange={(e) => setFormData({ ...formData, exclude_from_stats: e.target.checked })}

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -115,10 +115,11 @@ export default function OnboardingPage() {
         {/* 새 가계부 만들기 */}
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-5 space-y-4">
           <div>
-            <label className="block text-sm font-medium text-[var(--text-secondary)] mb-1.5">
+            <label htmlFor="onboarding-name" className="block text-sm font-medium text-[var(--text-secondary)] mb-1.5">
               가계부 이름
             </label>
             <input
+              id="onboarding-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -379,13 +379,13 @@ export default function RecurringList() {
 
       {/* 추가/수정 모달 */}
       {showModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true" aria-labelledby="recurring-modal-title">
           <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto">
             <div className="flex items-center justify-between p-5 border-b border-[var(--border-subtle)]">
-              <h2 className="text-lg font-semibold text-[var(--text-primary)]">
+              <h2 id="recurring-modal-title" className="text-lg font-semibold text-[var(--text-primary)]">
                 {editingId ? '반복 거래 수정' : '반복 거래 추가'}
               </h2>
-              <button onClick={() => setShowModal(false)} className="p-1 rounded-md hover:bg-[var(--surface-hover)]">
+              <button onClick={() => setShowModal(false)} className="p-1 rounded-md hover:bg-[var(--surface-hover)]" aria-label="닫기">
                 <X className="w-5 h-5 text-[var(--text-tertiary)]" />
               </button>
             </div>
@@ -393,7 +393,7 @@ export default function RecurringList() {
               {/* 타입 선택 (추가 시에만) */}
               {!editingId && (
                 <div>
-                  <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">유형</label>
+                  <span className="block text-sm font-medium text-[var(--text-secondary)] mb-2">유형</span>
                   <div className="flex gap-2">
                     <button
                       type="button"
@@ -419,8 +419,9 @@ export default function RecurringList() {
 
               {/* 설명 */}
               <div>
-                <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">설명</label>
+                <label htmlFor="reclist-description" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">설명</label>
                 <input
+                  id="reclist-description"
                   type="text"
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
@@ -431,8 +432,9 @@ export default function RecurringList() {
 
               {/* 금액 */}
               <div>
-                <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">금액</label>
+                <label htmlFor="reclist-amount" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">금액</label>
                 <input
+                  id="reclist-amount"
                   type="number"
                   value={formData.amount}
                   onChange={(e) => setFormData({ ...formData, amount: e.target.value })}
@@ -444,8 +446,9 @@ export default function RecurringList() {
 
               {/* 카테고리 */}
               <div>
-                <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">카테고리</label>
+                <label htmlFor="reclist-category" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">카테고리</label>
                 <select
+                  id="reclist-category"
                   value={formData.category_id}
                   onChange={(e) => setFormData({ ...formData, category_id: e.target.value })}
                   className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
@@ -461,8 +464,9 @@ export default function RecurringList() {
               {!editingId && (
                 <>
                   <div>
-                    <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 빈도</label>
+                    <label htmlFor="reclist-frequency" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 빈도</label>
                     <select
+                      id="reclist-frequency"
                       value={formData.frequency}
                       onChange={(e) => setFormData({ ...formData, frequency: e.target.value as typeof formData.frequency })}
                       className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
@@ -477,8 +481,9 @@ export default function RecurringList() {
                   {/* 빈도별 추가 필드 */}
                   {(formData.frequency === 'monthly' || formData.frequency === 'yearly') && (
                     <div>
-                      <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복일</label>
+                      <label htmlFor="reclist-day-of-month" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복일</label>
                       <input
+                        id="reclist-day-of-month"
                         type="number"
                         value={formData.day_of_month}
                         onChange={(e) => setFormData({ ...formData, day_of_month: e.target.value })}
@@ -491,8 +496,9 @@ export default function RecurringList() {
 
                   {formData.frequency === 'weekly' && (
                     <div>
-                      <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">요일</label>
+                      <label htmlFor="reclist-day-of-week" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">요일</label>
                       <select
+                        id="reclist-day-of-week"
                         value={formData.day_of_week}
                         onChange={(e) => setFormData({ ...formData, day_of_week: e.target.value })}
                         className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
@@ -506,8 +512,9 @@ export default function RecurringList() {
 
                   {formData.frequency === 'yearly' && (
                     <div>
-                      <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 월</label>
+                      <label htmlFor="reclist-month-of-year" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 월</label>
                       <select
+                        id="reclist-month-of-year"
                         value={formData.month_of_year}
                         onChange={(e) => setFormData({ ...formData, month_of_year: e.target.value })}
                         className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
@@ -521,8 +528,9 @@ export default function RecurringList() {
 
                   {formData.frequency === 'custom' && (
                     <div>
-                      <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 주기 (일)</label>
+                      <label htmlFor="reclist-interval" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 주기 (일)</label>
                       <input
+                        id="reclist-interval"
                         type="number"
                         value={formData.interval}
                         onChange={(e) => setFormData({ ...formData, interval: e.target.value })}
@@ -534,8 +542,9 @@ export default function RecurringList() {
 
                   {/* 시작일 */}
                   <div>
-                    <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">시작일</label>
+                    <label htmlFor="reclist-start-date" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">시작일</label>
                     <input
+                      id="reclist-start-date"
                       type="date"
                       value={formData.start_date}
                       onChange={(e) => setFormData({ ...formData, start_date: e.target.value })}
@@ -547,8 +556,9 @@ export default function RecurringList() {
 
               {/* 종료일 (항상 표시) */}
               <div>
-                <label className="block text-sm font-medium text-[var(--text-secondary)] mb-2">종료일 (선택)</label>
+                <label htmlFor="reclist-end-date" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">종료일 (선택)</label>
                 <input
+                  id="reclist-end-date"
                   type="date"
                   value={formData.end_date}
                   onChange={(e) => setFormData({ ...formData, end_date: e.target.value })}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -395,6 +395,8 @@ function MyAccountSection() {
                 </div>
                 <p className="text-xs text-[var(--text-tertiary)]">⏰ {expiresAt}까지 유효 (만료 전 입력하세요)</p>
                 <div
+                  role="button"
+                  tabIndex={0}
                   className="bg-[var(--surface-card)] rounded-lg p-3 border border-grape-200 cursor-pointer active:bg-grape-50"
                   onClick={(e) => {
                     const el = e.currentTarget.querySelector('p.selectable')
@@ -404,6 +406,19 @@ function MyAccountSection() {
                       const sel = window.getSelection()
                       sel?.removeAllRanges()
                       sel?.addRange(range)
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      const el = e.currentTarget.querySelector('p.selectable')
+                      if (el && window.getSelection) {
+                        const range = document.createRange()
+                        range.selectNodeContents(el)
+                        const sel = window.getSelection()
+                        sel?.removeAllRanges()
+                        sel?.addRange(range)
+                      }
                     }
                   }}
                 >
@@ -492,6 +507,8 @@ function MyAccountSection() {
                 </div>
                 <p className="text-xs text-[var(--text-tertiary)]">⏰ {kakaoExpiresAt}까지 유효 (만료 전 입력하세요)</p>
                 <div
+                  role="button"
+                  tabIndex={0}
                   className="bg-[var(--surface-card)] rounded-lg p-3 border border-grape-200 cursor-pointer active:bg-grape-50"
                   onClick={(e) => {
                     const el = e.currentTarget.querySelector('p.selectable')
@@ -501,6 +518,19 @@ function MyAccountSection() {
                       const sel = window.getSelection()
                       sel?.removeAllRanges()
                       sel?.addRange(range)
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      const el = e.currentTarget.querySelector('p.selectable')
+                      if (el && window.getSelection) {
+                        const range = document.createRange()
+                        range.selectNodeContents(el)
+                        const sel = window.getSelection()
+                        sel?.removeAllRanges()
+                        sel?.addRange(range)
+                      }
                     }
                   }}
                 >


### PR DESCRIPTION
## Summary

- `eslint-plugin-jsx-a11y` recommended 규칙 적용
- 23개 파일에 aria 속성 보강 + 키보드 접근성 개선

## 변경 내용

### eslint 설정
- `eslint-plugin-jsx-a11y` 설치 + `flatConfigs.recommended` 적용

### aria 속성 (주요)
- 모달/바텀시트: `role="dialog"` + `aria-modal="true"` + `aria-labelledby`
- 토스트: `role="status"` + `aria-live="polite"`
- 차트: `role="img"` + `aria-label`
- 네비게이션: `aria-label` 추가

### 폼 접근성
- 58개 label-input `htmlFor`+`id` 연결

### 키보드 내비게이션
- 클릭 가능한 div에 `role="button"` + `tabIndex={0}` + `onKeyDown` 추가

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 631 tests passed
- [x] `npm run build` — 성공
- [ ] CI 통과

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)