### PR TITLE
토스트 메시지 일관성 정비

### DIFF
--- a/frontend/src/components/admin/AdminFeedbackDashboard.tsx
+++ b/frontend/src/components/admin/AdminFeedbackDashboard.tsx
@@ -29,7 +29,7 @@ export default function AdminFeedbackDashboard() {
       const res = await feedbackApi.getAll()
       setFeedbacks(res.data)
     } catch {
-      addToast('error', '피드백 로딩 실패')
+      addToast('error', '피드백 로딩에 실패했습니다')
     } finally {
       setLoading(false)
     }
@@ -41,9 +41,9 @@ export default function AdminFeedbackDashboard() {
     try {
       const res = await feedbackApi.updateStatus(id, newStatus)
       setFeedbacks(prev => prev.map(f => f.id === id ? res.data : f))
-      addToast('success', '상태 변경 완료')
+      addToast('success', '상태가 변경되었습니다')
     } catch {
-      addToast('error', '상태 변경 실패')
+      addToast('error', '상태 변경에 실패했습니다')
     }
   }
 

--- a/frontend/src/components/admin/AdminUserManager.tsx
+++ b/frontend/src/components/admin/AdminUserManager.tsx
@@ -21,7 +21,7 @@ export default function AdminUserManager() {
       const res = await adminApi.getUserList(page, 20, search || undefined)
       setData(res.data)
     } catch {
-      addToast('error', '사용자 목록 로딩 실패')
+      addToast('error', '사용자 목록 로딩에 실패했습니다')
     } finally {
       setLoading(false)
     }
@@ -40,7 +40,7 @@ export default function AdminUserManager() {
       const res = await adminApi.getUserDetail(userId)
       setSelectedUser(res.data)
     } catch {
-      addToast('error', '사용자 정보 로딩 실패')
+      addToast('error', '사용자 정보 로딩에 실패했습니다')
     }
   }
 
@@ -48,10 +48,10 @@ export default function AdminUserManager() {
     try {
       const res = await adminApi.updateUser(userId, { is_active: !currentActive })
       setSelectedUser(res.data)
-      addToast('success', res.data.is_active ? '사용자 활성화' : '사용자 비활성화')
+      addToast('success', res.data.is_active ? '사용자가 활성화되었습니다' : '사용자가 비활성화되었습니다')
       fetchUsers()
     } catch {
-      addToast('error', '상태 변경 실패')
+      addToast('error', '상태 변경에 실패했습니다')
     }
   }
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -34,7 +34,7 @@ export default function AdminPage() {
       const res = await adminApi.getDashboardStats()
       setDashboard(res.data)
     } catch {
-      addToast('error', '데이터 로딩 실패')
+      addToast('error', '데이터 로딩에 실패했습니다')
     } finally {
       setLoading(false)
       setRefreshing(false)

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -51,7 +51,7 @@ export default function CategoryManager() {
       setCategories(res.data)
     } catch {
       setError(true)
-      addToast('error', '카테고리 목록을 불러오는데 실패했습니다')
+      addToast('error', '카테고리 목록 로딩에 실패했습니다')
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/ExpenseForm.tsx
+++ b/frontend/src/pages/ExpenseForm.tsx
@@ -101,9 +101,8 @@ export default function ExpenseForm() {
       } else {
         addToast('info', res.data.message || '지출 정보를 인식하지 못했습니다')
       }
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '파싱에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', '파싱에 실패했습니다')
     } finally {
       setLoading(false)
     }
@@ -138,13 +137,12 @@ export default function ExpenseForm() {
         savedCount++
       }
       trackEvent('expense_saved', { mode: 'natural', item_count: savedCount })
-      addToast('success', `🍇 포도알 +${savedCount}! 거래가 저장되었습니다`)
+      addToast('success', '거래가 저장되었습니다')
       setPreviewItems(null)
       setNaturalInput('')
       setTimeout(() => navigate('/expenses'), 500)
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '저장에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', '저장에 실패했습니다')
     } finally {
       setLoading(false)
     }
@@ -187,9 +185,8 @@ export default function ExpenseForm() {
       setShowNewCategoryFor(null)
       setNewCategoryName('')
       addToast('success', `"${name}" 카테고리가 추가되었습니다`)
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '카테고리 생성에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', '카테고리 생성에 실패했습니다')
     } finally {
       setCreatingCategory(false)
     }
@@ -208,9 +205,8 @@ export default function ExpenseForm() {
       setShowNewCategoryFor(null)
       setNewCategoryName('')
       addToast('success', `"${name}" 카테고리가 추가되었습니다`)
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '카테고리 생성에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', '카테고리 생성에 실패했습니다')
     } finally {
       setCreatingCategory(false)
     }
@@ -242,9 +238,8 @@ export default function ExpenseForm() {
         addToast('info', res.data.message || '결제 정보를 인식하지 못했습니다')
         setOcrPreview(null)
       }
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || 'OCR 처리에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', 'OCR 처리에 실패했습니다')
       setOcrPreview(null)
     } finally {
       setLoading(false)
@@ -288,11 +283,10 @@ export default function ExpenseForm() {
         exclude_from_stats: formData.exclude_from_stats,
       })
       trackEvent('expense_saved', { mode: 'form' })
-      addToast('success', '🍇 포도알 +1! 지출이 저장되었습니다')
+      addToast('success', '지출이 저장되었습니다')
       setTimeout(() => navigate('/expenses'), 500)
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '지출 저장에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', '지출 저장에 실패했습니다')
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/FeedbackPage.tsx
+++ b/frontend/src/pages/FeedbackPage.tsx
@@ -65,7 +65,7 @@ export default function FeedbackPage() {
     setSubmitting(true)
     try {
       await feedbackApi.create({ type, title: title.trim(), content: content.trim() })
-      addToast('success', '피드백이 제출되었습니다!')
+      addToast('success', '피드백이 제출되었습니다')
       trackEvent('feedback_submitted')
       setTitle('')
       setContent('')

--- a/frontend/src/pages/HouseholdDetailPage.tsx
+++ b/frontend/src/pages/HouseholdDetailPage.tsx
@@ -65,7 +65,7 @@ export default function HouseholdDetailPage() {
     if (id) {
       fetchHouseholdDetail(Number(id)).catch((err) => {
         console.error('가구 상세 조회 실패:', err)
-        addToast('error', '가구 정보를 불러오는데 실패했습니다')
+        addToast('error', '가구 정보 로딩에 실패했습니다')
       })
     }
 
@@ -101,7 +101,7 @@ export default function HouseholdDetailPage() {
    */
   useEffect(() => {
     if (error) {
-      addToast('error', error)
+      addToast('error', '처리에 실패했습니다')
       clearError()
     }
   }, [error, addToast, clearError])
@@ -119,7 +119,7 @@ export default function HouseholdDetailPage() {
         // 이메일 미발송 — 링크 복사 안내
         const link = `${window.location.origin}/invitations/accept?token=${result.token}`
         await navigator.clipboard.writeText(link)
-        addToast('warning', '이메일 발송 실패 — 초대 링크가 클립보드에 복사되었습니다')
+        addToast('warning', '이메일 발송에 실패하여 링크가 복사되었습니다')
       } else {
         addToast('success', '초대를 전송했습니다')
       }

--- a/frontend/src/pages/HouseholdListPage.tsx
+++ b/frontend/src/pages/HouseholdListPage.tsx
@@ -36,7 +36,7 @@ export default function HouseholdListPage() {
   useEffect(() => {
     fetchHouseholds().catch((err) => {
       console.error('가구 목록 조회 실패:', err)
-      addToast('error', '가구 목록을 불러오는데 실패했습니다')
+      addToast('error', '가구 목록 로딩에 실패했습니다')
     })
   }, [fetchHouseholds, addToast])
 
@@ -45,7 +45,7 @@ export default function HouseholdListPage() {
    */
   useEffect(() => {
     if (error) {
-      addToast('error', error)
+      addToast('error', '처리에 실패했습니다')
       clearError()
     }
   }, [error, addToast, clearError])

--- a/frontend/src/pages/IncomeForm.tsx
+++ b/frontend/src/pages/IncomeForm.tsx
@@ -103,13 +103,12 @@ export default function IncomeForm() {
         setRawInput(naturalInput.trim())
         setExpenseCount(expenseItems.length)
       } else if (expenseItems.length > 0) {
-        addToast('info', '입력한 내용이 모두 지출로 분류되었습니다. 지출 입력 페이지를 이용해주세요.')
+        addToast('info', '지출로 분류되었습니다. 지출 입력을 이용해주세요')
       } else {
         addToast('info', res.data.message || '수입 정보를 인식하지 못했습니다')
       }
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '파싱에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', '파싱에 실패했습니다')
     } finally {
       setLoading(false)
     }
@@ -137,14 +136,13 @@ export default function IncomeForm() {
         })
         savedCount++
       }
-      addToast('success', `🍇 포도알 +${savedCount}! 수입이 저장되었습니다`)
+      addToast('success', '수입이 저장되었습니다')
       trackEvent('income_saved', { mode: 'natural', item_count: savedCount })
       setPreviewItems(null)
       setNaturalInput('')
       setTimeout(() => navigate('/income'), 500)
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '저장에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', '저장에 실패했습니다')
     } finally {
       setLoading(false)
     }
@@ -186,9 +184,8 @@ export default function IncomeForm() {
       setShowNewCategoryFor(null)
       setNewCategoryName('')
       addToast('success', `"${name}" 카테고리가 추가되었습니다`)
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '카테고리 생성에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', '카테고리 생성에 실패했습니다')
     } finally {
       setCreatingCategory(false)
     }
@@ -207,9 +204,8 @@ export default function IncomeForm() {
       setShowNewCategoryFor(null)
       setNewCategoryName('')
       addToast('success', `"${name}" 카테고리가 추가되었습니다`)
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '카테고리 생성에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', '카테고리 생성에 실패했습니다')
     } finally {
       setCreatingCategory(false)
     }
@@ -248,12 +244,11 @@ export default function IncomeForm() {
         memo: formData.memo.trim() || undefined,
         exclude_from_stats: formData.exclude_from_stats,
       })
-      addToast('success', '🍇 포도알 +1! 수입이 저장되었습니다')
+      addToast('success', '수입이 저장되었습니다')
       trackEvent('income_saved', { mode: 'form' })
       setTimeout(() => navigate('/income'), 500)
-    } catch (error: unknown) {
-      const errorMsg = (error as { response?: { data?: { detail?: string } } }).response?.data?.detail || '수입 저장에 실패했습니다'
-      addToast('error', errorMsg)
+    } catch {
+      addToast('error', '수입 저장에 실패했습니다')
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/InvitationListPage.tsx
+++ b/frontend/src/pages/InvitationListPage.tsx
@@ -104,7 +104,7 @@ export default function InvitationListPage() {
   useEffect(() => {
     fetchMyInvitations().catch((err) => {
       console.error('초대 목록 조회 실패:', err)
-      addToast('error', '초대 목록을 불러오는데 실패했습니다')
+      addToast('error', '초대 목록 로딩에 실패했습니다')
     })
   }, [fetchMyInvitations, addToast])
 
@@ -113,7 +113,7 @@ export default function InvitationListPage() {
    */
   useEffect(() => {
     if (error) {
-      addToast('error', error)
+      addToast('error', '처리에 실패했습니다')
       clearError()
     }
   }, [error, addToast, clearError])

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -28,7 +28,7 @@ export default function OnboardingPage() {
     try {
       await onboardingApi.createHousehold(name.trim() || undefined)
       await fetchHouseholds()
-      addToast('success', '가계부가 생성되었습니다!')
+      addToast('success', '가계부가 생성되었습니다')
       trackEvent('onboarding_complete', { method: 'create' })
       navigate('/', { replace: true })
     } catch {
@@ -43,7 +43,7 @@ export default function OnboardingPage() {
     setAcceptingToken(token)
     try {
       await acceptInvitation(token)
-      addToast('success', `${householdName || '가계부'}에 참여했습니다!`)
+      addToast('success', `${householdName || '가계부'}에 참여했습니다`)
       trackEvent('onboarding_complete', { method: 'accept_invitation' })
       navigate('/', { replace: true })
     } catch {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -232,7 +232,7 @@ function MyAccountSection() {
       setLinkCode(data)
       trackEvent('telegram_linked')
     } catch {
-      addToast('error', '코드 발급에 실패했습니다.')
+      addToast('error', '코드 발급에 실패했습니다')
     } finally {
       setLoadingCode(false)
     }
@@ -243,11 +243,11 @@ function MyAccountSection() {
     setLoadingUnlink(true)
     try {
       await unlinkTelegram()
-      addToast('success', '텔레그램 연동이 해제되었습니다.')
+      addToast('success', '텔레그램 연동이 해제되었습니다')
       await refreshUser()
       setLinkCode(null)
     } catch {
-      addToast('error', '연동 해제에 실패했습니다.')
+      addToast('error', '연동 해제에 실패했습니다')
     } finally {
       setLoadingUnlink(false)
     }
@@ -257,9 +257,9 @@ function MyAccountSection() {
     if (!linkCode) return
     try {
       await navigator.clipboard.writeText(`/link ${linkCode.code}`)
-      addToast('success', '복사되었습니다!')
+      addToast('success', '복사되었습니다')
     } catch {
-      addToast('error', '자동 복사 실패 — 아래 명령어를 직접 복사해주세요')
+      addToast('error', '자동 복사에 실패했습니다')
     }
   }
 
@@ -270,7 +270,7 @@ function MyAccountSection() {
       setKakaoLinkCode(data)
       trackEvent('kakao_linked')
     } catch {
-      addToast('error', '코드 발급에 실패했습니다.')
+      addToast('error', '코드 발급에 실패했습니다')
     } finally {
       setLoadingKakaoCode(false)
     }
@@ -281,11 +281,11 @@ function MyAccountSection() {
     setLoadingKakaoUnlink(true)
     try {
       await unlinkKakao()
-      addToast('success', '카카오톡 연동이 해제되었습니다.')
+      addToast('success', '카카오톡 연동이 해제되었습니다')
       await refreshUser()
       setKakaoLinkCode(null)
     } catch {
-      addToast('error', '연동 해제에 실패했습니다.')
+      addToast('error', '연동 해제에 실패했습니다')
     } finally {
       setLoadingKakaoUnlink(false)
     }
@@ -296,9 +296,9 @@ function MyAccountSection() {
     try {
       // 카카오 봇은 "연동 {code}" 형식 사용 (한글 명령어 = /link 슬래시 명령어) (#200)
       await navigator.clipboard.writeText(`연동 ${kakaoLinkCode.code}`)
-      addToast('success', '복사되었습니다!')
+      addToast('success', '복사되었습니다')
     } catch {
-      addToast('error', '자동 복사 실패 — 아래 명령어를 직접 복사해주세요')
+      addToast('error', '자동 복사에 실패했습니다')
     }
   }
 
@@ -561,9 +561,9 @@ function MyAccountSection() {
                     try {
                       await navigator.clipboard.writeText(`연동 ${kakaoLinkCode.code}`)
                       window.open(KAKAO_CHANNEL_CHAT_URL, '_blank')
-                      addToast('success', '연동 코드가 복사되었어요. 카카오톡에서 붙여넣기 해주세요!')
+                      addToast('success', '연동 코드가 복사되었습니다')
                     } catch {
-                      addToast('error', '클립보드 복사에 실패했어요')
+                      addToast('error', '복사에 실패했습니다')
                     }
                   }}
                   className="block w-full text-center bg-[#FEE500] text-[#191919] rounded-xl py-3 font-medium hover:bg-[#FDD835] transition-colors"

--- a/frontend/src/pages/TransactionList.tsx
+++ b/frontend/src/pages/TransactionList.tsx
@@ -284,8 +284,8 @@ export default function TransactionList() {
         items={pendingRecurring}
         onExecute={async (id) => {
           try {
-            const res = await recurringApi.execute(id)
-            addToast('success', res.data.message)
+            await recurringApi.execute(id)
+            addToast('success', '거래가 등록되었습니다')
             setPendingRecurring((prev) => prev.filter((r) => r.id !== id))
             fetchData()
           } catch {

--- a/frontend/src/pages/__tests__/CategoryManager.test.tsx
+++ b/frontend/src/pages/__tests__/CategoryManager.test.tsx
@@ -402,7 +402,7 @@ describe('CategoryManager', () => {
 
       await waitFor(() => {
         expect(screen.getByText('문제가 발생했습니다')).toBeInTheDocument()
-        expect(mockAddToast).toHaveBeenCalledWith('error', '카테고리 목록을 불러오는데 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '카테고리 목록 로딩에 실패했습니다')
       })
     })
   })

--- a/frontend/src/pages/__tests__/IncomeForm.test.tsx
+++ b/frontend/src/pages/__tests__/IncomeForm.test.tsx
@@ -159,7 +159,7 @@ describe('IncomeForm', () => {
       fireEvent.submit(submitBtn.closest('form')!)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '🍇 포도알 +1! 수입이 저장되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '수입이 저장되었습니다')
       })
     })
 
@@ -292,7 +292,7 @@ describe('IncomeForm', () => {
       await waitFor(() => {
         expect(mockAddToast).toHaveBeenCalledWith(
           'info',
-          '입력한 내용이 모두 지출로 분류되었습니다. 지출 입력 페이지를 이용해주세요.'
+          '지출로 분류되었습니다. 지출 입력을 이용해주세요'
         )
       })
     })
@@ -361,7 +361,7 @@ describe('IncomeForm', () => {
       await user.click(screen.getByText(/1건 저장하기/))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '🍇 포도알 +1! 수입이 저장되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '수입이 저장되었습니다')
       })
     })
   })

--- a/frontend/src/pages/__tests__/OnboardingPage.test.tsx
+++ b/frontend/src/pages/__tests__/OnboardingPage.test.tsx
@@ -106,7 +106,7 @@ describe('OnboardingPage', () => {
       await user.click(screen.getByRole('button', { name: '새 가계부 만들기' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '가계부가 생성되었습니다!')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '가계부가 생성되었습니다')
         expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
       })
     })
@@ -119,7 +119,7 @@ describe('OnboardingPage', () => {
       await user.type(input, '엔터 테스트{Enter}')
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '가계부가 생성되었습니다!')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '가계부가 생성되었습니다')
       })
     })
 
@@ -170,7 +170,7 @@ describe('OnboardingPage', () => {
 
       await waitFor(() => {
         expect(mockAcceptInvitation).toHaveBeenCalledWith('invite-token-abc')
-        expect(mockAddToast).toHaveBeenCalledWith('success', '부부 가계부에 참여했습니다!')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '부부 가계부에 참여했습니다')
         expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
       })
     })


### PR DESCRIPTION
## Summary
- 전체 130+ addToast 호출을 스타일 가이드에 맞게 정비
- 이모지(🍇) 제거, 종결어미 통일(~했습니다), 느낌표/마침표 제거
- API 에러 원문 노출 제거 → 사용자 친화적 메시지로 대체
- 긴 메시지 간결화 (30자 이내)

## 스타일 가이드
| 규칙 | 기준 |
|------|------|
| 이모지 | 사용 안 함 |
| 종결어미 | `~했습니다` |
| 마침표/느낌표 | 없음 |
| 성공 | `{대상}이/가 {동작}되었습니다` |
| 에러 | `{동작}에 실패했습니다` |

## 변경 파일
- 소스 13개 + 테스트 3개 (메시지 문자열 매칭 동기화)

## Test plan
- [x] FE 632 tests passed, lint 0 errors, build 성공
- [ ] dev 배포 후 주요 플로우 토스트 확인

close #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)