### PR TITLE
fix: budget_bulk 테스트 수정 + CI ignore 제거 (#354, #355)

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -36,4 +36,4 @@ await get_household_member(household_id, current_user, db)
 - DB: SQLite in-memory (StaticPool, CI 속도용), 테스트마다 테이블 생성/삭제. 프로덕션은 Supabase PostgreSQL
 - conftest.py fixtures: `test_user`, `test_household`, `db_session`, `authenticated_client`
 - 테스트 데이터에 household_id 필수 포함
-- 기존 실패 중: `tests/integration/test_api_budget_bulk.py` (CI에서 `--ignore`)
+- `test_api_budget_bulk.py` — 벌크 저장 + 월별 알림 6개 테스트 (#354)

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -34,7 +34,7 @@
 
 2. 작업 + 커밋      (커밋 전 체크 규칙 준수)
 
-3. 로컬 테스트      cd backend && pytest --ignore=tests/integration/test_api_budget_bulk.py
+3. 로컬 테스트      cd backend && pytest
                     cd frontend && npm run lint && npm run test:run && npm run build
 
 4. PR 생성          git push -u origin feature/xxx

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -29,7 +29,7 @@ async def test_기능_설명(authenticated_client, test_user, db_session):
 ### 주의사항
 - 테스트 데이터에 `household_id` 필수 포함
 - rate limiter는 테스트 시 비활성화됨
-- `test_api_budget_bulk.py`는 기존 실패 — CI에서 `--ignore` 처리
+- `test_api_budget_bulk.py` — 벌크 저장 + 월별 알림 6개 테스트 (#354)
 
 ## 프론트엔드 (Vitest + React Testing Library + MSW)
 
@@ -77,7 +77,7 @@ vi.mock('../../hooks/useToast', () => ({
 ## 전체 테스트 실행
 ```bash
 # 백엔드
-cd backend && pytest --ignore=tests/integration/test_api_budget_bulk.py -v
+cd backend && pytest -v
 
 # 프론트엔드
 cd frontend && npm run test:run

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -71,7 +71,6 @@ jobs:
           ANTHROPIC_API_KEY: test-key  # pragma: allowlist secret
         run: |
           PYTHONPATH=backend uv run pytest backend/tests/ \
-            --ignore=backend/tests/integration/test_api_budget_bulk.py \
             --cov=app --cov-report=term --cov-report=json:backend-coverage.json
 
       - name: 커버리지 리포트 업로드

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,5 +169,4 @@ Frontend: `frontend/.env.development`:
 
 ## Known Issues
 
-- `tests/integration/test_api_budget_bulk.py` — 4개 테스트 기존부터 실패 중 (CI에서 `--ignore` 처리됨, 별도 수정 필요)
 - PWA 서비스 워커 캐시: 앱 구조 크게 변경 시 `frontend/vite.config.ts`의 `workbox.cacheId` 버전 올릴 것 (현재 `podo-budget-v2`)

--- a/backend/alembic/versions/d367e7848291_seed_system_categories_and_relink_.py
+++ b/backend/alembic/versions/d367e7848291_seed_system_categories_and_relink_.py
@@ -102,7 +102,7 @@ def upgrade() -> None:
         if new_sys_id is None:
             continue
         old_cats = conn.execute(
-            sa.text("SELECT id FROM categories WHERE name = :name " "AND NOT (user_id IS NULL AND household_id IS NULL)"),
+            sa.text("SELECT id FROM categories WHERE name = :name AND NOT (user_id IS NULL AND household_id IS NULL)"),
             {"name": old_name},
         ).fetchall()
         for (old_id,) in old_cats:
@@ -114,7 +114,7 @@ def upgrade() -> None:
         if sys_id is None:
             continue
         dup_cats = conn.execute(
-            sa.text("SELECT id FROM categories WHERE name = :name AND id != :sys_id " "AND NOT (user_id IS NULL AND household_id IS NULL)"),
+            sa.text("SELECT id FROM categories WHERE name = :name AND id != :sys_id AND NOT (user_id IS NULL AND household_id IS NULL)"),
             {"name": sys_name, "sys_id": sys_id},
         ).fetchall()
         for (dup_id,) in dup_cats:
@@ -134,7 +134,7 @@ def upgrade() -> None:
             ).fetchone()
             if existing is None:
                 conn.execute(
-                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) " "VALUES (:hh, NULL, :src, :target)"),
+                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) VALUES (:hh, NULL, :src, :target)"),
                     {"hh": hh_id, "src": old_name, "target": new_sys_id},
                 )
 

--- a/backend/alembic/versions/f5g6h7i8j9k0_migrate_legacy_categories.py
+++ b/backend/alembic/versions/f5g6h7i8j9k0_migrate_legacy_categories.py
@@ -85,7 +85,7 @@ def upgrade() -> None:
 
         # 이 이름의 비시스템 카테고리 전부 조회
         old_cats = conn.execute(
-            sa.text("SELECT id FROM categories WHERE name = :name " "AND NOT (user_id IS NULL AND household_id IS NULL)"),
+            sa.text("SELECT id FROM categories WHERE name = :name AND NOT (user_id IS NULL AND household_id IS NULL)"),
             {"name": old_name},
         ).fetchall()
 
@@ -108,7 +108,7 @@ def upgrade() -> None:
             ).fetchone()
             if existing is None:
                 conn.execute(
-                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) " "VALUES (:hh, NULL, :src, :target)"),
+                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) VALUES (:hh, NULL, :src, :target)"),
                     {"hh": hh_id, "src": old_name, "target": sys_id},
                 )
 

--- a/backend/app/api/budget.py
+++ b/backend/app/api/budget.py
@@ -23,6 +23,8 @@ from app.models.expense import Expense
 from app.models.user import User
 from app.schemas.budget import (
     BudgetAlert,
+    BudgetBulkSaveRequest,
+    BudgetBulkSaveResponse,
     BudgetCreate,
     BudgetMonthlyCategoryStats,
     BudgetMonthlyStatsResponse,
@@ -137,14 +139,92 @@ async def update_total_budget(
     )
 
 
-# NOTE: 고정 경로 엔드포인트(alerts, category-overview, monthly-stats, total-budget)를 반드시 /{budget_id} 앞에 정의해야 함.
+# NOTE: 고정 경로 엔드포인트(alerts, category-overview, monthly-stats, total-budget, bulk)를 반드시 /{budget_id} 앞에 정의해야 함.
 # FastAPI 0.109 (Starlette 0.35)에서는 /{budget_id} partial match 후 탐색을 멈춰
 # 뒤에 정의된 고정 경로가 Method Not Allowed를 반환하는 버그가 있음.
+
+
+@router.put("/bulk", response_model=BudgetBulkSaveResponse)
+async def bulk_save_budgets(
+    data: BudgetBulkSaveRequest,
+    household_id: int | None = Query(None, description="가구 ID (없으면 활성 가구 자동 감지)"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """월별 예산 벌크 저장
+
+    해당 월의 전체 예산을 한번에 갱신합니다.
+    요청에 포함된 카테고리는 생성/업데이트, 누락된 기존 예산은 삭제됩니다.
+    """
+    if household_id is None:
+        household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)
+
+    year, mon = map(int, data.month.split("-"))
+    start_date = datetime(year, mon, 1)
+
+    # 해당 월의 기존 예산 조회
+    existing_result = await db.execute(
+        select(Budget).where(
+            Budget.household_id == household_id,
+            Budget.period == "monthly",
+            Budget.start_date == start_date,
+        )
+    )
+    existing_budgets = {b.category_id: b for b in existing_result.scalars().all()}
+
+    # 요청 카테고리 ID 집합
+    request_category_ids = {item.category_id for item in data.budgets}
+
+    created = 0
+    updated = 0
+    deleted = 0
+
+    # 생성/업데이트
+    for item in data.budgets:
+        if item.category_id in existing_budgets:
+            # 기존 예산 업데이트
+            budget = existing_budgets[item.category_id]
+            budget.amount = item.amount
+            budget.alert_threshold = data.alert_threshold
+            updated += 1
+        else:
+            # 새 예산 생성
+            new_budget = Budget(
+                user_id=current_user.id,
+                household_id=household_id,
+                category_id=item.category_id,
+                amount=item.amount,
+                period="monthly",
+                start_date=start_date,
+                alert_threshold=data.alert_threshold,
+            )
+            db.add(new_budget)
+            created += 1
+
+    # 요청에 없는 기존 예산 삭제
+    for cat_id, budget in existing_budgets.items():
+        if cat_id not in request_category_ids:
+            await db.delete(budget)
+            deleted += 1
+
+    await db.commit()
+    logger.info(
+        "예산 벌크 저장: user=%s, household=%s, month=%s, created=%d, updated=%d, deleted=%d",
+        current_user.id,
+        household_id,
+        data.month,
+        created,
+        updated,
+        deleted,
+    )
+    return BudgetBulkSaveResponse(created=created, updated=updated, deleted=deleted)
 
 
 @router.get("/alerts", response_model=list[BudgetAlert])
 async def get_budget_alerts(
     household_id: int | None = Query(None, description="가구 ID (없으면 개인 예산)"),
+    month: str | None = Query(None, description="YYYY-MM 형식 (없으면 현재 월)", pattern=r"^\d{4}-\d{2}$"),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -152,7 +232,7 @@ async def get_budget_alerts(
     if household_id is None:
         household_id = await get_user_active_household_id(current_user, db)
     await get_household_member(household_id, current_user, db)
-    return await budget_service.get_budget_alerts(db, household_id)
+    return await budget_service.get_budget_alerts(db, household_id, month=month)
 
 
 @router.get("/category-overview", response_model=list[CategoryBudgetOverview])

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -266,7 +266,7 @@ async def _handle_start_command(chat_id: int, user_text: str, bot_user: Any, db:
             }
             await send_telegram_message(
                 chat_id,
-                "🔗 연동 완료! 이제 포도가계부를 사용할 수 있어요 🍇\n\n" "말하듯 편하게 지출을 입력해보세요.\n" '"점심 김치찌개 8000원"',
+                '🔗 연동 완료! 이제 포도가계부를 사용할 수 있어요 🍇\n\n말하듯 편하게 지출을 입력해보세요.\n"점심 김치찌개 8000원"',
                 reply_markup=reply_markup,
             )
             return {"ok": True}

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -128,6 +128,40 @@ class BudgetMonthlyStatsResponse(BaseModel):
     categories: list[BudgetMonthlyCategoryStats]
 
 
+class BudgetBulkItem(BaseModel):
+    """벌크 저장 요청 내 개별 예산 항목"""
+
+    category_id: int = Field(..., description="카테고리 ID")
+    amount: float = Field(..., gt=0, description="예산 금액 (양수)")
+
+
+class BudgetBulkSaveRequest(BaseModel):
+    """벌크 예산 저장 요청 스키마
+
+    해당 월의 전체 예산을 한번에 갱신합니다.
+    - 기존에 없는 category_id → 생성
+    - 기존에 있는 category_id → 금액 업데이트
+    - 요청에 없는 기존 예산 → 삭제
+
+    Attributes:
+        month: 대상 월 (YYYY-MM)
+        alert_threshold: 알림 임계값 (0.0~1.0)
+        budgets: 카테고리별 예산 목록
+    """
+
+    month: str = Field(..., description="대상 월 (YYYY-MM)", pattern=r"^\d{4}-\d{2}$")
+    alert_threshold: float = Field(default=0.8, ge=0.0, le=1.0, description="알림 임계값")
+    budgets: list[BudgetBulkItem] = Field(..., description="카테고리별 예산 목록")
+
+
+class BudgetBulkSaveResponse(BaseModel):
+    """벌크 예산 저장 응답 스키마"""
+
+    created: int = Field(..., description="새로 생성된 예산 수")
+    updated: int = Field(..., description="업데이트된 예산 수")
+    deleted: int = Field(..., description="삭제된 예산 수")
+
+
 class BudgetAlert(BaseModel):
     """예산 초과/경고 알림 스키마
 

--- a/backend/app/services/bot_messages.py
+++ b/backend/app/services/bot_messages.py
@@ -98,12 +98,12 @@ def format_parse_error(strike: int | str = 1) -> str:
     if isinstance(strike, str):
         strike = 1
     if strike <= 1:
-        return "🤔 금액을 찾지 못했어요\n\n" "이렇게 입력해보세요:\n" '"점심 김치찌개 8000원"'
+        return '🤔 금액을 찾지 못했어요\n\n이렇게 입력해보세요:\n"점심 김치찌개 8000원"'
     elif strike == 2:
-        return "😅 아직 이해하지 못했어요\n\n" "다른 방식으로 입력해볼까요?\n" '"8000원 점심" 처럼 금액을 먼저 써도 돼요'
+        return '😅 아직 이해하지 못했어요\n\n다른 방식으로 입력해볼까요?\n"8000원 점심" 처럼 금액을 먼저 써도 돼요'
     else:
         # strike >= 3
-        return "제가 아직 이해하기 어려운 표현인 것 같아요 😊\n\n" "아래 버튼으로 도움말을 확인해보세요"
+        return "제가 아직 이해하기 어려운 표현인 것 같아요 😊\n\n아래 버튼으로 도움말을 확인해보세요"
 
 
 def format_unknown_input(**kwargs) -> str:
@@ -137,12 +137,7 @@ def format_help_message(platform: str = "telegram") -> str:
         )
     else:
         commands = (
-            "\n명령어:\n"
-            "/report — 이번 달 지출 요약\n"
-            "/budget — 예산 현황\n"
-            "/link 코드 — 웹 계정 연동\n"
-            "피드백 [내용] — 의견이나 버그 신고\n"
-            "/help — 이 도움말"
+            "\n명령어:\n/report — 이번 달 지출 요약\n/budget — 예산 현황\n/link 코드 — 웹 계정 연동\n피드백 [내용] — 의견이나 버그 신고\n/help — 이 도움말"
         )
 
     return base + commands
@@ -161,24 +156,12 @@ def format_welcome_message() -> str:
 
 def format_link_usage_message() -> str:
     """연동 코드 사용법 (텔레그램)"""
-    return (
-        "🔗 웹 계정 연동 방법\n\n"
-        "1. 포도가계부 웹 → 설정 → 텔레그램 연동\n"
-        "2. 코드를 발급받아 아래처럼 입력\n\n"
-        "/link ABC123\n\n"
-        "⏰ 코드는 15분 후 만료돼요"
-    )
+    return "🔗 웹 계정 연동 방법\n\n1. 포도가계부 웹 → 설정 → 텔레그램 연동\n2. 코드를 발급받아 아래처럼 입력\n\n/link ABC123\n\n⏰ 코드는 15분 후 만료돼요"
 
 
 def format_kakao_link_usage_message() -> str:
     """연동 코드 사용법 (카카오톡)"""
-    return (
-        "🔗 웹 계정 연동 방법\n\n"
-        "1. 포도가계부 웹 → 설정 → 카카오톡 연동\n"
-        "2. 코드를 발급받아 아래처럼 입력\n\n"
-        "연동 ABC123\n\n"
-        "⏰ 코드는 15분 후 만료돼요"
-    )
+    return "🔗 웹 계정 연동 방법\n\n1. 포도가계부 웹 → 설정 → 카카오톡 연동\n2. 코드를 발급받아 아래처럼 입력\n\n연동 ABC123\n\n⏰ 코드는 15분 후 만료돼요"
 
 
 def format_delete_confirm(amount: float, description: str, **kwargs) -> str:
@@ -340,10 +323,4 @@ def format_feedback_received() -> str:
 
 def format_feedback_guide() -> str:
     """피드백 사용법 안내 메시지"""
-    return (
-        "💬 피드백을 보내주세요!\n\n"
-        "예시:\n"
-        "· 피드백 검색 기능이 있으면 좋겠어요\n"
-        "· 버그 카테고리가 안 보여요\n\n"
-        "'버그'로 시작하면 버그 신고로 분류돼요."
-    )
+    return "💬 피드백을 보내주세요!\n\n예시:\n· 피드백 검색 기능이 있으면 좋겠어요\n· 버그 카테고리가 안 보여요\n\n'버그'로 시작하면 버그 신고로 분류돼요."

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -15,7 +15,7 @@ from app.models.expense import Expense
 from app.schemas.budget import BudgetAlert, CategoryBudgetOverview, MonthlySpending
 
 
-async def get_budget_alerts(db: AsyncSession, household_id: int) -> list[BudgetAlert]:
+async def get_budget_alerts(db: AsyncSession, household_id: int, *, month: str | None = None) -> list[BudgetAlert]:
     """예산 초과/경고 알림 계산 (#176)
 
     카테고리별 예산과 현재까지의 지출을 비교하여 알림 목록을 반환합니다.
@@ -24,6 +24,7 @@ async def get_budget_alerts(db: AsyncSession, household_id: int) -> list[BudgetA
     Args:
         db: 데이터베이스 세션
         household_id: 가구 ID
+        month: 대상 월 YYYY-MM (None이면 현재 월)
 
     Returns:
         초과/경고 순으로 정렬된 BudgetAlert 목록
@@ -34,8 +35,15 @@ async def get_budget_alerts(db: AsyncSession, household_id: int) -> list[BudgetA
     alerts: list[BudgetAlert] = []
     now = datetime.now(UTC).replace(tzinfo=None)
 
+    # month 파라미터가 있으면 해당 월 기준, 없으면 현재 시점 기준
+    if month:
+        year, mon = map(int, month.split("-"))
+        ref_date = datetime(year, mon, 1)
+    else:
+        ref_date = now
+
     # 유효한 예산만 필터 (기간 미시작 제외)
-    active_budgets = [b for b in budgets if b.start_date <= now]
+    active_budgets = [b for b in budgets if b.start_date <= ref_date]
     if not active_budgets:
         return alerts
 
@@ -44,22 +52,29 @@ async def get_budget_alerts(db: AsyncSession, household_id: int) -> list[BudgetA
     cat_result = await db.execute(select(Category).where(Category.id.in_(category_ids)))
     categories_map = {c.id: c for c in cat_result.scalars().all()}
 
-    # period_start별로 예산 그룹화 (period 타입별로 동일한 period_start 공유)
-    budgets_by_period: dict[datetime, list] = {}
+    # period_start/period_end별로 예산 그룹화
+    budgets_by_period: dict[tuple[datetime, datetime], list] = {}
     for budget in active_budgets:
-        if budget.period == "monthly":
+        if month:
+            # month 지정 시: 해당 월 전체 기간으로 고정
+            period_start = datetime(year, mon, 1)
+            period_end = datetime(year + 1, 1, 1) if mon == 12 else datetime(year, mon + 1, 1)
+        elif budget.period == "monthly":
             period_start = datetime(now.year, now.month, 1)
+            period_end = now
         elif budget.period == "weekly":
             days_since_monday = now.weekday()
             period_start = datetime(now.year, now.month, now.day) - timedelta(days=days_since_monday)
+            period_end = now
         else:  # daily
             period_start = datetime(now.year, now.month, now.day)
-        budgets_by_period.setdefault(period_start, []).append(budget)
+            period_end = now
+        budgets_by_period.setdefault((period_start, period_end), []).append(budget)
 
-    # period_start별 지출 합계 배치 조회 (period 유형 수만큼 쿼리 — 보통 1~3회)
+    # period별 지출 합계 배치 조회
     expense_scope = Expense.household_id == household_id
     spent_map: dict[int, float] = {}
-    for period_start, period_budgets in budgets_by_period.items():
+    for (period_start, period_end), period_budgets in budgets_by_period.items():
         period_cat_ids = [b.category_id for b in period_budgets]
         expense_result = await db.execute(
             select(Expense.category_id, func.sum(Expense.amount).label("total"))
@@ -67,7 +82,7 @@ async def get_budget_alerts(db: AsyncSession, household_id: int) -> list[BudgetA
                 expense_scope,
                 Expense.category_id.in_(period_cat_ids),
                 Expense.date >= period_start,
-                Expense.date <= now,
+                Expense.date < period_end,
             )
             .group_by(Expense.category_id)
         )

--- a/backend/tests/integration/test_api_budget_bulk.py
+++ b/backend/tests/integration/test_api_budget_bulk.py
@@ -8,14 +8,15 @@ from httpx import AsyncClient
 from app.models.budget import Budget
 from app.models.category import Category
 from app.models.expense import Expense
+from app.models.household import Household
 from app.models.user import User
 
 
 @pytest.mark.asyncio
-async def test_bulk_save_create_budgets(authenticated_client: AsyncClient, test_user: User, db_session):
+async def test_bulk_save_create_budgets(authenticated_client: AsyncClient, test_user: User, test_household: Household, db_session):
     """벌크 저장 - 새 예산 생성"""
-    cat1 = Category(user_id=test_user.id, name="식비", type="expense")
-    cat2 = Category(user_id=test_user.id, name="교통비", type="expense")
+    cat1 = Category(user_id=test_user.id, household_id=test_household.id, name="식비", type="expense")
+    cat2 = Category(user_id=test_user.id, household_id=test_household.id, name="교통비", type="expense")
     db_session.add_all([cat1, cat2])
     await db_session.commit()
     await db_session.refresh(cat1)
@@ -41,9 +42,9 @@ async def test_bulk_save_create_budgets(authenticated_client: AsyncClient, test_
 
 
 @pytest.mark.asyncio
-async def test_bulk_save_update_existing(authenticated_client: AsyncClient, test_user: User, db_session):
+async def test_bulk_save_update_existing(authenticated_client: AsyncClient, test_user: User, test_household: Household, db_session):
     """벌크 저장 - 기존 예산 업데이트"""
-    cat = Category(user_id=test_user.id, name="식비", type="expense")
+    cat = Category(user_id=test_user.id, household_id=test_household.id, name="식비", type="expense")
     db_session.add(cat)
     await db_session.commit()
     await db_session.refresh(cat)
@@ -51,6 +52,7 @@ async def test_bulk_save_update_existing(authenticated_client: AsyncClient, test
     # 기존 예산 생성
     budget = Budget(
         user_id=test_user.id,
+        household_id=test_household.id,
         category_id=cat.id,
         amount=200000,
         period="monthly",
@@ -79,10 +81,10 @@ async def test_bulk_save_update_existing(authenticated_client: AsyncClient, test
 
 
 @pytest.mark.asyncio
-async def test_bulk_save_delete_missing(authenticated_client: AsyncClient, test_user: User, db_session):
+async def test_bulk_save_delete_missing(authenticated_client: AsyncClient, test_user: User, test_household: Household, db_session):
     """벌크 저장 - 요청에 없는 예산 삭제"""
-    cat1 = Category(user_id=test_user.id, name="식비", type="expense")
-    cat2 = Category(user_id=test_user.id, name="교통비", type="expense")
+    cat1 = Category(user_id=test_user.id, household_id=test_household.id, name="식비", type="expense")
+    cat2 = Category(user_id=test_user.id, household_id=test_household.id, name="교통비", type="expense")
     db_session.add_all([cat1, cat2])
     await db_session.commit()
     await db_session.refresh(cat1)
@@ -93,6 +95,7 @@ async def test_bulk_save_delete_missing(authenticated_client: AsyncClient, test_
         db_session.add(
             Budget(
                 user_id=test_user.id,
+                household_id=test_household.id,
                 category_id=cat.id,
                 amount=100000,
                 period="monthly",
@@ -121,9 +124,9 @@ async def test_bulk_save_delete_missing(authenticated_client: AsyncClient, test_
 
 
 @pytest.mark.asyncio
-async def test_bulk_save_empty_clears_all(authenticated_client: AsyncClient, test_user: User, db_session):
+async def test_bulk_save_empty_clears_all(authenticated_client: AsyncClient, test_user: User, test_household: Household, db_session):
     """벌크 저장 - 빈 배열이면 전체 삭제"""
-    cat = Category(user_id=test_user.id, name="식비", type="expense")
+    cat = Category(user_id=test_user.id, household_id=test_household.id, name="식비", type="expense")
     db_session.add(cat)
     await db_session.commit()
     await db_session.refresh(cat)
@@ -131,6 +134,7 @@ async def test_bulk_save_empty_clears_all(authenticated_client: AsyncClient, tes
     db_session.add(
         Budget(
             user_id=test_user.id,
+            household_id=test_household.id,
             category_id=cat.id,
             amount=100000,
             period="monthly",
@@ -151,9 +155,9 @@ async def test_bulk_save_empty_clears_all(authenticated_client: AsyncClient, tes
 
 
 @pytest.mark.asyncio
-async def test_alerts_with_month_filter(authenticated_client: AsyncClient, test_user: User, db_session):
+async def test_alerts_with_month_filter(authenticated_client: AsyncClient, test_user: User, test_household: Household, db_session):
     """월별 알림 조회 - month 파라미터 사용"""
-    cat = Category(user_id=test_user.id, name="식비", type="expense")
+    cat = Category(user_id=test_user.id, household_id=test_household.id, name="식비", type="expense")
     db_session.add(cat)
     await db_session.commit()
     await db_session.refresh(cat)
@@ -162,6 +166,7 @@ async def test_alerts_with_month_filter(authenticated_client: AsyncClient, test_
     db_session.add(
         Budget(
             user_id=test_user.id,
+            household_id=test_household.id,
             category_id=cat.id,
             amount=300000,
             period="monthly",
@@ -174,6 +179,7 @@ async def test_alerts_with_month_filter(authenticated_client: AsyncClient, test_
     db_session.add(
         Expense(
             user_id=test_user.id,
+            household_id=test_household.id,
             amount=250000,
             description="2월 식비",
             category_id=cat.id,
@@ -192,9 +198,9 @@ async def test_alerts_with_month_filter(authenticated_client: AsyncClient, test_
 
 
 @pytest.mark.asyncio
-async def test_alerts_month_filter_ignores_other_months(authenticated_client: AsyncClient, test_user: User, db_session):
+async def test_alerts_month_filter_ignores_other_months(authenticated_client: AsyncClient, test_user: User, test_household: Household, db_session):
     """월별 알림 - 다른 달 지출은 포함하지 않음"""
-    cat = Category(user_id=test_user.id, name="식비", type="expense")
+    cat = Category(user_id=test_user.id, household_id=test_household.id, name="식비", type="expense")
     db_session.add(cat)
     await db_session.commit()
     await db_session.refresh(cat)
@@ -203,6 +209,7 @@ async def test_alerts_month_filter_ignores_other_months(authenticated_client: As
     db_session.add(
         Budget(
             user_id=test_user.id,
+            household_id=test_household.id,
             category_id=cat.id,
             amount=300000,
             period="monthly",
@@ -215,6 +222,7 @@ async def test_alerts_month_filter_ignores_other_months(authenticated_client: As
     db_session.add(
         Expense(
             user_id=test_user.id,
+            household_id=test_household.id,
             amount=500000,
             description="1월 식비",
             category_id=cat.id,

--- a/backend/tests/integration/test_api_expenses.py
+++ b/backend/tests/integration/test_api_expenses.py
@@ -326,7 +326,7 @@ async def test_create_expense_with_date_only_format(authenticated_client, test_u
         "date": "2026-02-11",
     }
     response = await authenticated_client.post("/api/expenses", json=payload)
-    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 지출 생성이 실패함. " "ExpenseCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
+    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 지출 생성이 실패함. ExpenseCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
     data = response.json()
     assert data["description"] == "전기차충전"
     assert data["amount"] == 11680

--- a/backend/tests/integration/test_api_income.py
+++ b/backend/tests/integration/test_api_income.py
@@ -207,7 +207,7 @@ async def test_create_income_with_date_only_format(authenticated_client, test_us
         "date": "2026-02-01",  # LLM이 반환하는 형식 — 시간 없는 날짜
     }
     response = await authenticated_client.post("/api/income", json=payload)
-    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 수입 생성이 실패함. " "IncomeCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
+    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 수입 생성이 실패함. IncomeCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
     data = response.json()
     assert data["description"] == "2월 월급"
     assert data["amount"] == 3500000


### PR DESCRIPTION
## Summary

- **#354**: `test_api_budget_bulk.py` 6개 테스트 수정 + CI `--ignore` 제거
- **#355**: AuthContext 테스트 이미 Supabase Auth 기반으로 정상 → 변경 불필요

## 변경 내용

- `PUT /api/budgets/bulk` 엔드포인트 구현 (벌크 예산 저장)
- `GET /api/budgets/alerts`에 `month` 쿼리 파라미터 추가
- `test_api_budget_bulk.py`: 모든 테스트에 `test_household` fixture + `household_id` 추가
- `ci-test.yml`: `--ignore=test_api_budget_bulk.py` 제거
- CLAUDE.md, rules 파일에서 budget_bulk ignore 참조 제거

## Test plan

- [x] budget_bulk 6개 테스트 통과
- [x] 전체 BE 904 passed (ignore 없이)
- [x] FE 671 passed
- [ ] CI 통과

Closes #354
Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)