### PR TITLE
fix: Shadow User 생성 레이스 컨디션 수정 (409 Conflict)

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -122,6 +122,10 @@ async def get_current_user(
         return user
 
     # 3단계: 완전히 새로운 유저 자동 생성
+    # 동시 요청 레이스 컨디션 방어: 프론트엔드가 여러 API를 동시 호출하면
+    # 같은 auth_user_id로 INSERT가 중복 실행 → IntegrityError 시 재조회
+    from sqlalchemy.exc import IntegrityError
+
     new_user = User(
         auth_user_id=auth_user_id,
         username=name or email.split("@")[0],
@@ -129,7 +133,17 @@ async def get_current_user(
         hashed_password=None,  # SSO 유저는 로컬 패스워드 없음
     )
     db.add(new_user)
-    await db.commit()
-    await db.refresh(new_user)
-    _auth_id_cache[auth_user_id] = new_user.id
-    return new_user
+    try:
+        await db.commit()
+        await db.refresh(new_user)
+        _auth_id_cache[auth_user_id] = new_user.id
+        return new_user
+    except IntegrityError:
+        await db.rollback()
+        # 다른 요청이 먼저 생성 완료 → 재조회
+        result = await db.execute(select(User).where(User.auth_user_id == auth_user_id))
+        user = result.scalar_one_or_none()
+        if user:
+            _auth_id_cache[auth_user_id] = user.id
+            return user
+        raise credentials_exception from None

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -25,10 +25,32 @@ apiClient.interceptors.request.use(
   (error) => Promise.reject(error)
 )
 
+// 409 Conflict 자동 재시도 (Fly.io 콜드 스타트 또는 동시 요청 레이스 컨디션)
+const MAX_RETRIES = 2
+const RETRY_DELAY = 1500
+
+async function retryOn409(error: unknown): Promise<unknown> {
+  const axiosError = error as import('axios').AxiosError
+  const config = axiosError.config as import('axios').InternalAxiosRequestConfig & { _retryCount?: number }
+  if (!config || axiosError.response?.status !== 409) return Promise.reject(error)
+
+  config._retryCount = (config._retryCount ?? 0) + 1
+  if (config._retryCount > MAX_RETRIES) return Promise.reject(error)
+
+  await new Promise(resolve => setTimeout(resolve, RETRY_DELAY))
+  return apiClient.request(config)
+}
+
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
+  async (error) => {
     const status = error.response?.status
+
+    // 409 Conflict → 자동 재시도
+    if (status === 409) {
+      return retryOn409(error)
+    }
+
     const message = error.response?.data?.detail || '요청 처리 중 오류가 발생했습니다'
 
     // 401은 AuthContext에서 처리 (SSO 리디렉션)


### PR DESCRIPTION
## 문제
새 계정 첫 접속 시 프론트엔드가 여러 API를 동시 호출하면, `get_current_user`에서 같은 `auth_user_id`로 Shadow User를 중복 생성 → `IntegrityError` → 전역 핸들러가 409 Conflict 반환 → 모든 API 실패.

## 수정
- **BE** (`auth.py`): 3단계 유저 생성에서 `IntegrityError` catch → rollback + 재조회
- **FE** (`client.ts`): 409 응답 시 1.5초 후 최대 2회 자동 재시도 (Fly.io 콜드 스타트 대응 포함)

## Test plan
- [x] BE 881 tests passed
- [x] FE lint + build passed
- [ ] dev 환경에서 새 계정 생성 → 정상 접속 확인