### PR TITLE
fix: 탭 전환 시 스크롤 위치 초기화 + 서버 설정 핫픽스

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -31,6 +31,11 @@ export default function Layout() {
 
   // 초기 fetch는 ProtectedRoute의 initializeApp()에서 수행
 
+  // 탭 전환 시 스크롤 위치 초기화 — 이전 탭의 스크롤이 다른 탭에 적용되는 문제 방지
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [location.pathname])
+
   useEffect(() => {
     if (!householdDropdownOpen) return
     const handleClick = () => setHouseholdDropdownOpen(false)


### PR DESCRIPTION
## Summary
- 탭 전환 시 이전 탭의 스크롤 위치가 다른 탭에 적용되는 문제 수정 (Layout에 `window.scrollTo(0,0)` 추가)
- Fly.io 시크릿 설정 완료 (코드 외 변경):
  - `ADMIN_USER_ID=1` (dev + prod) — 보안 패치 #133 이후 관리자 메뉴 실종 문제 해결
  - `KAKAO_CALLBACK_ENABLED=true` (dev) — 카카오 에러 1002 (5초 타임아웃 초과) 방지

## Test plan
- [x] 프론트엔드 빌드 통과
- [x] ESLint 통과 (기존 warning만)
- [x] Vitest 67파일 631개 테스트 통과
- [ ] 탭 전환 시 스크롤이 최상단으로 리셋되는지 확인
- [ ] 관리자 메뉴가 정상 표시되는지 확인 (dev/prod)
- [ ] 카카오 봇 입력이 에러 없이 동작하는지 확인 (dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)