### PR TITLE
feat: 커스텀 메트릭 + 헬스체크 엔드포인트 (#254)

### DIFF
--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -1,0 +1,113 @@
+"""커스텀 메트릭 수집 -- Sentry + 인메모리 카운터 (#254)
+
+Sentry DSN이 설정된 경우 sentry_sdk로 메트릭 전송.
+미설정이어도 인메모리 카운터로 /health 엔드포인트에서 조회 가능.
+"""
+
+import logging
+import time
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MetricCounter:
+    total: int = 0
+    success: int = 0
+    failure: int = 0
+    total_latency_ms: float = 0.0
+
+    @property
+    def success_rate(self) -> float:
+        return (self.success / self.total * 100) if self.total > 0 else 0.0
+
+    @property
+    def avg_latency_ms(self) -> float:
+        return (self.total_latency_ms / self.total) if self.total > 0 else 0.0
+
+
+# 인메모리 메트릭 저장소
+_metrics: dict[str, MetricCounter] = defaultdict(MetricCounter)
+
+
+def record_llm_call(provider: str, success: bool, latency_ms: float) -> None:
+    """LLM API 호출 기록 — 실패해도 비즈니스 로직에 영향 없음"""
+    try:
+        key = f"llm.{provider}"
+        counter = _metrics[key]
+        counter.total += 1
+        if success:
+            counter.success += 1
+        else:
+            counter.failure += 1
+        counter.total_latency_ms += latency_ms
+    except Exception:
+        pass
+
+    # Sentry 메트릭 (DSN 설정 시)
+    try:
+        import sentry_sdk
+
+        sentry_sdk.metrics.incr("llm.call", tags={"provider": provider, "success": str(success)})
+        sentry_sdk.metrics.distribution("llm.latency_ms", latency_ms, tags={"provider": provider})
+    except Exception:
+        pass
+
+
+def record_external_api_call(service: str, success: bool, latency_ms: float) -> None:
+    """외부 API 호출 기록 (네이버, 야후, 업비트, 환율 등) — 실패해도 비즈니스 로직에 영향 없음"""
+    try:
+        key = f"external.{service}"
+        counter = _metrics[key]
+        counter.total += 1
+        if success:
+            counter.success += 1
+        else:
+            counter.failure += 1
+        counter.total_latency_ms += latency_ms
+    except Exception:
+        pass
+
+    try:
+        import sentry_sdk
+
+        sentry_sdk.metrics.incr("external_api.call", tags={"service": service, "success": str(success)})
+    except Exception:
+        pass
+
+
+@asynccontextmanager
+async def track_llm_call(provider: str):
+    """LLM 호출 메트릭 자동 추적 컨텍스트 매니저"""
+    t0 = time.monotonic()
+    success = False
+    try:
+        yield
+        success = True
+    except Exception:
+        raise
+    finally:
+        latency = (time.monotonic() - t0) * 1000
+        record_llm_call(provider=provider, success=success, latency_ms=latency)
+
+
+def get_metrics_summary() -> dict:
+    """현재 메트릭 요약 반환"""
+    return {
+        key: {
+            "total": c.total,
+            "success": c.success,
+            "failure": c.failure,
+            "success_rate": round(c.success_rate, 1),
+            "avg_latency_ms": round(c.avg_latency_ms, 1),
+        }
+        for key, c in _metrics.items()
+    }
+
+
+def reset_metrics() -> None:
+    """메트릭 초기화 (테스트용)"""
+    _metrics.clear()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -272,6 +272,56 @@ async def health():
     return {"status": "healthy"}
 
 
+@app.get("/health/llm")
+async def health_llm():
+    """LLM 프로바이더 헬스체크 (#254)
+
+    프로바이더 인스턴스 생성 가능 여부 + 인메모리 메트릭 요약 반환.
+    실패 시 503 응답.
+    """
+    from app.core.metrics import get_metrics_summary
+    from app.services.llm_service import get_llm_provider
+
+    try:
+        provider = get_llm_provider()
+        provider_name = type(provider).__name__
+        # LLM 관련 메트릭만 필터링
+        all_metrics = get_metrics_summary()
+        llm_metrics = {k: v for k, v in all_metrics.items() if k.startswith("llm.")}
+        return {
+            "status": "healthy",
+            "provider": provider_name,
+            "metrics": llm_metrics,
+        }
+    except Exception as e:
+        return JSONResponse(
+            status_code=503,
+            content={"status": "unhealthy", "error": str(e)},
+        )
+
+
+@app.get("/health/external")
+async def health_external():
+    """외부 API 헬스체크 (#254)
+
+    인메모리 메트릭 기반으로 외부 API 상태 요약 반환.
+    실제 API 호출 없이 기록된 메트릭만 표시.
+    """
+    from app.core.metrics import get_metrics_summary
+
+    all_metrics = get_metrics_summary()
+    external_metrics = {k: v for k, v in all_metrics.items() if k.startswith("external.")}
+
+    if not external_metrics:
+        return {"status": "no_data", "metrics": {}}
+
+    # 실패가 1건이라도 있으면 degraded
+    has_failure = any(m["failure"] > 0 for m in external_metrics.values())
+    status = "degraded" if has_failure else "healthy"
+
+    return {"status": status, "metrics": external_metrics}
+
+
 @app.get("/health/db")
 async def health_db():
     """

--- a/backend/app/services/exchange_rate.py
+++ b/backend/app/services/exchange_rate.py
@@ -5,9 +5,12 @@ frankfurter.app API를 사용하여 외화 → KRW 실시간 환율을 조회합
 """
 
 import logging
+import time
 from datetime import datetime, timedelta
 
 import httpx
+
+from app.core.metrics import record_external_api_call
 
 logger = logging.getLogger(__name__)
 
@@ -42,19 +45,24 @@ async def get_exchange_rate(currency: str) -> float | None:
             return rate
 
     # API 호출
+    t0 = time.monotonic()
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(f"https://api.frankfurter.dev/v1/latest?base={currency}&symbols=KRW")
             resp.raise_for_status()
             data = resp.json()
             rate = data["rates"]["KRW"]
+            latency = (time.monotonic() - t0) * 1000
 
             # 캐시 저장
             _rate_cache[currency] = (rate, now)
+            record_external_api_call(service="frankfurter", success=True, latency_ms=latency)
             logger.info(f"환율 조회 성공: 1 {currency} = {rate:,.2f} KRW")
             return rate
 
     except Exception as e:
+        latency = (time.monotonic() - t0) * 1000
+        record_external_api_call(service="frankfurter", success=False, latency_ms=latency)
         logger.error(f"환율 조회 실패 ({currency}): {e}")
         _rate_cache[currency] = (None, now)  # 실패 캐시 (NEGATIVE_CACHE_TTL 적용, #159)
         return None

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Literal
 
 from app.core.config import settings
+from app.core.metrics import track_llm_call
 
 logger = logging.getLogger(__name__)
 
@@ -117,50 +118,48 @@ class AnthropicProvider(LLMProvider):
         max_retries = 2
         for attempt in range(max_retries):
             try:
-                response = await self.client.messages.create(
-                    model=self.model,
-                    max_tokens=8192,  # Haiku 최대값 — 월간 40건+ 파싱 대응
-                    system=get_expense_parser_prompt(categories=categories, history_hints=history_hints, category_mappings=category_mappings),
-                    messages=[{"role": "user", "content": user_input}],
-                    timeout=25.0,  # LLM 응답 타임아웃 (#172)
-                )
+                async with track_llm_call("anthropic"):
+                    response = await self.client.messages.create(
+                        model=self.model,
+                        max_tokens=8192,  # Haiku 최대값 — 월간 40건+ 파싱 대응
+                        system=get_expense_parser_prompt(categories=categories, history_hints=history_hints, category_mappings=category_mappings),
+                        messages=[{"role": "user", "content": user_input}],
+                        timeout=25.0,  # LLM 응답 타임아웃 (#172)
+                    )
 
-                # 토큰 한도 초과 감지 — JSON이 중간에 잘린 경우
-                if response.stop_reason == "max_tokens":
-                    logger.warning(f"max_tokens 초과: 응답이 잘렸습니다. 입력 길이={len(user_input)}")
-                    return {"error": "입력이 너무 길어 처리할 수 없습니다. 날짜별로 나누어 입력해주세요."}
+                    # 토큰 한도 초과 감지 — JSON이 중간에 잘린 경우
+                    if response.stop_reason == "max_tokens":
+                        logger.warning(f"max_tokens 초과: 응답이 잘렸습니다. 입력 길이={len(user_input)}")
+                        raise ValueError("max_tokens_exceeded")
 
-                # 텍스트 응답에서 JSON 추출 (```json 블록 처리)
-                text = _extract_json_text(response.content[0].text)
+                    # 텍스트 응답에서 JSON 추출 (```json 블록 처리)
+                    text = _extract_json_text(response.content[0].text)
+                    parsed = json.loads(text)
 
-                parsed = json.loads(text)
-
-                # 단일 지출 (dict)인 경우
-                if isinstance(parsed, dict):
-                    # 에러 응답 확인
-                    if "error" in parsed:
+                    # 단일 지출 (dict)인 경우
+                    if isinstance(parsed, dict):
+                        if "error" in parsed:
+                            return parsed
+                        if "amount" not in parsed or parsed["amount"] is None:
+                            return {"error": "금액을 찾을 수 없습니다"}
                         return parsed
 
-                    # 필수 필드 검증
-                    if "amount" not in parsed or parsed["amount"] is None:
-                        return {"error": "금액을 찾을 수 없습니다"}
+                    # 여러 지출 (list)인 경우
+                    elif isinstance(parsed, list):
+                        for item in parsed:
+                            if not isinstance(item, dict):
+                                return {"error": "잘못된 형식입니다"}
+                            if "amount" not in item or item["amount"] is None:
+                                return {"error": "일부 항목의 금액을 찾을 수 없습니다"}
+                        return parsed
 
-                    return parsed
+                    else:
+                        return {"error": "잘못된 형식입니다"}
 
-                # 여러 지출 (list)인 경우
-                elif isinstance(parsed, list):
-                    # 각 항목의 필수 필드 검증
-                    for item in parsed:
-                        if not isinstance(item, dict):
-                            return {"error": "잘못된 형식입니다"}
-                        if "amount" not in item or item["amount"] is None:
-                            return {"error": "일부 항목의 금액을 찾을 수 없습니다"}
-
-                    return parsed
-
-                else:
-                    return {"error": "잘못된 형식입니다"}
-
+            except ValueError as e:
+                if str(e) == "max_tokens_exceeded":
+                    return {"error": "입력이 너무 길어 처리할 수 없습니다. 날짜별로 나누어 입력해주세요."}
+                raise
             except json.JSONDecodeError:
                 logger.warning(f"JSON 파싱 실패 (시도 {attempt + 1}/{max_retries}): {text}")
                 if attempt == max_retries - 1:
@@ -181,50 +180,50 @@ class AnthropicProvider(LLMProvider):
         image_data = base64.b64encode(image_bytes).decode("utf-8")
 
         try:
-            response = await self.client.messages.create(
-                model=self.model,
-                max_tokens=512,
-                system=get_ocr_expense_prompt(),
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "image",
-                                "source": {
-                                    "type": "base64",
-                                    "media_type": media_type,
-                                    "data": image_data,
+            async with track_llm_call("anthropic"):
+                response = await self.client.messages.create(
+                    model=self.model,
+                    max_tokens=512,
+                    system=get_ocr_expense_prompt(),
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": media_type,
+                                        "data": image_data,
+                                    },
                                 },
-                            },
-                            {
-                                "type": "text",
-                                "text": "이 이미지에서 결제 정보를 추출해주세요.",
-                            },
-                        ],
-                    }
-                ],
-            )
+                                {
+                                    "type": "text",
+                                    "text": "이 이미지에서 결제 정보를 추출해주세요.",
+                                },
+                            ],
+                        }
+                    ],
+                )
 
-            text = _extract_json_text(response.content[0].text)
+                text = _extract_json_text(response.content[0].text)
+                parsed = json.loads(text)
 
-            parsed = json.loads(text)
-
-            if isinstance(parsed, dict):
-                if "error" in parsed:
+                if isinstance(parsed, dict):
+                    if "error" in parsed:
+                        return parsed
+                    if "amount" not in parsed or parsed["amount"] is None:
+                        return {"error": "금액을 찾을 수 없습니다"}
                     return parsed
-                if "amount" not in parsed or parsed["amount"] is None:
-                    return {"error": "금액을 찾을 수 없습니다"}
-                return parsed
 
-            elif isinstance(parsed, list):
-                for item in parsed:
-                    if not isinstance(item, dict) or "amount" not in item:
-                        return {"error": "잘못된 형식입니다"}
-                return parsed
+                elif isinstance(parsed, list):
+                    for item in parsed:
+                        if not isinstance(item, dict) or "amount" not in item:
+                            return {"error": "잘못된 형식입니다"}
+                    return parsed
 
-            else:
-                return {"error": "잘못된 형식입니다"}
+                else:
+                    return {"error": "잘못된 형식입니다"}
 
         except json.JSONDecodeError:
             logger.warning(f"OCR JSON 파싱 실패: {text}")
@@ -238,25 +237,25 @@ class AnthropicProvider(LLMProvider):
         from app.services.prompts import INSIGHTS_SYSTEM_PROMPT
 
         try:
-            # 지출 데이터를 텍스트로 정리
-            data_text = json.dumps(expenses_data, ensure_ascii=False, indent=2)
+            async with track_llm_call("anthropic"):
+                data_text = json.dumps(expenses_data, ensure_ascii=False, indent=2)
 
-            response = await self.client.messages.create(
-                model=self.model,
-                max_tokens=2048,
-                system=INSIGHTS_SYSTEM_PROMPT,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": f"다음 지출 데이터를 분석해주세요:\n\n{data_text}",
-                    }
-                ],
-            )
+                response = await self.client.messages.create(
+                    model=self.model,
+                    max_tokens=2048,
+                    system=INSIGHTS_SYSTEM_PROMPT,
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": f"다음 지출 데이터를 분석해주세요:\n\n{data_text}",
+                        }
+                    ],
+                )
 
-            if response.stop_reason == "max_tokens":
-                logger.warning("인사이트 생성: max_tokens 초과로 응답이 잘렸습니다.")
+                if response.stop_reason == "max_tokens":
+                    logger.warning("인사이트 생성: max_tokens 초과로 응답이 잘렸습니다.")
 
-            return response.content[0].text
+                return response.content[0].text
 
         except Exception as e:
             logger.error(f"인사이트 생성 실패: {e}")
@@ -265,12 +264,13 @@ class AnthropicProvider(LLMProvider):
     async def generate(self, prompt: str) -> str:
         """범용 텍스트 생성"""
         try:
-            response = await self.client.messages.create(
-                model=self.model,
-                max_tokens=2048,
-                messages=[{"role": "user", "content": prompt}],
-            )
-            return response.content[0].text
+            async with track_llm_call("anthropic"):
+                response = await self.client.messages.create(
+                    model=self.model,
+                    max_tokens=2048,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                return response.content[0].text
         except Exception as e:
             logger.error(f"Claude generate 실패: {e}")
             return ""
@@ -282,32 +282,33 @@ class AnthropicProvider(LLMProvider):
             COMPREHENSIVE_INSIGHTS_SYSTEM_PROMPT,
         )
 
-        response = await self.client.messages.create(
-            model=self.model,
-            max_tokens=2000,
-            system=COMPREHENSIVE_INSIGHTS_SYSTEM_PROMPT,
-            messages=[
-                {
-                    "role": "user",
-                    "content": f"다음 재무 데이터를 분석해주세요:\n\n{json.dumps(report_data, ensure_ascii=False, indent=2)}",
-                }
-            ],
-            tools=[
-                {
-                    "name": "structured_insights",
-                    "description": "구조화된 재무 인사이트 응답",
-                    "input_schema": COMPREHENSIVE_INSIGHTS_JSON_SCHEMA,
-                }
-            ],
-            tool_choice={"type": "tool", "name": "structured_insights"},
-        )
+        async with track_llm_call("anthropic"):
+            response = await self.client.messages.create(
+                model=self.model,
+                max_tokens=2000,
+                system=COMPREHENSIVE_INSIGHTS_SYSTEM_PROMPT,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": f"다음 재무 데이터를 분석해주세요:\n\n{json.dumps(report_data, ensure_ascii=False, indent=2)}",
+                    }
+                ],
+                tools=[
+                    {
+                        "name": "structured_insights",
+                        "description": "구조화된 재무 인사이트 응답",
+                        "input_schema": COMPREHENSIVE_INSIGHTS_JSON_SCHEMA,
+                    }
+                ],
+                tool_choice={"type": "tool", "name": "structured_insights"},
+            )
 
-        # tool_use 블록에서 구조화된 JSON 추출
-        for block in response.content:
-            if block.type == "tool_use":
-                return block.input
+            # tool_use 블록에서 구조화된 JSON 추출
+            for block in response.content:
+                if block.type == "tool_use":
+                    return block.input
 
-        raise ValueError("LLM이 구조화된 응답을 반환하지 않았습니다")
+            raise ValueError("LLM이 구조화된 응답을 반환하지 않았습니다")
 
 
 class OpenAIProvider(LLMProvider):
@@ -335,55 +336,53 @@ class OpenAIProvider(LLMProvider):
         max_retries = 2
         for attempt in range(max_retries):
             try:
-                response = await self.client.chat.completions.create(
-                    model=self.model,
-                    max_tokens=8192,  # Haiku 최대값 — 월간 40건+ 파싱 대응
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": get_expense_parser_prompt(categories=categories, history_hints=history_hints, category_mappings=category_mappings),
-                        },
-                        {"role": "user", "content": user_input},
-                    ],
-                    timeout=25.0,  # LLM 응답 타임아웃 (#172)
-                )
+                async with track_llm_call("openai"):
+                    response = await self.client.chat.completions.create(
+                        model=self.model,
+                        max_tokens=8192,  # Haiku 최대값 — 월간 40건+ 파싱 대응
+                        messages=[
+                            {
+                                "role": "system",
+                                "content": get_expense_parser_prompt(categories=categories, history_hints=history_hints, category_mappings=category_mappings),
+                            },
+                            {"role": "user", "content": user_input},
+                        ],
+                        timeout=25.0,  # LLM 응답 타임아웃 (#172)
+                    )
 
-                # 토큰 한도 초과 감지
-                if response.choices[0].finish_reason == "length":
-                    logger.warning(f"max_tokens 초과: 응답이 잘렸습니다. 입력 길이={len(user_input)}")
-                    return {"error": "입력이 너무 길어 처리할 수 없습니다. 날짜별로 나누어 입력해주세요."}
+                    # 토큰 한도 초과 감지
+                    if response.choices[0].finish_reason == "length":
+                        logger.warning(f"max_tokens 초과: 응답이 잘렸습니다. 입력 길이={len(user_input)}")
+                        raise ValueError("max_tokens_exceeded")
 
-                # 텍스트 응답에서 JSON 추출 (```json 블록 처리)
-                text = _extract_json_text(response.choices[0].message.content)
+                    # 텍스트 응답에서 JSON 추출 (```json 블록 처리)
+                    text = _extract_json_text(response.choices[0].message.content)
+                    parsed = json.loads(text)
 
-                parsed = json.loads(text)
-
-                # 단일 지출 (dict)인 경우
-                if isinstance(parsed, dict):
-                    # 에러 응답 확인
-                    if "error" in parsed:
+                    # 단일 지출 (dict)인 경우
+                    if isinstance(parsed, dict):
+                        if "error" in parsed:
+                            return parsed
+                        if "amount" not in parsed or parsed["amount"] is None:
+                            return {"error": "금액을 찾을 수 없습니다"}
                         return parsed
 
-                    # 필수 필드 검증
-                    if "amount" not in parsed or parsed["amount"] is None:
-                        return {"error": "금액을 찾을 수 없습니다"}
+                    # 여러 지출 (list)인 경우
+                    elif isinstance(parsed, list):
+                        for item in parsed:
+                            if not isinstance(item, dict):
+                                return {"error": "잘못된 형식입니다"}
+                            if "amount" not in item or item["amount"] is None:
+                                return {"error": "일부 항목의 금액을 찾을 수 없습니다"}
+                        return parsed
 
-                    return parsed
+                    else:
+                        return {"error": "잘못된 형식입니다"}
 
-                # 여러 지출 (list)인 경우
-                elif isinstance(parsed, list):
-                    # 각 항목의 필수 필드 검증
-                    for item in parsed:
-                        if not isinstance(item, dict):
-                            return {"error": "잘못된 형식입니다"}
-                        if "amount" not in item or item["amount"] is None:
-                            return {"error": "일부 항목의 금액을 찾을 수 없습니다"}
-
-                    return parsed
-
-                else:
-                    return {"error": "잘못된 형식입니다"}
-
+            except ValueError as e:
+                if str(e) == "max_tokens_exceeded":
+                    return {"error": "입력이 너무 길어 처리할 수 없습니다. 날짜별로 나누어 입력해주세요."}
+                raise
             except json.JSONDecodeError:
                 logger.warning(f"JSON 파싱 실패 (시도 {attempt + 1}/{max_retries}): {text}")
                 if attempt == max_retries - 1:
@@ -403,22 +402,22 @@ class OpenAIProvider(LLMProvider):
         from app.services.prompts import INSIGHTS_SYSTEM_PROMPT
 
         try:
-            # 지출 데이터를 텍스트로 정리
-            data_text = json.dumps(expenses_data, ensure_ascii=False, indent=2)
+            async with track_llm_call("openai"):
+                data_text = json.dumps(expenses_data, ensure_ascii=False, indent=2)
 
-            response = await self.client.chat.completions.create(
-                model=self.model,
-                max_tokens=2048,
-                messages=[
-                    {"role": "system", "content": INSIGHTS_SYSTEM_PROMPT},
-                    {"role": "user", "content": f"다음 지출 데이터를 분석해주세요:\n\n{data_text}"},
-                ],
-            )
+                response = await self.client.chat.completions.create(
+                    model=self.model,
+                    max_tokens=2048,
+                    messages=[
+                        {"role": "system", "content": INSIGHTS_SYSTEM_PROMPT},
+                        {"role": "user", "content": f"다음 지출 데이터를 분석해주세요:\n\n{data_text}"},
+                    ],
+                )
 
-            if response.choices[0].finish_reason == "length":
-                logger.warning("인사이트 생성: max_tokens 초과로 응답이 잘렸습니다.")
+                if response.choices[0].finish_reason == "length":
+                    logger.warning("인사이트 생성: max_tokens 초과로 응답이 잘렸습니다.")
 
-            return response.choices[0].message.content
+                return response.choices[0].message.content
 
         except Exception as e:
             logger.error(f"인사이트 생성 실패: {e}")
@@ -427,12 +426,13 @@ class OpenAIProvider(LLMProvider):
     async def generate(self, prompt: str) -> str:
         """범용 텍스트 생성"""
         try:
-            response = await self.client.chat.completions.create(
-                model=self.model,
-                max_tokens=2048,
-                messages=[{"role": "user", "content": prompt}],
-            )
-            return response.choices[0].message.content
+            async with track_llm_call("openai"):
+                response = await self.client.chat.completions.create(
+                    model=self.model,
+                    max_tokens=2048,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                return response.choices[0].message.content
         except Exception as e:
             logger.error(f"OpenAI generate 실패: {e}")
             return ""
@@ -444,27 +444,27 @@ class OpenAIProvider(LLMProvider):
             COMPREHENSIVE_INSIGHTS_SYSTEM_PROMPT,
         )
 
-        response = await self.client.chat.completions.create(
-            model=self.model,
-            max_tokens=2000,
-            messages=[
-                {"role": "system", "content": COMPREHENSIVE_INSIGHTS_SYSTEM_PROMPT},
-                {
-                    "role": "user",
-                    "content": f"다음 재무 데이터를 분석해주세요:\n\n{json.dumps(report_data, ensure_ascii=False, indent=2)}",
+        async with track_llm_call("openai"):
+            response = await self.client.chat.completions.create(
+                model=self.model,
+                max_tokens=2000,
+                messages=[
+                    {"role": "system", "content": COMPREHENSIVE_INSIGHTS_SYSTEM_PROMPT},
+                    {
+                        "role": "user",
+                        "content": f"다음 재무 데이터를 분석해주세요:\n\n{json.dumps(report_data, ensure_ascii=False, indent=2)}",
+                    },
+                ],
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "structured_insights",
+                        "schema": COMPREHENSIVE_INSIGHTS_JSON_SCHEMA,
+                        "strict": True,
+                    },
                 },
-            ],
-            response_format={
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "structured_insights",
-                    "schema": COMPREHENSIVE_INSIGHTS_JSON_SCHEMA,
-                    "strict": True,
-                },
-            },
-        )
-
-        return json.loads(response.choices[0].message.content)
+            )
+            return json.loads(response.choices[0].message.content)
 
 
 class GoogleProvider(LLMProvider):

--- a/backend/app/services/price_service.py
+++ b/backend/app/services/price_service.py
@@ -13,6 +13,7 @@ import time
 import httpx
 
 from app.core.config import settings
+from app.core.metrics import record_external_api_call
 from app.services.exchange_rate import get_exchange_rate
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ async def _get_kis_token() -> str | None:
     """한투 API OAuth 토큰 발급/캐싱 (24시간 유효, 1시간 전 갱신)"""
     global _kis_token, _kis_token_expires
 
-    if _kis_token and time.time() < _kis_token_expires - 3600:
+    if _kis_token and time.monotonic() < _kis_token_expires - 3600:
         return _kis_token
 
     if not settings.KIS_APPKEY or not settings.KIS_APPSECRET:
@@ -68,7 +69,7 @@ async def _get_kis_token() -> str | None:
                 _kis_token = data["access_token"]
                 # token_token_expired: "YYYY-MM-DD HH:MM:SS" 형식이지만
                 # 안전하게 현재 + 23시간으로 설정
-                _kis_token_expires = time.time() + 23 * 3600
+                _kis_token_expires = time.monotonic() + 23 * 3600
                 logger.info("한투 API 토큰 발급 성공")
                 return _kis_token
     except Exception:
@@ -104,10 +105,12 @@ async def get_stock_kr_price(ticker: str) -> float | None:
 
 async def _get_stock_kr_price_kis(ticker: str) -> float | None:
     """한투 API 한국 주식 현재가 조회"""
+
     token = await _get_kis_token()
     if not token:
         return None
 
+    t0 = time.monotonic()
     try:
         async with httpx.AsyncClient(timeout=10) as client:
             resp = await client.get(
@@ -124,32 +127,43 @@ async def _get_stock_kr_price_kis(ticker: str) -> float | None:
                     "FID_INPUT_ISCD": ticker,
                 },
             )
+            latency = (time.monotonic() - t0) * 1000
             if resp.status_code == 200:
                 data = resp.json()
                 output = data.get("output", {})
                 price = float(output.get("stck_prpr", 0))
                 if price > 0:
+                    record_external_api_call(service="kis", success=True, latency_ms=latency)
                     return price
+            record_external_api_call(service="kis", success=False, latency_ms=latency)
     except Exception:
+        latency = (time.monotonic() - t0) * 1000
+        record_external_api_call(service="kis", success=False, latency_ms=latency)
         logger.warning("한투 API 시세 조회 실패: %s", ticker)
     return None
 
 
 async def _get_stock_kr_price_naver(ticker: str) -> float | None:
     """네이버 금융 한국 주식 현재가 조회 (fallback)"""
+
+    t0 = time.monotonic()
     try:
         async with httpx.AsyncClient(timeout=10) as client:
             resp = await client.get(
                 f"https://m.stock.naver.com/api/stock/{ticker}/basic",
                 headers={"User-Agent": "Mozilla/5.0"},
             )
+            latency = (time.monotonic() - t0) * 1000
             if resp.status_code == 200:
                 data = resp.json()
                 price = float(data.get("currentPrice", 0))
                 if price > 0:
+                    record_external_api_call(service="naver", success=True, latency_ms=latency)
                     return price
+            record_external_api_call(service="naver", success=False, latency_ms=latency)
     except Exception:
-        pass
+        latency = (time.monotonic() - t0) * 1000
+        record_external_api_call(service="naver", success=False, latency_ms=latency)
     return None
 
 
@@ -174,6 +188,7 @@ async def get_stock_us_price(ticker: str) -> tuple[float | None, float | None]:
                 return None, None
             return cached_usd, cached_usd * usd_krw if usd_krw else None
 
+        t0 = time.monotonic()
         try:
             async with httpx.AsyncClient(timeout=10) as client:
                 resp = await client.get(
@@ -181,15 +196,19 @@ async def get_stock_us_price(ticker: str) -> tuple[float | None, float | None]:
                     params={"interval": "1d", "range": "1d"},
                     headers={"User-Agent": "Mozilla/5.0"},
                 )
+                latency = (time.monotonic() - t0) * 1000
                 if resp.status_code == 200:
                     data = resp.json()
                     meta = data["chart"]["result"][0]["meta"]
                     price_usd = float(meta["regularMarketPrice"])
                     _set_cached(key, price_usd)
+                    record_external_api_call(service="yahoo", success=True, latency_ms=latency)
                     krw_price = price_usd * usd_krw if usd_krw else None
                     return price_usd, krw_price
+                record_external_api_call(service="yahoo", success=False, latency_ms=latency)
         except Exception:
-            pass
+            latency = (time.monotonic() - t0) * 1000
+            record_external_api_call(service="yahoo", success=False, latency_ms=latency)
         _set_cached(key, None)  # 실패 캐시 (#159)
     return None, None
 
@@ -210,20 +229,25 @@ async def get_crypto_price(symbol: str) -> float | None:
             return cached  # type: ignore[return-value]
 
         market = f"KRW-{symbol.upper()}"
+        t0 = time.monotonic()
         try:
             async with httpx.AsyncClient(timeout=10) as client:
                 resp = await client.get(
                     "https://api.upbit.com/v1/ticker",
                     params={"markets": market},
                 )
+                latency = (time.monotonic() - t0) * 1000
                 if resp.status_code == 200:
                     data = resp.json()
                     if data and len(data) > 0:
                         price = float(data[0]["trade_price"])
                         _set_cached(key, price)
+                        record_external_api_call(service="upbit", success=True, latency_ms=latency)
                         return price
+                record_external_api_call(service="upbit", success=False, latency_ms=latency)
         except Exception:
-            pass
+            latency = (time.monotonic() - t0) * 1000
+            record_external_api_call(service="upbit", success=False, latency_ms=latency)
         _set_cached(key, None)  # 실패 캐시 (#159)
     return None
 
@@ -394,7 +418,7 @@ def _get_cached(key: str) -> "float | None | object":
     if key in _price_cache:
         price, ts = _price_cache[key]
         ttl = NEGATIVE_CACHE_TTL if price is None else CACHE_TTL
-        if time.time() - ts < ttl:
+        if time.monotonic() - ts < ttl:
             return price  # None(실패 캐시) 또는 float
         del _price_cache[key]
     return _CACHE_MISS
@@ -402,4 +426,4 @@ def _get_cached(key: str) -> "float | None | object":
 
 def _set_cached(key: str, price: float | None) -> None:
     """캐시 저장 — None이면 실패 캐시 (NEGATIVE_CACHE_TTL 적용) (#159)"""
-    _price_cache[key] = (price, time.time())
+    _price_cache[key] = (price, time.monotonic())

--- a/backend/tests/integration/test_health_endpoints.py
+++ b/backend/tests/integration/test_health_endpoints.py
@@ -1,0 +1,88 @@
+"""헬스체크 엔드포인트 통합 테스트 (#254)
+
+/health/llm, /health/external 엔드포인트 동작 검증.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+class TestHealthLLM:
+    """GET /health/llm 엔드포인트 테스트"""
+
+    async def test_health_llm_returns_healthy(self, client: AsyncClient):
+        """LLM 프로바이더가 정상이면 200 + healthy 상태를 반환한다"""
+        response = await client.get("/health/llm")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert "provider" in data
+
+    async def test_health_llm_returns_unhealthy_on_failure(self, client: AsyncClient):
+        """LLM 프로바이더 초기화 실패 시 503을 반환한다"""
+        with patch("app.services.llm_service.get_llm_provider", side_effect=Exception("API key missing")):
+            response = await client.get("/health/llm")
+            assert response.status_code == 503
+            data = response.json()
+            assert data["status"] == "unhealthy"
+
+
+@pytest.mark.asyncio
+class TestHealthExternal:
+    """GET /health/external 엔드포인트 테스트"""
+
+    async def test_health_external_returns_status(self, client: AsyncClient):
+        """외부 API 메트릭 요약을 반환한다"""
+        response = await client.get("/health/external")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] in ("healthy", "degraded", "no_data")
+        assert "metrics" in data
+
+    async def test_health_external_partial_failure(self, client: AsyncClient):
+        """일부 외부 API 실패 시에도 200 + degraded 상태를 반환한다"""
+        from app.core.metrics import record_external_api_call, reset_metrics
+
+        reset_metrics()
+        # 성공 1건 + 실패 1건 기록
+        record_external_api_call(service="naver", success=True, latency_ms=50.0)
+        record_external_api_call(service="upbit", success=False, latency_ms=100.0)
+
+        response = await client.get("/health/external")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "degraded"
+        assert "external.naver" in data["metrics"]
+        assert "external.upbit" in data["metrics"]
+
+        # 정리
+        reset_metrics()
+
+    async def test_health_external_all_healthy(self, client: AsyncClient):
+        """모든 외부 API가 성공이면 healthy 상태를 반환한다"""
+        from app.core.metrics import record_external_api_call, reset_metrics
+
+        reset_metrics()
+        record_external_api_call(service="naver", success=True, latency_ms=50.0)
+        record_external_api_call(service="yahoo", success=True, latency_ms=80.0)
+
+        response = await client.get("/health/external")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+
+        reset_metrics()
+
+    async def test_health_external_no_data(self, client: AsyncClient):
+        """메트릭 데이터가 없으면 no_data 상태를 반환한다"""
+        from app.core.metrics import reset_metrics
+
+        reset_metrics()
+
+        response = await client.get("/health/external")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "no_data"

--- a/backend/tests/unit/test_metrics.py
+++ b/backend/tests/unit/test_metrics.py
@@ -1,0 +1,100 @@
+"""커스텀 메트릭 모듈 단위 테스트 (#254)"""
+
+import pytest
+
+
+class TestMetricsModule:
+    """app.core.metrics 모듈 존재 및 기본 기능 테스트"""
+
+    def test_metrics_module_exists(self):
+        """metrics 모듈을 import할 수 있다"""
+        from app.core.metrics import get_metrics_summary, reset_metrics
+
+        assert callable(get_metrics_summary)
+        assert callable(reset_metrics)
+
+    def test_record_llm_call_function_exists(self):
+        """record_llm_call 함수가 존재하고 호출 가능하다"""
+        from app.core.metrics import record_llm_call
+
+        assert callable(record_llm_call)
+
+    def test_record_external_api_call_function_exists(self):
+        """record_external_api_call 함수가 존재하고 호출 가능하다"""
+        from app.core.metrics import record_external_api_call
+
+        assert callable(record_external_api_call)
+
+    def test_record_llm_call_success(self):
+        """LLM 호출 성공을 기록하면 메트릭에 반영된다"""
+        from app.core.metrics import get_metrics_summary, record_llm_call, reset_metrics
+
+        reset_metrics()
+        record_llm_call(provider="anthropic", success=True, latency_ms=150.0)
+
+        summary = get_metrics_summary()
+        assert "llm.anthropic" in summary
+        assert summary["llm.anthropic"]["total"] == 1
+        assert summary["llm.anthropic"]["success"] == 1
+        assert summary["llm.anthropic"]["failure"] == 0
+        assert summary["llm.anthropic"]["avg_latency_ms"] == 150.0
+
+    def test_record_llm_call_failure(self):
+        """LLM 호출 실패를 기록하면 메트릭에 반영된다"""
+        from app.core.metrics import get_metrics_summary, record_llm_call, reset_metrics
+
+        reset_metrics()
+        record_llm_call(provider="openai", success=False, latency_ms=5000.0)
+
+        summary = get_metrics_summary()
+        assert summary["llm.openai"]["total"] == 1
+        assert summary["llm.openai"]["success"] == 0
+        assert summary["llm.openai"]["failure"] == 1
+
+    def test_record_llm_call_success_rate(self):
+        """여러 호출 후 성공률이 올바르게 계산된다"""
+        from app.core.metrics import get_metrics_summary, record_llm_call, reset_metrics
+
+        reset_metrics()
+        record_llm_call(provider="anthropic", success=True, latency_ms=100.0)
+        record_llm_call(provider="anthropic", success=True, latency_ms=200.0)
+        record_llm_call(provider="anthropic", success=False, latency_ms=300.0)
+
+        summary = get_metrics_summary()
+        assert summary["llm.anthropic"]["total"] == 3
+        assert summary["llm.anthropic"]["success"] == 2
+        assert summary["llm.anthropic"]["success_rate"] == pytest.approx(66.7, abs=0.1)
+        assert summary["llm.anthropic"]["avg_latency_ms"] == 200.0
+
+    def test_record_external_api_call_success(self):
+        """외부 API 호출을 기록하면 메트릭에 반영된다"""
+        from app.core.metrics import get_metrics_summary, record_external_api_call, reset_metrics
+
+        reset_metrics()
+        record_external_api_call(service="naver", success=True, latency_ms=50.0)
+        record_external_api_call(service="upbit", success=False, latency_ms=10000.0)
+
+        summary = get_metrics_summary()
+        assert "external.naver" in summary
+        assert summary["external.naver"]["total"] == 1
+        assert summary["external.naver"]["success"] == 1
+        assert "external.upbit" in summary
+        assert summary["external.upbit"]["failure"] == 1
+
+    def test_reset_metrics_clears_all(self):
+        """reset_metrics 호출 후 메트릭이 비어있다"""
+        from app.core.metrics import get_metrics_summary, record_llm_call, reset_metrics
+
+        record_llm_call(provider="test", success=True, latency_ms=10.0)
+        reset_metrics()
+
+        summary = get_metrics_summary()
+        assert len(summary) == 0
+
+    def test_empty_metrics_summary(self):
+        """초기 상태에서 메트릭 요약이 빈 딕셔너리이다"""
+        from app.core.metrics import get_metrics_summary, reset_metrics
+
+        reset_metrics()
+        summary = get_metrics_summary()
+        assert summary == {}

--- a/backend/tests/unit/test_price_service.py
+++ b/backend/tests/unit/test_price_service.py
@@ -233,6 +233,6 @@ def test_price_cache_ttl():
     assert _get_cached("test:CACHE_DIFFERENT_KEY") is _CACHE_MISS
 
     # 3. 만료: TTL 초과 항목은 _CACHE_MISS 반환 + 캐시에서 삭제
-    price_service._price_cache["test:EXPIRED"] = (9999.0, time.time() - price_service.CACHE_TTL - 1)
+    price_service._price_cache["test:EXPIRED"] = (9999.0, time.monotonic() - price_service.CACHE_TTL - 1)
     assert _get_cached("test:EXPIRED") is _CACHE_MISS
     assert "test:EXPIRED" not in price_service._price_cache


### PR DESCRIPTION
## Summary

- 인메모리 메트릭 카운터 + 선택적 Sentry 메트릭 전송
- `/health/llm`, `/health/external` 헬스체크 엔드포인트 추가
- LLM/외부 API 호출에 메트릭 계측 적용

## 변경 내용

### 신규: `core/metrics.py`
- `record_llm_call()`, `record_external_api_call()` — try/except 보호, 비즈니스 로직 영향 없음
- `track_llm_call()` — async context manager로 LLM 계측 코드 통합
- `get_metrics_summary()`, `reset_metrics()` — 헬스체크/테스트용

### 헬스체크 엔드포인트
- `/health/llm` — LLM 프로바이더 상태 + 호출 성공률/레이턴시
- `/health/external` — 외부 API(KIS/네이버/Yahoo/업비트/환율) 메트릭 요약

### 계측 적용
- `llm_service.py`: AnthropicProvider/OpenAIProvider 10개 메서드에 `track_llm_call` context manager
- `price_service.py`: 4개 외부 API 호출에 `record_external_api_call`
- `exchange_rate.py`: frankfurter API에 `record_external_api_call`
- `time.time()` → `time.monotonic()` 통일

## 코드 리뷰 반영
- C1: 메트릭 함수 내부 try/except 래핑 (비즈니스 로직 보호)
- C2: time.monotonic() 통일
- I1: 56개 개별 record_llm_call → 10개 context manager로 통합
- I3: 함수 내부 import → 모듈 레벨 import

## Test plan

- [x] 신규 테스트 15개 (단위 9 + 통합 6)
- [x] 전체 749 passed, 5 skipped
- [x] ruff lint/format 통과
- [ ] CI 통과

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)