### PR TITLE
fix: 뒤로가기 UX 개선 — 진입 경로 기반 네비게이션 (#332)

### DIFF
--- a/frontend/src/hooks/__tests__/useGoBack.test.ts
+++ b/frontend/src/hooks/__tests__/useGoBack.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// react-router-dom mock
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+import { useGoBack } from '../useGoBack'
+
+describe('useGoBack', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('히스토리가 충분하면 navigate(-1) 호출', () => {
+    // history.length > 2: 현재 페이지 + 이전 페이지 존재
+    Object.defineProperty(window, 'history', {
+      value: { length: 3 },
+      writable: true,
+    })
+
+    const { result } = renderHook(() => useGoBack('/settings'))
+    act(() => result.current())
+
+    expect(mockNavigate).toHaveBeenCalledWith(-1)
+  })
+
+  it('히스토리가 없으면 fallback 경로로 이동', () => {
+    Object.defineProperty(window, 'history', {
+      value: { length: 1 },
+      writable: true,
+    })
+
+    const { result } = renderHook(() => useGoBack('/settings'))
+    act(() => result.current())
+
+    expect(mockNavigate).toHaveBeenCalledWith('/settings')
+  })
+
+  it('fallback 기본값은 /', () => {
+    Object.defineProperty(window, 'history', {
+      value: { length: 1 },
+      writable: true,
+    })
+
+    const { result } = renderHook(() => useGoBack())
+    act(() => result.current())
+
+    expect(mockNavigate).toHaveBeenCalledWith('/')
+  })
+})

--- a/frontend/src/hooks/useGoBack.ts
+++ b/frontend/src/hooks/useGoBack.ts
@@ -1,0 +1,20 @@
+/**
+ * 뒤로가기 훅 — 진입 경로에 따라 일관된 네비게이션 (#332)
+ *
+ * 브라우저 히스토리가 있으면 뒤로가기(-1), 없으면 fallback 경로로 이동.
+ * PWA에서 직접 URL 접근 시 히스토리가 없을 수 있으므로 fallback 필수.
+ */
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export function useGoBack(fallback: string = '/') {
+  const navigate = useNavigate()
+
+  return useCallback(() => {
+    if (window.history.length > 2) {
+      navigate(-1)
+    } else {
+      navigate(fallback)
+    }
+  }, [navigate, fallback])
+}

--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useMemo } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useGoBack } from '../hooks/useGoBack'
 import { ArrowLeft, BarChart3, AlertTriangle, Wallet } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import budgetApi from '../api/budgets'
@@ -18,7 +18,7 @@ import type { BudgetAlert, CategoryBudgetOverview } from '../types'
 import { formatAmount } from '../utils/format'
 
 export default function BudgetManager() {
-  const navigate = useNavigate()
+  const goBack = useGoBack('/settings')
   const { addToast } = useToast()
 
   const [overview, setOverview] = useState<CategoryBudgetOverview[]>([])
@@ -218,7 +218,7 @@ export default function BudgetManager() {
 
   return (
     <div className="space-y-6">
-      <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+      <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
         <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
       </button>
 

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useGoBack } from '../hooks/useGoBack'
 import { ArrowLeft, Lock, Plus } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { categoryApi } from '../api/categories'
@@ -15,7 +15,7 @@ import LoadingSpinner from '../components/LoadingSpinner'
 import type { Category } from '../types'
 
 export default function CategoryManager() {
-  const navigate = useNavigate()
+  const goBack = useGoBack('/settings')
   const { addToast } = useToast()
   const [activeTab, setActiveTab] = useState<'expense' | 'income'>('expense')
   const [categories, setCategories] = useState<Category[]>([])
@@ -164,7 +164,7 @@ export default function CategoryManager() {
   if (error) {
     return (
       <div className="space-y-6">
-        <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
           <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
         </button>
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]">
@@ -177,7 +177,7 @@ export default function CategoryManager() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
           <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
         </button>
         <button

--- a/frontend/src/pages/FeedbackPage.tsx
+++ b/frontend/src/pages/FeedbackPage.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useEffect, useState, useCallback } from 'react'
-import { Link } from 'react-router-dom'
+import { useGoBack } from '../hooks/useGoBack'
 import { ArrowLeft, Bug, Lightbulb, MessageSquarePlus, Send } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { feedbackApi } from '../api/feedback'
@@ -27,6 +27,7 @@ const STATUS_LABELS: Record<FeedbackStatus, { text: string; className: string }>
 
 export default function FeedbackPage() {
   const { addToast } = useToast()
+  const goBack = useGoBack('/settings')
   const [type, setType] = useState<FeedbackType>('feature')
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
@@ -96,9 +97,9 @@ export default function FeedbackPage() {
   if (error) {
     return (
       <div className="space-y-6">
-        <Link to="/settings" aria-label="뒤로가기" className="text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] inline-block">
+        <button onClick={goBack} aria-label="뒤로가기" className="text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] inline-block">
           <ArrowLeft className="w-5 h-5" />
-        </Link>
+        </button>
         <ErrorState onRetry={loadData} />
       </div>
     )
@@ -106,9 +107,9 @@ export default function FeedbackPage() {
 
   return (
     <div className="space-y-6">
-      <Link to="/settings" aria-label="뒤로가기" className="text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] inline-block">
+      <button onClick={goBack} aria-label="뒤로가기" className="text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] inline-block">
         <ArrowLeft className="w-5 h-5" />
-      </Link>
+      </button>
 
       {/* 제출 폼 */}
       <form onSubmit={handleSubmit} className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-6 space-y-4">

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -3,7 +3,7 @@
  * @description 사용 가이드 페이지 - 앱 기능별 상세 사용법 안내
  */
 
-import { useNavigate } from 'react-router-dom'
+import { useGoBack } from '../hooks/useGoBack'
 import {
   ArrowLeft,
   MessageSquare,
@@ -62,12 +62,12 @@ function SectionCard({
 }
 
 export default function GuidePage() {
-  const navigate = useNavigate()
+  const goBack = useGoBack('/settings')
 
   return (
     <div className="space-y-6">
       <button
-        onClick={() => navigate('/settings')}
+        onClick={() => goBack()}
         className="w-9 h-9 flex items-center justify-center rounded-xl border border-[var(--border-default)] hover:bg-[var(--surface-hover)] transition-colors"
       >
         <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />

--- a/frontend/src/pages/HouseholdListPage.tsx
+++ b/frontend/src/pages/HouseholdListPage.tsx
@@ -7,6 +7,7 @@
 import type { } from 'react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useGoBack } from '../hooks/useGoBack'
 import { ArrowLeft, Users, Calendar } from 'lucide-react'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
@@ -20,6 +21,7 @@ import { trackEvent } from '../utils/analytics'
 
 export default function HouseholdListPage() {
   const navigate = useNavigate()
+  const goBack = useGoBack('/settings')
   const { addToast } = useToast()
 
   // Zustand 스토어
@@ -90,7 +92,7 @@ export default function HouseholdListPage() {
   if (error && households.length === 0) {
     return (
       <div className="space-y-6">
-        <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
           <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
         </button>
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]">
@@ -105,7 +107,7 @@ export default function HouseholdListPage() {
       {/* 헤더 */}
       <div className="flex items-center justify-between">
         <div>
-          <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+          <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
           <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
         </button>
           <p className="text-sm text-[var(--text-tertiary)] mt-1">

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useGoBack } from '../hooks/useGoBack'
 import { ArrowLeft, Plus, Pencil, Trash2, Pause, Play, X, Zap } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { recurringApi } from '../api/recurring'
@@ -50,7 +50,7 @@ const emptyForm = {
 }
 
 export default function RecurringList() {
-  const navigate = useNavigate()
+  const goBack = useGoBack('/settings')
   const { addToast } = useToast()
   const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
 
@@ -222,7 +222,7 @@ export default function RecurringList() {
   if (error) {
     return (
       <div className="space-y-6">
-        <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
           <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
         </button>
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60">
@@ -236,7 +236,7 @@ export default function RecurringList() {
     <div className="space-y-6">
       {/* 헤더 */}
       <div className="flex items-center justify-between">
-        <button onClick={() => navigate('/settings')} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
           <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
         </button>
         <button

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@
 
 import { useState, useEffect } from 'react'
 import { Link, useParams, useNavigate } from 'react-router-dom'
+import { useGoBack } from '../hooks/useGoBack'
 import {
   Tags, PiggyBank, Repeat, Users, LogOut, BookOpen, MessageSquarePlus,
   Megaphone, ChevronRight, ArrowLeft, User, Send, MessageCircle, ShieldCheck,
@@ -101,11 +102,11 @@ function SettingsMenu({ menuItems }: { menuItems: MenuItem[] }) {
 
 /* ─── 서브 페이지 래퍼 ─── */
 function SubPageWrapper({ children }: { children: React.ReactNode }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack('/settings')
   return (
     <div className="space-y-6">
       <button
-        onClick={() => navigate('/settings')}
+        onClick={() => goBack()}
         className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
       >
         <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />

--- a/frontend/src/pages/__tests__/FeedbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/FeedbackPage.test.tsx
@@ -115,10 +115,10 @@ describe('FeedbackPage', () => {
     expect(screen.getAllByText('다크모드 추가').length).toBeGreaterThan(0)
   })
 
-  it('뒤로가기 링크가 설정 페이지로 이동한다', () => {
+  it('뒤로가기 버튼이 존재한다', () => {
     renderPage()
-    const backLink = screen.getByRole('link', { name: '뒤로가기' })
-    expect(backLink).toHaveAttribute('href', '/settings')
+    const backButton = screen.getByRole('button', { name: '뒤로가기' })
+    expect(backButton).toBeInTheDocument()
   })
 
   it('getMine 에러 시 에러 상태를 표시한다', async () => {


### PR DESCRIPTION
## Summary

- close #332

### 문제
설정 하위 페이지(카테고리, 예산, 정기거래 등)의 뒤로가기 버튼이 항상 `/settings`로 이동.
온보딩 웰컴카드에서 진입해도 설정 리스트로 가서 혼란.

### 해결
`useGoBack(fallback)` 훅 생성:
- 브라우저 히스토리가 있으면 `navigate(-1)` (이전 페이지로)
- 히스토리 없으면 (PWA 직접 접근 등) fallback 경로로 이동

### 변경 파일 (7개 페이지)
| 페이지 | 변경 |
|--------|------|
| CategoryManager | `navigate('/settings')` → `goBack()` |
| BudgetManager | 동일 |
| RecurringList | settings만 goBack, 다른 navigate 유지 |
| GuidePage | 동일 |
| HouseholdListPage | settings만 goBack, 다른 navigate 유지 |
| FeedbackPage | `Link to="/settings"` → `button onClick={goBack}` |
| SettingsPage (SubPageWrapper) | 동일 |

### 테스트
- `useGoBack` 훅 테스트 3개 (TDD)
- FeedbackPage 뒤로가기 테스트 업데이트
- 전체 685개 통과

🤖 Generated with Claude Code