### PR TITLE
feat: GA4 Analytics 트래킹 도입 (#78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ Frontend: `frontend/.env.development`:
 - `VITE_API_URL` — API base URL (default: `/api`, proxied by Vite)
 - `VITE_SENTRY_DSN` — Sentry DSN (빈 문자열이면 비활성화)
 - `VITE_SENTRY_ENVIRONMENT` — Sentry 환경
+- `VITE_GA_MEASUREMENT_ID` — Google Analytics 4 Measurement ID (빈 문자열이면 비활성화)
 
 ## Project Documents
 

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -5,3 +5,4 @@ VITE_AUTH_URL=http://localhost:3000
 VITE_AUTH_CALLBACK_URL=http://localhost:5173/auth/callback
 VITE_TELEGRAM_BOT_USERNAME=PodoBudgetDevBot
 VITE_KAKAO_CHANNEL_URL=http://pf.kakao.com/_xkxkAb/chat
+VITE_GA_MEASUREMENT_ID=

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useChangelog } from '../hooks/useChangelog'
+import { trackPageView } from '../utils/analytics'
 
 
 const navItems: { path: string; label: string; icon: LucideIcon }[] = [
@@ -31,9 +32,10 @@ export default function Layout() {
 
   // 초기 fetch는 ProtectedRoute의 initializeApp()에서 수행
 
-  // 탭 전환 시 스크롤 위치 초기화 — 이전 탭의 스크롤이 다른 탭에 적용되는 문제 방지
+  // 탭 전환 시 스크롤 위치 초기화 + 페이지뷰 트래킹
   useEffect(() => {
     window.scrollTo(0, 0)
+    trackPageView(location.pathname)
   }, [location.pathname])
 
   useEffect(() => {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -23,6 +23,7 @@ import type { User } from '../types'
 import authApi from '../api/auth'
 import apiClient from '../api/client'
 import { getCookieToken } from '../utils/token'
+import { identifyUser } from '../utils/analytics'
 
 interface AuthContextType {
   /** 현재 로그인한 사용자 프로필 (API로 로드, null이면 로딩 중이거나 미로그인) */
@@ -158,6 +159,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .then((response) => {
         if (active) {
           setUserProfile(response.data)
+          identifyUser(String(response.data.id))
           setLoadedToken(token)
         }
       })

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import { ToastProvider } from './contexts/ToastContext'
 import { AuthProvider } from './contexts/AuthContext'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { initSentry, getErrorBoundary } from './utils/sentry'
+import { initAnalytics } from './utils/analytics'
 import './index.css'
 import App from './App.tsx'
 
@@ -37,6 +38,7 @@ function SentryFallback() {
 // Sentry 초기화 후 앱 렌더링 (DSN 없으면 즉시 렌더링)
 async function bootstrap() {
   await initSentry()
+  await initAnalytics()
 
   const ErrorBoundary = getErrorBoundary()
 

--- a/frontend/src/pages/AssetForm.tsx
+++ b/frontend/src/pages/AssetForm.tsx
@@ -9,6 +9,7 @@ import { accountApi } from '../api/accounts'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import LoadingSpinner from '../components/LoadingSpinner'
 import type { AssetSearchResult, CreateAssetParams, Account } from '../types'
+import { trackEvent } from '../utils/analytics'
 
 // 한국 주식 정적 종목 리스트 (lazy load)
 let _stocksKrCache: AssetSearchResult[] | null = null
@@ -233,6 +234,7 @@ export default function AssetForm() {
         await assetApi.create(item)
       }
       addToast('success', `${previewItems.length}개 자산이 등록되었습니다`)
+      trackEvent('asset_added')
       navigate('/assets')
     } catch {
       addToast('error', '저장 중 오류가 발생했습니다')
@@ -256,6 +258,7 @@ export default function AssetForm() {
       } else {
         await assetApi.create(form)
         addToast('success', '자산이 등록되었습니다')
+        trackEvent('asset_added')
       }
       navigate('/assets')
     } catch {

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -16,6 +16,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
+import { trackEvent } from '../utils/analytics'
 
 export default function AuthCallbackPage() {
   const navigate = useNavigate()
@@ -45,6 +46,7 @@ export default function AuthCallbackPage() {
   useEffect(() => {
     console.log('[podo-auth] AuthCallback Effect2:', { urlToken: !!urlToken, isAuthenticated, intendedPath })
     if (!urlToken || isAuthenticated) {
+      trackEvent('login')
       navigate(intendedPath, { replace: true })
     }
   }, [isAuthenticated, urlToken, intendedPath, navigate])

--- a/frontend/src/pages/ExpenseForm.tsx
+++ b/frontend/src/pages/ExpenseForm.tsx
@@ -17,6 +17,7 @@ import { chatApi } from '../api/chat'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import type { Category, ParsedExpenseItem } from '../types'
 import ParsedItemPreviewCard from '../components/ParsedItemPreviewCard'
+import { trackEvent } from '../utils/analytics'
 
 type InputMode = 'natural' | 'form' | 'ocr'
 
@@ -96,6 +97,7 @@ export default function ExpenseForm() {
         }))
         setPreviewItems(editables)
         setRawInput(naturalInput.trim())
+        trackEvent('expense_preview', { mode: 'natural', item_count: editables.length })
       } else {
         addToast('info', res.data.message || '지출 정보를 인식하지 못했습니다')
       }
@@ -135,6 +137,7 @@ export default function ExpenseForm() {
         }
         savedCount++
       }
+      trackEvent('expense_saved', { mode: 'natural', item_count: savedCount })
       addToast('success', `🍇 포도알 +${savedCount}! 거래가 저장되었습니다`)
       setPreviewItems(null)
       setNaturalInput('')
@@ -234,6 +237,7 @@ export default function ExpenseForm() {
         }))
         setPreviewItems(editables)
         setRawInput(`[OCR] ${file.name}`)
+        trackEvent('ocr_upload', { item_count: editables.length })
       } else {
         addToast('info', res.data.message || '결제 정보를 인식하지 못했습니다')
         setOcrPreview(null)
@@ -283,6 +287,7 @@ export default function ExpenseForm() {
         memo: formData.memo.trim() || undefined,
         exclude_from_stats: formData.exclude_from_stats,
       })
+      trackEvent('expense_saved', { mode: 'form' })
       addToast('success', '🍇 포도알 +1! 지출이 저장되었습니다')
       setTimeout(() => navigate('/expenses'), 500)
     } catch (error: unknown) {

--- a/frontend/src/pages/FeedbackPage.tsx
+++ b/frontend/src/pages/FeedbackPage.tsx
@@ -10,6 +10,7 @@ import { useToast } from '../hooks/useToast'
 import { feedbackApi } from '../api/feedback'
 import ErrorState from '../components/ErrorState'
 import type { Feedback, FeedbackStatus, FeedbackType } from '../types'
+import { trackEvent } from '../utils/analytics'
 
 const STATUS_LABELS: Record<FeedbackStatus, { text: string; className: string }> = {
   new: { text: '접수', className: 'bg-[var(--surface-hover)] text-[var(--text-secondary)]' },
@@ -65,6 +66,7 @@ export default function FeedbackPage() {
     try {
       await feedbackApi.create({ type, title: title.trim(), content: content.trim() })
       addToast('success', '피드백이 제출되었습니다!')
+      trackEvent('feedback_submitted')
       setTitle('')
       setContent('')
       await loadData()

--- a/frontend/src/pages/HouseholdDetailPage.tsx
+++ b/frontend/src/pages/HouseholdDetailPage.tsx
@@ -17,6 +17,7 @@ import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorState from '../components/ErrorState'
 import type { InviteMemberDto, UpdateHouseholdDto, MemberRole } from '../types'
 import { formatDate, formatRole, getRoleBadgeColor } from '../utils/household'
+import { trackEvent } from '../utils/analytics'
 
 type TabType = 'members' | 'invitations' | 'settings'
 
@@ -122,6 +123,7 @@ export default function HouseholdDetailPage() {
       } else {
         addToast('success', '초대를 전송했습니다')
       }
+      trackEvent('member_invited')
       setShowInviteModal(false)
       // 초대 목록 새로고침
       await fetchHouseholdInvitations(Number(id)).catch(() => {})

--- a/frontend/src/pages/HouseholdListPage.tsx
+++ b/frontend/src/pages/HouseholdListPage.tsx
@@ -16,6 +16,7 @@ import ErrorState from '../components/ErrorState'
 import LoadingSpinner from '../components/LoadingSpinner'
 import type { CreateHouseholdDto } from '../types'
 import { formatDate, formatRole, getRoleBadgeColor } from '../utils/household'
+import { trackEvent } from '../utils/analytics'
 
 export default function HouseholdListPage() {
   const navigate = useNavigate()
@@ -57,6 +58,7 @@ export default function HouseholdListPage() {
     try {
       const newHousehold = await createHousehold(data)
       addToast('success', '가구가 생성되었습니다')
+      trackEvent('household_created')
       setShowCreateModal(false)
       // 생성 후 상세 페이지로 이동
       navigate(`/households/${newHousehold.id}`)

--- a/frontend/src/pages/IncomeForm.tsx
+++ b/frontend/src/pages/IncomeForm.tsx
@@ -16,6 +16,7 @@ import { chatApi } from '../api/chat'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import type { Category, ParsedExpenseItem } from '../types'
 import ParsedItemPreviewCard from '../components/ParsedItemPreviewCard'
+import { trackEvent } from '../utils/analytics'
 
 type InputMode = 'natural' | 'form'
 
@@ -137,6 +138,7 @@ export default function IncomeForm() {
         savedCount++
       }
       addToast('success', `🍇 포도알 +${savedCount}! 수입이 저장되었습니다`)
+      trackEvent('income_saved', { mode: 'natural', item_count: savedCount })
       setPreviewItems(null)
       setNaturalInput('')
       setTimeout(() => navigate('/income'), 500)
@@ -247,6 +249,7 @@ export default function IncomeForm() {
         exclude_from_stats: formData.exclude_from_stats,
       })
       addToast('success', '🍇 포도알 +1! 수입이 저장되었습니다')
+      trackEvent('income_saved', { mode: 'form' })
       setTimeout(() => navigate('/income'), 500)
     } catch (error: unknown) {
       const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '수입 저장에 실패했습니다'

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -29,6 +29,7 @@ import StructuredInsightsView from '../components/stats/StructuredInsightsView'
 
 // 유틸
 import { calculateHealthScore } from '../utils/healthScore'
+import { trackEvent } from '../utils/analytics'
 
 // 타입
 import type {
@@ -202,6 +203,7 @@ export default function InsightsPage() {
 
       const result = await insightsApi.generateComprehensive(requestData)
       setStructuredInsights(result.insights)
+      trackEvent('ai_analysis_requested')
       addToast('success', 'AI 분석이 완료되었습니다')
     } catch {
       addToast('error', 'AI 분석 생성에 실패했습니다')

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -9,6 +9,7 @@ import { Mail } from 'lucide-react'
 import { onboardingApi } from '../api/onboarding'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
+import { trackEvent } from '../utils/analytics'
 
 export default function OnboardingPage() {
   const navigate = useNavigate()
@@ -28,6 +29,7 @@ export default function OnboardingPage() {
       await onboardingApi.createHousehold(name.trim() || undefined)
       await fetchHouseholds()
       addToast('success', '가계부가 생성되었습니다!')
+      trackEvent('onboarding_complete', { method: 'create' })
       navigate('/', { replace: true })
     } catch {
       addToast('error', '가계부 생성에 실패했습니다')
@@ -42,6 +44,7 @@ export default function OnboardingPage() {
     try {
       await acceptInvitation(token)
       addToast('success', `${householdName || '가계부'}에 참여했습니다!`)
+      trackEvent('onboarding_complete', { method: 'accept_invitation' })
       navigate('/', { replace: true })
     } catch {
       addToast('error', '초대 수락에 실패했습니다')

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -34,9 +34,11 @@ export default function PrivacyPolicyPage() {
               <ul className="list-disc list-inside space-y-1 ml-4">
                 <li><strong>필수 항목</strong>: 사용자명, 비밀번호(암호화 저장), 지출 내역(금액, 설명, 카테고리, 날짜)</li>
                 <li><strong>선택 항목</strong>: 이메일(공유 가계부 초대 기능 이용 시 권장)</li>
+                <li><strong>자동 수집 항목</strong>: 서비스 이용 기록(페이지 방문, 기능 사용 빈도), 기기 정보(브라우저 유형, 화면 해상도), 접속 IP</li>
               </ul>
               <p className="mt-2">
                 개인정보는 회원가입 시 사용자가 직접 입력하거나, 서비스 이용 과정에서 자동으로 수집됩니다.
+                서비스 이용 분석을 위해 Google Analytics를 사용하며, 이를 통해 방문 페이지, 체류 시간, 이벤트 정보가 수집됩니다.
               </p>
             </section>
 
@@ -48,6 +50,7 @@ export default function PrivacyPolicyPage() {
                 <li>AI 기반 자동 카테고리 분류 및 인사이트 생성</li>
                 <li>공유 가계부 기능(초대, 멤버 관리)</li>
                 <li>서비스 개선 및 신규 기능 개발</li>
+                <li>서비스 이용 통계 분석(Google Analytics를 통한 사용 패턴 분석)</li>
               </ul>
             </section>
 
@@ -61,6 +64,12 @@ export default function PrivacyPolicyPage() {
                 <li><strong>제공 항목</strong>: 사용자가 입력한 지출 텍스트(예: "오늘 점심에 김치찌개 8000원 먹었어")</li>
                 <li><strong>제공 목적</strong>: 지출 내역 자동 파싱(금액, 카테고리, 날짜 추출) 및 월별 지출 인사이트 생성</li>
                 <li><strong>보유 기간</strong>: 각 제3자의 개인정보처리방침에 따름</li>
+              </ul>
+              <ul className="list-disc list-inside space-y-1 ml-4 mt-3">
+                <li><strong>제공받는 자</strong>: Google (Google Analytics)</li>
+                <li><strong>제공 항목</strong>: 서비스 이용 기록(페이지 방문, 기능 사용 이벤트), 기기 정보, 접속 IP(익명화 처리)</li>
+                <li><strong>제공 목적</strong>: 서비스 이용 통계 분석 및 개선</li>
+                <li><strong>보유 기간</strong>: Google의 개인정보처리방침에 따름</li>
               </ul>
               <p className="mt-2">
                 위 제3자 제공 이외에 법령에 따른 경우를 제외하고는 사용자의 개인정보를 외부에 제공하지 않습니다.

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -15,6 +15,7 @@ import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
 import type { RecurringTransaction, RecurringTransactionCreate, Category } from '../types'
 import { formatAmount } from '../utils/format'
+import { trackEvent } from '../utils/analytics'
 
 /* 빈도 한국어 표시 */
 function formatFrequency(r: RecurringTransaction): string {
@@ -168,6 +169,7 @@ export default function RecurringList() {
         }
         await recurringApi.create(payload)
         addToast('success', '반복 거래가 추가되었습니다')
+        trackEvent('recurring_added')
       }
       setShowModal(false)
       loadData()

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -19,6 +19,7 @@ import { useChangelog } from '../hooks/useChangelog'
 import { useTheme } from '../contexts/ThemeContext'
 import type { ThemeMode } from '../contexts/ThemeContext'
 import type { ChangelogItem } from '../data/changelogs'
+import { trackEvent } from '../utils/analytics'
 
 const AUTH_URL = import.meta.env.VITE_AUTH_URL || 'https://auth.podonest.com'
 
@@ -229,6 +230,7 @@ function MyAccountSection() {
     try {
       const data = await generateTelegramLinkCode()
       setLinkCode(data)
+      trackEvent('telegram_linked')
     } catch {
       addToast('error', '코드 발급에 실패했습니다.')
     } finally {
@@ -266,6 +268,7 @@ function MyAccountSection() {
     try {
       const data = await generateKakaoLinkCode()
       setKakaoLinkCode(data)
+      trackEvent('kakao_linked')
     } catch {
       addToast('error', '코드 발급에 실패했습니다.')
     } finally {

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -1,0 +1,58 @@
+/**
+ * Google Analytics 4 래퍼
+ * VITE_GA_MEASUREMENT_ID가 설정된 경우에만 gtag.js를 동적 로드하여 번들 크기 절감
+ * Sentry 래퍼(utils/sentry.ts)와 동일한 패턴: 미설정 시 모든 함수가 no-op
+ */
+
+let _initialized = false
+
+/** GA4 초기화 — Measurement ID가 있을 때만 gtag.js 로드 */
+export async function initAnalytics(): Promise<void> {
+  const measurementId = import.meta.env.VITE_GA_MEASUREMENT_ID
+  if (!measurementId) return
+
+  // gtag.js 스크립트 동적 삽입
+  const script = document.createElement('script')
+  script.async = true
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`
+  document.head.appendChild(script)
+
+  // gtag 초기화
+  window.dataLayer = window.dataLayer || []
+  window.gtag = function gtag() {
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer!.push(arguments)
+  }
+  window.gtag('js', new Date())
+  window.gtag('config', measurementId, {
+    send_page_view: false, // 수동 page_view 전송 (SPA 라우팅 대응)
+  })
+
+  _initialized = true
+}
+
+/** 커스텀 이벤트 전송 */
+export function trackEvent(eventName: string, params?: Record<string, unknown>): void {
+  if (!_initialized) return
+  window.gtag('event', eventName, params)
+}
+
+/** 페이지뷰 전송 (SPA 라우트 변경 시 호출) */
+export function trackPageView(path: string): void {
+  if (!_initialized) return
+  window.gtag('event', 'page_view', { page_path: path })
+}
+
+/** 사용자 식별 (로그인 후 호출) */
+export function identifyUser(userId: string): void {
+  if (!_initialized) return
+  window.gtag('set', { user_id: userId })
+}
+
+// gtag 타입 선언
+declare global {
+  interface Window {
+    dataLayer?: unknown[]
+    gtag: (...args: unknown[]) => void
+  }
+}


### PR DESCRIPTION
## Summary
- GA4 기반 사용자 행동 분석 트래킹 도입
- `utils/analytics.ts` 래퍼: Sentry 패턴 복제, `VITE_GA_MEASUREMENT_ID` 미설정 시 완전 no-op
- 핵심 퍼널 이벤트 16개 삽입
- 개인정보처리방침 GA4 트래킹 고지 추가

## 핵심 이벤트 (16개)
| 이벤트 | 위치 | 퍼널 |
|--------|------|------|
| `page_view` | Layout (자동) | 전체 |
| `login` | AuthCallbackPage | 가입 |
| `onboarding_complete` | OnboardingPage | 가입 |
| `expense_preview` | ExpenseForm | 입력 |
| `expense_saved` | ExpenseForm | 입력 |
| `income_saved` | IncomeForm | 입력 |
| `ocr_upload` | ExpenseForm | 입력 |
| `ai_analysis_requested` | InsightsPage | 활용 |
| `asset_added` | AssetForm | 활용 |
| `recurring_added` | RecurringList | 활용 |
| `telegram_linked` | SettingsPage | 안착 |
| `kakao_linked` | SettingsPage | 안착 |
| `household_created` | HouseholdListPage | 공유 |
| `member_invited` | HouseholdDetailPage | 공유 |
| `feedback_submitted` | FeedbackPage | 피드백 |
| `identifyUser` | AuthContext | 식별 |

## 배포 시 필요한 작업
- Cloudflare Pages 환경변수에 `VITE_GA_MEASUREMENT_ID` 설정 (GA4 콘솔에서 발급)

## Test plan
- [x] 빌드 통과
- [x] ESLint 0 에러
- [x] 67파일 632개 테스트 통과
- [x] `VITE_GA_MEASUREMENT_ID` 미설정 시 no-op 동작 확인

close #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)