### PR TITLE
fix: 모바일 date input 오버플로우 + PWA pull-to-refresh 수정 (#114, #72)

### DIFF
--- a/frontend/src/components/PullToRefresh.tsx
+++ b/frontend/src/components/PullToRefresh.tsx
@@ -58,9 +58,12 @@ export default function PullToRefresh({ onRefresh, children }: PullToRefreshProp
     let isPulling = false
 
     const getScrollTop = (): number => {
+      // window 스크롤 우선 — Layout의 <main>에 overflow 없으므로 스크롤은 window에서 발생
+      if (window.scrollY > 0) return window.scrollY
+      // fallback: 스크롤 컨테이너가 별도로 있는 경우
       const main = el.closest('main')
-      if (main) return main.scrollTop
-      return window.scrollY
+      if (main && main.scrollTop > 0) return main.scrollTop
+      return 0
     }
 
     // non-passive: 당기는 중에만 등록

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -193,3 +193,12 @@ body {
 .animate-slide-up {
   animation: slide-up 0.25s ease-out;
 }
+
+/* iOS 네이티브 date input이 w-full을 무시하고 컨테이너 밖으로 넘치는 버그 수정 (#114) */
+input[type="date"],
+input[type="datetime-local"] {
+  max-width: 100%;
+  box-sizing: border-box;
+  -webkit-appearance: none;
+  appearance: none;
+}


### PR DESCRIPTION
## Summary

- close #114 모바일 달력 선택 UI가 화면 범위를 넘어가는 버그
- close #72 풀-투-리프레시 PWA 전용으로 고도화

### #114: date input 오버플로우
- iOS 네이티브 `<input type="date">`가 `w-full`을 무시하고 컨테이너 밖으로 넘침
- `index.css`에 글로벌 CSS 추가: `max-width: 100%` + `box-sizing: border-box` + `-webkit-appearance: none`
- ExpenseDetail, IncomeDetail, ExpenseForm, IncomeForm 4개 페이지 모두 영향

### #72: PWA pull-to-refresh 스크롤 오작동
- **원인**: `getScrollTop()`이 `el.closest('main').scrollTop`을 사용하는데, Layout의 `<main>`에 overflow 속성이 없어서 scrollTop이 항상 0. 스크롤 어디에 있든 "맨 위"로 판단.
- **수정**: `window.scrollY`를 우선 체크하도록 변경. 스크롤이 맨 위가 아니면 pull-to-refresh 무시.

🤖 Generated with Claude Code