### PR TITLE
test: 봇 API + expenses API 테스트 커버리지 강화 (#357, #358)

### DIFF
--- a/backend/alembic/versions/d367e7848291_seed_system_categories_and_relink_.py
+++ b/backend/alembic/versions/d367e7848291_seed_system_categories_and_relink_.py
@@ -102,7 +102,7 @@ def upgrade() -> None:
         if new_sys_id is None:
             continue
         old_cats = conn.execute(
-            sa.text("SELECT id FROM categories WHERE name = :name " "AND NOT (user_id IS NULL AND household_id IS NULL)"),
+            sa.text("SELECT id FROM categories WHERE name = :name AND NOT (user_id IS NULL AND household_id IS NULL)"),
             {"name": old_name},
         ).fetchall()
         for (old_id,) in old_cats:
@@ -114,7 +114,7 @@ def upgrade() -> None:
         if sys_id is None:
             continue
         dup_cats = conn.execute(
-            sa.text("SELECT id FROM categories WHERE name = :name AND id != :sys_id " "AND NOT (user_id IS NULL AND household_id IS NULL)"),
+            sa.text("SELECT id FROM categories WHERE name = :name AND id != :sys_id AND NOT (user_id IS NULL AND household_id IS NULL)"),
             {"name": sys_name, "sys_id": sys_id},
         ).fetchall()
         for (dup_id,) in dup_cats:
@@ -134,7 +134,7 @@ def upgrade() -> None:
             ).fetchone()
             if existing is None:
                 conn.execute(
-                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) " "VALUES (:hh, NULL, :src, :target)"),
+                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) VALUES (:hh, NULL, :src, :target)"),
                     {"hh": hh_id, "src": old_name, "target": new_sys_id},
                 )
 

--- a/backend/alembic/versions/f5g6h7i8j9k0_migrate_legacy_categories.py
+++ b/backend/alembic/versions/f5g6h7i8j9k0_migrate_legacy_categories.py
@@ -85,7 +85,7 @@ def upgrade() -> None:
 
         # 이 이름의 비시스템 카테고리 전부 조회
         old_cats = conn.execute(
-            sa.text("SELECT id FROM categories WHERE name = :name " "AND NOT (user_id IS NULL AND household_id IS NULL)"),
+            sa.text("SELECT id FROM categories WHERE name = :name AND NOT (user_id IS NULL AND household_id IS NULL)"),
             {"name": old_name},
         ).fetchall()
 
@@ -108,7 +108,7 @@ def upgrade() -> None:
             ).fetchone()
             if existing is None:
                 conn.execute(
-                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) " "VALUES (:hh, NULL, :src, :target)"),
+                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) VALUES (:hh, NULL, :src, :target)"),
                     {"hh": hh_id, "src": old_name, "target": sys_id},
                 )
 

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -266,7 +266,7 @@ async def _handle_start_command(chat_id: int, user_text: str, bot_user: Any, db:
             }
             await send_telegram_message(
                 chat_id,
-                "🔗 연동 완료! 이제 포도가계부를 사용할 수 있어요 🍇\n\n" "말하듯 편하게 지출을 입력해보세요.\n" '"점심 김치찌개 8000원"',
+                '🔗 연동 완료! 이제 포도가계부를 사용할 수 있어요 🍇\n\n말하듯 편하게 지출을 입력해보세요.\n"점심 김치찌개 8000원"',
                 reply_markup=reply_markup,
             )
             return {"ok": True}

--- a/backend/app/services/bot_messages.py
+++ b/backend/app/services/bot_messages.py
@@ -98,12 +98,12 @@ def format_parse_error(strike: int | str = 1) -> str:
     if isinstance(strike, str):
         strike = 1
     if strike <= 1:
-        return "🤔 금액을 찾지 못했어요\n\n" "이렇게 입력해보세요:\n" '"점심 김치찌개 8000원"'
+        return '🤔 금액을 찾지 못했어요\n\n이렇게 입력해보세요:\n"점심 김치찌개 8000원"'
     elif strike == 2:
-        return "😅 아직 이해하지 못했어요\n\n" "다른 방식으로 입력해볼까요?\n" '"8000원 점심" 처럼 금액을 먼저 써도 돼요'
+        return '😅 아직 이해하지 못했어요\n\n다른 방식으로 입력해볼까요?\n"8000원 점심" 처럼 금액을 먼저 써도 돼요'
     else:
         # strike >= 3
-        return "제가 아직 이해하기 어려운 표현인 것 같아요 😊\n\n" "아래 버튼으로 도움말을 확인해보세요"
+        return "제가 아직 이해하기 어려운 표현인 것 같아요 😊\n\n아래 버튼으로 도움말을 확인해보세요"
 
 
 def format_unknown_input(**kwargs) -> str:
@@ -137,12 +137,7 @@ def format_help_message(platform: str = "telegram") -> str:
         )
     else:
         commands = (
-            "\n명령어:\n"
-            "/report — 이번 달 지출 요약\n"
-            "/budget — 예산 현황\n"
-            "/link 코드 — 웹 계정 연동\n"
-            "피드백 [내용] — 의견이나 버그 신고\n"
-            "/help — 이 도움말"
+            "\n명령어:\n/report — 이번 달 지출 요약\n/budget — 예산 현황\n/link 코드 — 웹 계정 연동\n피드백 [내용] — 의견이나 버그 신고\n/help — 이 도움말"
         )
 
     return base + commands
@@ -161,24 +156,12 @@ def format_welcome_message() -> str:
 
 def format_link_usage_message() -> str:
     """연동 코드 사용법 (텔레그램)"""
-    return (
-        "🔗 웹 계정 연동 방법\n\n"
-        "1. 포도가계부 웹 → 설정 → 텔레그램 연동\n"
-        "2. 코드를 발급받아 아래처럼 입력\n\n"
-        "/link ABC123\n\n"
-        "⏰ 코드는 15분 후 만료돼요"
-    )
+    return "🔗 웹 계정 연동 방법\n\n1. 포도가계부 웹 → 설정 → 텔레그램 연동\n2. 코드를 발급받아 아래처럼 입력\n\n/link ABC123\n\n⏰ 코드는 15분 후 만료돼요"
 
 
 def format_kakao_link_usage_message() -> str:
     """연동 코드 사용법 (카카오톡)"""
-    return (
-        "🔗 웹 계정 연동 방법\n\n"
-        "1. 포도가계부 웹 → 설정 → 카카오톡 연동\n"
-        "2. 코드를 발급받아 아래처럼 입력\n\n"
-        "연동 ABC123\n\n"
-        "⏰ 코드는 15분 후 만료돼요"
-    )
+    return "🔗 웹 계정 연동 방법\n\n1. 포도가계부 웹 → 설정 → 카카오톡 연동\n2. 코드를 발급받아 아래처럼 입력\n\n연동 ABC123\n\n⏰ 코드는 15분 후 만료돼요"
 
 
 def format_delete_confirm(amount: float, description: str, **kwargs) -> str:
@@ -340,10 +323,4 @@ def format_feedback_received() -> str:
 
 def format_feedback_guide() -> str:
     """피드백 사용법 안내 메시지"""
-    return (
-        "💬 피드백을 보내주세요!\n\n"
-        "예시:\n"
-        "· 피드백 검색 기능이 있으면 좋겠어요\n"
-        "· 버그 카테고리가 안 보여요\n\n"
-        "'버그'로 시작하면 버그 신고로 분류돼요."
-    )
+    return "💬 피드백을 보내주세요!\n\n예시:\n· 피드백 검색 기능이 있으면 좋겠어요\n· 버그 카테고리가 안 보여요\n\n'버그'로 시작하면 버그 신고로 분류돼요."

--- a/backend/tests/integration/test_api_expenses.py
+++ b/backend/tests/integration/test_api_expenses.py
@@ -326,7 +326,7 @@ async def test_create_expense_with_date_only_format(authenticated_client, test_u
         "date": "2026-02-11",
     }
     response = await authenticated_client.post("/api/expenses", json=payload)
-    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 지출 생성이 실패함. " "ExpenseCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
+    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 지출 생성이 실패함. ExpenseCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
     data = response.json()
     assert data["description"] == "전기차충전"
     assert data["amount"] == 11680

--- a/backend/tests/integration/test_api_expenses_extra.py
+++ b/backend/tests/integration/test_api_expenses_extra.py
@@ -1,0 +1,586 @@
+"""
+지출 API 추가 통합 테스트 (#358)
+
+기존 test_api_expenses.py에서 누락된 영역:
+- GET /api/expenses/stats (주간/월간/연간 통합 통계)
+- GET /api/expenses/stats/comparison (기간 비교)
+- POST /api/expenses/ocr (이미지 OCR 파싱, LLM 모킹)
+- 검색 + 필터 조합 (query + date_range + category_id)
+- search/summary에 날짜 필터 조합
+- 멤버별 필터링 (member_user_id)
+- exclude_from_stats 필드 동작
+"""
+
+from datetime import datetime
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.category import Category
+from app.models.expense import Expense
+from app.models.household import Household
+from app.models.user import User
+
+# ── GET /api/expenses/stats 통합 통계 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stats_weekly(authenticated_client, test_user: User, test_household: Household, db_session):
+    """주간 통계 조회"""
+    cat = Category(name="식비", user_id=test_user.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    # 2026-03-23 (월)~29 (일) 주간에 지출 생성
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=8000, description="점심", category_id=cat.id, date=datetime(2026, 3, 23))
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=5000, description="커피", category_id=cat.id, date=datetime(2026, 3, 24))
+    db_session.add_all([e1, e2])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/expenses/stats?period=weekly&date=2026-03-23")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["period"] == "weekly"
+    assert data["total"] == 13000.0
+    assert data["count"] == 2
+    assert len(data["by_category"]) == 1
+    assert data["by_category"][0]["category"] == "식비"
+    assert len(data["trend"]) >= 1  # 일별 트렌드
+
+
+@pytest.mark.asyncio
+async def test_stats_monthly(authenticated_client, test_user: User, test_household: Household, db_session):
+    """월간 통계 조회"""
+    cat = Category(name="교통비", user_id=test_user.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=15000, description="택시", category_id=cat.id, date=datetime(2026, 3, 10))
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=3000, description="버스", category_id=cat.id, date=datetime(2026, 3, 20))
+    db_session.add_all([e1, e2])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/expenses/stats?period=monthly&date=2026-03-15")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["period"] == "monthly"
+    assert data["total"] == 18000.0
+    assert data["count"] == 2
+    assert "2026년 3월" in data["label"]
+    assert len(data["trend"]) == 2  # 2일에 지출
+
+
+@pytest.mark.asyncio
+async def test_stats_yearly(authenticated_client, test_user: User, test_household: Household, db_session):
+    """연간 통계 조회"""
+    cat = Category(name="식비", user_id=test_user.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=100000, description="1월 지출", category_id=cat.id, date=datetime(2026, 1, 15))
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=200000, description="3월 지출", category_id=cat.id, date=datetime(2026, 3, 15))
+    db_session.add_all([e1, e2])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/expenses/stats?period=yearly&date=2026-06-01")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["period"] == "yearly"
+    assert data["total"] == 300000.0
+    assert data["count"] == 2
+    assert "2026년" in data["label"]
+    # 연간은 월별 12포인트 트렌드
+    assert len(data["trend"]) >= 2
+
+
+@pytest.mark.asyncio
+async def test_stats_empty(authenticated_client, test_user: User, db_session):
+    """통계 조회 — 데이터 없음"""
+    response = await authenticated_client.get("/api/expenses/stats?period=monthly&date=2026-01-15")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total"] == 0.0
+    assert data["count"] == 0
+    assert data["by_category"] == []
+
+
+@pytest.mark.asyncio
+async def test_stats_excludes_flagged(authenticated_client, test_user: User, test_household: Household, db_session):
+    """exclude_from_stats=True인 지출은 통계에서 제외"""
+    cat = Category(name="저축", user_id=test_user.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    e_normal = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=50000,
+        description="정상 지출",
+        category_id=cat.id,
+        date=datetime(2026, 3, 15),
+    )
+    e_excluded = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=5000000,
+        description="저축 이체",
+        category_id=cat.id,
+        date=datetime(2026, 3, 15),
+        exclude_from_stats=True,
+    )
+    db_session.add_all([e_normal, e_excluded])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/expenses/stats?period=monthly&date=2026-03-15")
+    assert response.status_code == 200
+
+    data = response.json()
+    # exclude_from_stats=True인 500만원은 제외되고 5만원만 집계
+    assert data["total"] == 50000.0
+    assert data["count"] == 1
+
+
+# ── GET /api/expenses/stats/comparison ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stats_comparison_monthly(authenticated_client, test_user: User, test_household: Household, db_session):
+    """월간 비교 통계"""
+    cat = Category(name="식비", user_id=test_user.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    # 2월 지출
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=100000, description="2월 식비", category_id=cat.id, date=datetime(2026, 2, 15))
+    # 3월 지출
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=150000, description="3월 식비", category_id=cat.id, date=datetime(2026, 3, 15))
+    db_session.add_all([e1, e2])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/expenses/stats/comparison?period=monthly&date=2026-03-31&months=3")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "current" in data
+    assert "previous" in data
+    assert "change" in data
+    assert "trend" in data
+    assert len(data["trend"]) == 3  # 3개월 트렌드
+
+
+@pytest.mark.asyncio
+async def test_stats_comparison_yearly(authenticated_client, test_user: User, test_household: Household, db_session):
+    """연간 비교 통계"""
+    cat = Category(name="식비", user_id=test_user.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    # 2025년 지출
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=500000, description="2025 식비", category_id=cat.id, date=datetime(2025, 6, 15))
+    # 2026년 지출
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=300000, description="2026 식비", category_id=cat.id, date=datetime(2026, 3, 15))
+    db_session.add_all([e1, e2])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/expenses/stats/comparison?period=yearly&date=2026-03-15&months=2")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "current" in data
+    assert "previous" in data
+    assert data["current"]["total"] == 300000.0
+    assert data["previous"]["total"] == 500000.0
+    assert data["change"]["amount"] == -200000.0
+
+
+@pytest.mark.asyncio
+async def test_stats_comparison_empty(authenticated_client, test_user: User, db_session):
+    """비교 통계 — 데이터 없음"""
+    response = await authenticated_client.get("/api/expenses/stats/comparison?period=monthly&date=2026-01-15")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["current"]["total"] == 0.0
+    assert data["previous"]["total"] == 0.0
+
+
+# ── POST /api/expenses/ocr ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ocr_parse_success(authenticated_client, test_user: User, db_session):
+    """OCR 이미지 파싱 성공 (LLM 모킹)"""
+    # 유효한 JPEG 매직 바이트로 시작하는 더미 이미지
+    dummy_jpeg = b"\xff\xd8\xff" + b"\x00" * 100
+
+    with patch("app.api.expenses.get_llm_provider") as mock_provider_fn:
+        mock_provider = mock_provider_fn.return_value
+        mock_provider.parse_image = AsyncMock(
+            return_value={
+                "amount": 25000,
+                "description": "편의점 결제",
+                "category": "생활",
+                "date": "2026-03-25",
+                "memo": "",
+            }
+        )
+
+        response = await authenticated_client.post(
+            "/api/expenses/ocr",
+            files={"file": ("receipt.jpg", BytesIO(dummy_jpeg), "image/jpeg")},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "인식" in data["message"]
+    assert data["parsed_items"] is not None
+    assert len(data["parsed_items"]) == 1
+    assert data["parsed_items"][0]["amount"] == 25000
+
+
+@pytest.mark.asyncio
+async def test_ocr_invalid_content_type(authenticated_client, test_user: User, db_session):
+    """OCR 잘못된 파일 형식 → 400"""
+    response = await authenticated_client.post(
+        "/api/expenses/ocr",
+        files={"file": ("doc.pdf", BytesIO(b"dummy pdf content"), "application/pdf")},
+    )
+    assert response.status_code == 400
+    assert "이미지" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_ocr_magic_byte_mismatch(authenticated_client, test_user: User, db_session):
+    """OCR 매직 바이트 불일치 → 400"""
+    # Content-Type은 JPEG이지만 실제 내용은 PNG 매직 바이트 아님
+    fake_jpeg = b"NOT_JPEG_CONTENT"
+
+    response = await authenticated_client.post(
+        "/api/expenses/ocr",
+        files={"file": ("fake.jpg", BytesIO(fake_jpeg), "image/jpeg")},
+    )
+    assert response.status_code == 400
+    assert "올바르지 않습니다" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_ocr_llm_error_response(authenticated_client, test_user: User, db_session):
+    """OCR LLM 파싱 실패 → 에러 메시지 반환"""
+    dummy_jpeg = b"\xff\xd8\xff" + b"\x00" * 100
+
+    with patch("app.api.expenses.get_llm_provider") as mock_provider_fn:
+        mock_provider = mock_provider_fn.return_value
+        mock_provider.parse_image = AsyncMock(return_value={"error": "이미지를 인식할 수 없습니다"})
+
+        response = await authenticated_client.post(
+            "/api/expenses/ocr",
+            files={"file": ("receipt.jpg", BytesIO(dummy_jpeg), "image/jpeg")},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "인식할 수 없습니다" in data["message"]
+    assert data["parsed_items"] is None
+
+
+@pytest.mark.asyncio
+async def test_ocr_multiple_items(authenticated_client, test_user: User, db_session):
+    """OCR 다건 인식 (영수증에 여러 항목)"""
+    dummy_jpeg = b"\xff\xd8\xff" + b"\x00" * 100
+
+    with patch("app.api.expenses.get_llm_provider") as mock_provider_fn:
+        mock_provider = mock_provider_fn.return_value
+        mock_provider.parse_image = AsyncMock(
+            return_value=[
+                {"amount": 5000, "description": "아메리카노", "category": "카페", "date": "2026-03-25"},
+                {"amount": 12000, "description": "샐러드", "category": "식비", "date": "2026-03-25"},
+            ]
+        )
+
+        response = await authenticated_client.post(
+            "/api/expenses/ocr",
+            files={"file": ("receipt.jpg", BytesIO(dummy_jpeg), "image/jpeg")},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["parsed_items"] is not None
+    assert len(data["parsed_items"]) == 2
+    assert "2건" in data["message"]
+    assert "17,000" in data["message"]
+
+
+# ── 검색 + 날짜 필터 조합 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_with_date_filter(authenticated_client, test_user: User, test_household: Household, db_session):
+    """query + 날짜 범위 필터 조합"""
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=8000, description="점심 김치찌개", date=datetime(2026, 2, 15))
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=9000, description="점심 된장찌개", date=datetime(2026, 3, 15))
+    e3 = Expense(user_id=test_user.id, household_id=test_household.id, amount=5000, description="커피", date=datetime(2026, 3, 16))
+    db_session.add_all([e1, e2, e3])
+    await db_session.commit()
+
+    # "점심" 검색 + 3월로 필터 → 된장찌개만
+    response = await authenticated_client.get("/api/expenses?query=점심&start_date=2026-03-01&end_date=2026-03-31")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["description"] == "점심 된장찌개"
+
+
+@pytest.mark.asyncio
+async def test_search_with_all_filters(authenticated_client, test_user: User, test_household: Household, db_session):
+    """query + category_id + 날짜 범위 필터 조합"""
+    cat = Category(name="식비", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=8000, description="점심", category_id=cat.id, date=datetime(2026, 3, 10))
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=12000, description="점심 회식", category_id=None, date=datetime(2026, 3, 15))
+    e3 = Expense(user_id=test_user.id, household_id=test_household.id, amount=5000, description="커피", category_id=cat.id, date=datetime(2026, 3, 20))
+    db_session.add_all([e1, e2, e3])
+    await db_session.commit()
+
+    # "점심" + 식비 카테고리 + 3월 → e1만
+    response = await authenticated_client.get(f"/api/expenses?query=점심&category_id={cat.id}&start_date=2026-03-01&end_date=2026-03-31")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["description"] == "점심"
+    assert data[0]["amount"] == 8000.0
+
+
+# ── search/summary 날짜 필터 조합 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_summary_with_date_filter(authenticated_client, test_user: User, test_household: Household, db_session):
+    """search/summary에 날짜 필터 적용"""
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=10000, description="택시", date=datetime(2026, 2, 15))
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=20000, description="택시", date=datetime(2026, 3, 15))
+    db_session.add_all([e1, e2])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/expenses/search/summary?query=택시&start_date=2026-03-01&end_date=2026-03-31")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total_count"] == 1
+    assert data["total_amount"] == 20000.0
+
+
+@pytest.mark.asyncio
+async def test_search_summary_with_category_filter(authenticated_client, test_user: User, test_household: Household, db_session):
+    """search/summary에 카테고리 필터 적용"""
+    cat = Category(name="교통", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=15000, description="택시", category_id=cat.id, date=datetime(2026, 3, 1))
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=8000, description="점심", category_id=None, date=datetime(2026, 3, 2))
+    db_session.add_all([e1, e2])
+    await db_session.commit()
+
+    response = await authenticated_client.get(f"/api/expenses/search/summary?category_id={cat.id}")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total_count"] == 1
+    assert data["total_amount"] == 15000.0
+
+
+# ── 일별 통계 (monthly stats daily_trend) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_monthly_stats_daily_trend(authenticated_client, test_user: User, test_household: Household, db_session):
+    """월별 통계의 daily_trend 정확성 검증"""
+    cat = Category(name="식비", user_id=test_user.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    # 3월 5일에 2건, 3월 10일에 1건
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=5000, description="커피", category_id=cat.id, date=datetime(2026, 3, 5, 10, 0))
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=8000, description="점심", category_id=cat.id, date=datetime(2026, 3, 5, 12, 0))
+    e3 = Expense(user_id=test_user.id, household_id=test_household.id, amount=15000, description="저녁", category_id=cat.id, date=datetime(2026, 3, 10, 19, 0))
+    db_session.add_all([e1, e2, e3])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/expenses/stats/monthly?month=2026-03")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total"] == 28000.0
+    assert len(data["daily_trend"]) == 2  # 2일에 지출
+
+    # 날짜별 합계 검증
+    daily_map = {d["date"]: d["amount"] for d in data["daily_trend"]}
+    assert daily_map.get("2026-03-05") == 13000.0  # 5000 + 8000
+    assert daily_map.get("2026-03-10") == 15000.0
+
+
+# ── 멤버별 필터링 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_filter_by_member_user_id(authenticated_client, test_user: User, test_household: Household, db_session):
+    """member_user_id로 특정 멤버의 지출만 필터링"""
+    from app.models.household_member import HouseholdMember
+
+    # 두 번째 멤버 생성 (같은 가구)
+    user2 = User(
+        auth_user_id="a1b2c3d4-9999-0000-0000-000000000099",
+        username="member2",
+        email="member2@test.com",
+        is_active=True,
+    )
+    db_session.add(user2)
+    await db_session.flush()
+    member2 = HouseholdMember(household_id=test_household.id, user_id=user2.id, role="member")
+    db_session.add(member2)
+    await db_session.flush()
+
+    # test_user의 지출
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=8000, description="test_user 지출", date=datetime(2026, 3, 15))
+    # user2의 지출
+    e2 = Expense(user_id=user2.id, household_id=test_household.id, amount=5000, description="member2 지출", date=datetime(2026, 3, 15))
+    db_session.add_all([e1, e2])
+    await db_session.commit()
+
+    # member_user_id=user2.id로 필터
+    response = await authenticated_client.get(f"/api/expenses?member_user_id={user2.id}")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["description"] == "member2 지출"
+
+
+# ── 지출 수정 시 일부 필드만 변경 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_expense_partial(authenticated_client, test_user: User, test_household: Household, db_session):
+    """지출 수정 시 금액만 변경 (다른 필드 유지)"""
+    cat = Category(name="식비", user_id=test_user.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    expense = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=8000,
+        description="김치찌개",
+        category_id=cat.id,
+        date=datetime(2026, 3, 15),
+        memo="원래 메모",
+    )
+    db_session.add(expense)
+    await db_session.commit()
+    await db_session.refresh(expense)
+
+    # 금액만 변경
+    response = await authenticated_client.put(f"/api/expenses/{expense.id}", json={"amount": 10000.0})
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["amount"] == 10000.0
+    assert data["description"] == "김치찌개"  # 유지
+    assert data["memo"] == "원래 메모"  # 유지
+
+
+@pytest.mark.asyncio
+async def test_update_expense_category(authenticated_client, test_user: User, test_household: Household, db_session):
+    """지출 수정 시 카테고리 변경"""
+    cat1 = Category(name="식비", user_id=test_user.id)
+    cat2 = Category(name="외식비", user_id=test_user.id)
+    db_session.add_all([cat1, cat2])
+    await db_session.commit()
+    await db_session.refresh(cat1)
+    await db_session.refresh(cat2)
+
+    expense = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=8000,
+        description="김치찌개",
+        category_id=cat1.id,
+        date=datetime(2026, 3, 15),
+    )
+    db_session.add(expense)
+    await db_session.commit()
+    await db_session.refresh(expense)
+
+    response = await authenticated_client.put(f"/api/expenses/{expense.id}", json={"category_id": cat2.id})
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["category_id"] == cat2.id
+
+
+# ── 카테고리 없는 지출의 통계 (미분류) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stats_uncategorized(authenticated_client, test_user: User, test_household: Household, db_session):
+    """카테고리 없는 지출은 통계에서 '미분류'로 표시"""
+    e = Expense(user_id=test_user.id, household_id=test_household.id, amount=10000, description="미분류 지출", category_id=None, date=datetime(2026, 3, 15))
+    db_session.add(e)
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/expenses/stats?period=monthly&date=2026-03-15")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["total"] == 10000.0
+    assert len(data["by_category"]) == 1
+    assert data["by_category"][0]["category"] == "미분류"
+
+
+# ── 비교 통계에서 카테고리별 비교 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stats_comparison_by_category(authenticated_client, test_user: User, test_household: Household, db_session):
+    """월간 비교 통계에서 카테고리별 비교 데이터 포함"""
+    cat = Category(name="식비", user_id=test_user.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    # 2월 식비 100,000원
+    e1 = Expense(user_id=test_user.id, household_id=test_household.id, amount=100000, description="2월 식비", category_id=cat.id, date=datetime(2026, 2, 15))
+    # 3월 식비 150,000원
+    e2 = Expense(user_id=test_user.id, household_id=test_household.id, amount=150000, description="3월 식비", category_id=cat.id, date=datetime(2026, 3, 15))
+    db_session.add_all([e1, e2])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/expenses/stats/comparison?period=monthly&date=2026-03-31")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "by_category_comparison" in data
+    assert len(data["by_category_comparison"]) >= 1
+
+    food_comparison = next((c for c in data["by_category_comparison"] if c["category"] == "식비"), None)
+    assert food_comparison is not None
+    assert food_comparison["current"] == 150000.0
+    assert food_comparison["previous"] == 100000.0
+    assert food_comparison["change_amount"] == 50000.0

--- a/backend/tests/integration/test_api_income.py
+++ b/backend/tests/integration/test_api_income.py
@@ -207,7 +207,7 @@ async def test_create_income_with_date_only_format(authenticated_client, test_us
         "date": "2026-02-01",  # LLM이 반환하는 형식 — 시간 없는 날짜
     }
     response = await authenticated_client.post("/api/income", json=payload)
-    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 수입 생성이 실패함. " "IncomeCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
+    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 수입 생성이 실패함. IncomeCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
     data = response.json()
     assert data["description"] == "2월 월급"
     assert data["amount"] == 3500000

--- a/backend/tests/integration/test_api_kakao_extra.py
+++ b/backend/tests/integration/test_api_kakao_extra.py
@@ -1,0 +1,321 @@
+"""
+카카오톡 채널 봇 Webhook API 추가 테스트 (#357)
+
+기존 test_api_kakao.py에서 누락된 영역:
+- /unlink 명령어
+- 콜백 모드: 명령어 외 자연어 입력이 아닌 경로
+- LLM 빈 응답/빈 리스트 처리
+- 연동 후 지출 → 수입 연속 플로우
+- 다건 혼합 (수입 + 지출) 저장 후 DB 검증
+"""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.core.config import settings as _app_settings
+from app.core.database import get_db
+from app.main import app as _app
+from app.models.expense import Expense
+from app.models.household import Household
+from app.models.household_member import HouseholdMember
+from app.models.income import Income
+from app.services.bot_strike_service import _error_counts
+
+# 테스트용 API 키
+_KAKAO_TEST_API_KEY = "kakao-test-key-for-pytest-extra"  # pragma: allowlist secret
+
+
+@pytest.fixture(autouse=True)
+def _kakao_api_key():
+    """카카오 테스트에서 KAKAO_BOT_API_KEY를 테스트 값으로 설정."""
+    with patch.object(_app_settings, "KAKAO_BOT_API_KEY", _KAKAO_TEST_API_KEY):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _clear_strike_counts():
+    """테스트 간 Strike 카운트 격리"""
+    _error_counts.clear()
+    yield
+    _error_counts.clear()
+
+
+@pytest_asyncio.fixture
+async def client(db_session):
+    """카카오 테스트용 HTTP 클라이언트"""
+
+    async def override_get_db():
+        yield db_session
+
+    _app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(
+        transport=ASGITransport(app=_app),
+        base_url="http://test",
+        headers={"Authorization": _KAKAO_TEST_API_KEY},
+    ) as ac:
+        yield ac
+
+    _app.dependency_overrides.clear()
+
+
+def make_kakao_request(utterance: str, user_id: str = "kakao_user_extra") -> dict:
+    """카카오 i 오픈빌더 요청 형식 생성 헬퍼"""
+    return {
+        "intent": {"id": "test_intent", "name": "TestIntent"},
+        "userRequest": {
+            "utterance": utterance,
+            "params": {},
+            "block": {"id": "test_block", "name": "TestBlock"},
+            "user": {"id": user_id, "type": "botUserKey"},
+        },
+        "bot": {"id": "test_bot", "name": "HomeNRich"},
+    }
+
+
+def make_kakao_request_with_callback(utterance: str, user_id: str = "kakao_user_extra", callback_url: str = "https://callback.kakao.com/test") -> dict:
+    """callbackUrl이 포함된 카카오 요청 생성 헬퍼"""
+    return {
+        "intent": {"id": "test_intent", "name": "TestIntent"},
+        "userRequest": {
+            "utterance": utterance,
+            "params": {},
+            "block": {"id": "test_block", "name": "TestBlock"},
+            "user": {"id": user_id, "type": "botUserKey"},
+            "callbackUrl": callback_url,
+        },
+        "bot": {"id": "test_bot", "name": "HomeNRich"},
+    }
+
+
+async def setup_kakao_bot_user_with_household(db_session, platform_user_id: str):
+    """카카오 봇 사용자에게 가구를 설정하는 헬퍼"""
+    from app.services.bot_user_service import get_or_create_bot_user
+
+    bot_user = await get_or_create_bot_user(db_session, platform="kakao", platform_user_id=platform_user_id)
+    household = Household(name=f"카카오 추가 테스트 가구 {platform_user_id}")
+    db_session.add(household)
+    await db_session.flush()
+    member = HouseholdMember(household_id=household.id, user_id=bot_user.id, role="owner")
+    db_session.add(member)
+    await db_session.commit()
+    return bot_user, household
+
+
+# ── LLM 빈 응답 처리 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kakao_llm_returns_empty_dict(client, db_session, mock_llm_parse_expense):
+    """LLM이 빈 dict를 반환하면 파싱 실패로 처리"""
+    await setup_kakao_bot_user_with_household(db_session, "kakao_user_extra")
+
+    mock_llm_parse_expense.return_value = {}
+
+    payload = make_kakao_request("잘 모르겠는 입력")
+    response = await client.post("/api/kakao/webhook", json=payload)
+    assert response.status_code == 200
+
+    # DB에 저장되지 않음
+    result = await db_session.execute(select(Expense))
+    assert len(result.scalars().all()) == 0
+
+
+@pytest.mark.asyncio
+async def test_kakao_llm_returns_empty_list(client, db_session, mock_llm_parse_expense):
+    """LLM이 빈 list를 반환하면 에러 메시지 반환"""
+    await setup_kakao_bot_user_with_household(db_session, "kakao_user_extra")
+
+    mock_llm_parse_expense.return_value = []
+
+    payload = make_kakao_request("빈 리스트 입력")
+    response = await client.post("/api/kakao/webhook", json=payload)
+    assert response.status_code == 200
+
+    # DB에 저장되지 않음
+    result = await db_session.execute(select(Expense))
+    assert len(result.scalars().all()) == 0
+
+
+# ── 콜백 모드: /undo 등 빠른 명령어도 동기 처리 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kakao_callback_mode_undo_no_callback(client, db_session, mock_llm_parse_expense):
+    """콜백 모드 활성화 + 취소 명령어 → useCallback 없이 즉시 동기 처리"""
+    await setup_kakao_bot_user_with_household(db_session, "kakao_user_extra")
+
+    # 먼저 지출 입력
+    payload_expense = make_kakao_request("커피 5000원")
+    await client.post("/api/kakao/webhook", json=payload_expense)
+
+    with patch.object(_app_settings, "KAKAO_CALLBACK_ENABLED", True):
+        payload = make_kakao_request_with_callback("취소")
+        response = await client.post("/api/kakao/webhook", json=payload)
+        assert response.status_code == 200
+
+        data = response.json()
+        # 명령어는 콜백 안 쓰고 즉시 처리
+        assert "useCallback" not in data
+        assert "template" in data
+        text = data["template"]["outputs"][0]["simpleText"]["text"]
+        assert "삭제" in text
+
+
+# ── 콜백 모드: /help 도움말도 동기 처리 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kakao_callback_mode_help_no_callback(client, db_session):
+    """콜백 모드 + 도움말 명령어 → 즉시 동기 응답"""
+    with patch.object(_app_settings, "KAKAO_CALLBACK_ENABLED", True):
+        payload = make_kakao_request_with_callback("도움말")
+        response = await client.post("/api/kakao/webhook", json=payload)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "useCallback" not in data
+        assert "template" in data
+
+
+# ── 연동 해제: /unlink 또는 '해제' 한글 명령어 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kakao_unlinked_user_expense_creates_auto_household(client, db_session, mock_llm_parse_expense):
+    """연동 안 된 사용자가 지출 입력 시 자동 가구가 생성되어 저장됨"""
+    payload = make_kakao_request("점심 8000원", user_id="kakao_auto_hh_user")
+    response = await client.post("/api/kakao/webhook", json=payload)
+    assert response.status_code == 200
+
+    # 지출이 저장됨 (자동 가구 생성)
+    result = await db_session.execute(select(Expense))
+    expenses = result.scalars().all()
+    assert len(expenses) == 1
+    assert expenses[0].amount == 8000.0
+    assert expenses[0].household_id is not None
+
+
+# ── 수입 후 지출 연속 입력 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kakao_income_then_expense_sequential(client, db_session, mock_llm_parse_expense):
+    """수입 → 지출 순서로 연속 입력 시 각각 올바른 테이블에 저장"""
+    await setup_kakao_bot_user_with_household(db_session, "kakao_user_extra")
+
+    # 수입
+    mock_llm_parse_expense.return_value = {
+        "amount": 3000000,
+        "description": "월급",
+        "category": "급여",
+        "date": "2026-03-20",
+        "type": "income",
+    }
+    await client.post("/api/kakao/webhook", json=make_kakao_request("월급 300만원"))
+
+    # 지출
+    mock_llm_parse_expense.return_value = {
+        "amount": 8000,
+        "category": "식비",
+        "description": "점심",
+        "date": "2026-03-20",
+        "memo": "",
+    }
+    await client.post("/api/kakao/webhook", json=make_kakao_request("점심 8000원"))
+
+    # Income 1건
+    result = await db_session.execute(select(Income))
+    incomes = result.scalars().all()
+    assert len(incomes) == 1
+    assert incomes[0].amount == 3000000
+
+    # Expense 1건
+    result = await db_session.execute(select(Expense))
+    expenses = result.scalars().all()
+    assert len(expenses) == 1
+    assert expenses[0].amount == 8000
+
+
+# ── API 키 미설정 시 503 반환 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kakao_webhook_no_api_key_returns_503(client, db_session):
+    """API 키가 빈 문자열이면 503 반환"""
+    with patch("app.api.kakao.settings") as mock_settings:
+        mock_settings.KAKAO_BOT_API_KEY = ""
+
+        payload = make_kakao_request("/help")
+        response = await client.post("/api/kakao/webhook", json=payload)
+        assert response.status_code == 503
+
+
+# ── /start 명령어는 카카오에서 지원하지 않음 → LLM 파싱으로 넘어감 ──────
+
+
+@pytest.mark.asyncio
+async def test_kakao_start_command_not_supported(client, db_session, mock_llm_parse_expense):
+    """/start는 카카오에서 별도 명령어가 아니므로 LLM 파싱으로 넘어감"""
+    await setup_kakao_bot_user_with_household(db_session, "kakao_user_extra")
+
+    mock_llm_parse_expense.return_value = {"error": "파싱 실패"}
+
+    payload = make_kakao_request("/start")
+    response = await client.post("/api/kakao/webhook", json=payload)
+    assert response.status_code == 200
+
+    # 파싱 에러 또는 도움말 메시지
+    data = response.json()
+    text = data["template"]["outputs"][0]["simpleText"]["text"]
+    assert len(text) > 0
+
+
+# ── 특수 문자 입력 처리 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kakao_special_characters_input(client, db_session, mock_llm_parse_expense):
+    """특수 문자가 포함된 입력도 정상 처리"""
+    await setup_kakao_bot_user_with_household(db_session, "kakao_user_extra")
+
+    mock_llm_parse_expense.return_value = {
+        "amount": 15000,
+        "category": "식비",
+        "description": "치킨&피자",
+        "date": "2026-03-25",
+        "memo": "",
+    }
+
+    payload = make_kakao_request("치킨&피자 15,000원!!")
+    response = await client.post("/api/kakao/webhook", json=payload)
+    assert response.status_code == 200
+
+    result = await db_session.execute(select(Expense))
+    expenses = result.scalars().all()
+    assert len(expenses) == 1
+    assert expenses[0].amount == 15000
+
+
+# ── quickReply 응답에 항상 도움말 포함 확인 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kakao_help_response_has_quickreplies(client, db_session):
+    """도움말 응답에 quickReplies가 포함됨"""
+    payload = make_kakao_request("도움말")
+    response = await client.post("/api/kakao/webhook", json=payload)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "quickReplies" in data["template"]
+    quick_replies = data["template"]["quickReplies"]
+    assert len(quick_replies) > 0
+    labels = [qr["label"] for qr in quick_replies]
+    # 도움말 quickReply에는 지출 보기 + 예산 현황 버튼이 있음
+    assert any("지출" in label for label in labels)
+    assert any("예산" in label for label in labels)

--- a/backend/tests/integration/test_api_telegram_extra.py
+++ b/backend/tests/integration/test_api_telegram_extra.py
@@ -1,0 +1,346 @@
+"""
+Telegram Webhook API 추가 테스트 (#357)
+
+기존 test_api_telegram.py에서 누락된 영역:
+- 수입 자연어 입력 다건 (list 반환)
+- 수정 명령어 (금액 변경 콜백)
+- LLM 파싱 시 빈 응답
+- /link 코드 없이 입력
+- /feedback 콜백 모드
+- 메시지 포맷 정합성
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from app.models.category import Category
+from app.models.expense import Expense
+from app.models.household import Household
+from app.models.household_member import HouseholdMember
+from app.models.income import Income
+from app.models.user import User
+
+
+async def setup_bot_user_with_household(db_session, chat_id: int):
+    """봇 사용자에게 가구를 설정하는 헬퍼"""
+    from app.services.bot_user_service import get_or_create_bot_user
+
+    bot_user = await get_or_create_bot_user(db_session, platform="telegram", platform_user_id=str(chat_id))
+    household = Household(name=f"테스트 가구 {chat_id}")
+    db_session.add(household)
+    await db_session.flush()
+    member = HouseholdMember(household_id=household.id, user_id=bot_user.id, role="owner")
+    db_session.add(member)
+    await db_session.commit()
+    return bot_user, household
+
+
+# ── 수입 다건 입력 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_webhook_multiple_income_input(client, db_session, mock_telegram_send, mock_llm_parse_expense):
+    """여러 수입 동시 입력 (list 반환, 모두 type=income)"""
+    bot_user, household = await setup_bot_user_with_household(db_session, chat_id=70001)
+
+    # 수입 카테고리 생성
+    cat1 = Category(name="급여", type="income", household_id=household.id)
+    cat2 = Category(name="부수입", type="income", household_id=household.id)
+    db_session.add_all([cat1, cat2])
+    await db_session.commit()
+
+    mock_llm_parse_expense.return_value = [
+        {"amount": 3000000, "category": "급여", "description": "월급", "date": "2026-03-20", "type": "income"},
+        {"amount": 500000, "category": "부수입", "description": "부업", "date": "2026-03-20", "type": "income"},
+    ]
+
+    payload = {"message": {"chat": {"id": 70001}, "text": "월급 300만원, 부업 50만원"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    # Income 2건 저장
+    result = await db_session.execute(select(Income))
+    incomes = result.scalars().all()
+    assert len(incomes) == 2
+
+    # Expense는 0건
+    result = await db_session.execute(select(Expense))
+    assert len(result.scalars().all()) == 0
+
+    # 메시지에 건수 포함
+    mock_telegram_send.assert_called_once()
+    sent_message = mock_telegram_send.call_args[0][1]
+    assert "2건" in sent_message
+    assert "수입" in sent_message
+
+
+# ── 혼합 입력 (수입 + 지출) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_webhook_mixed_income_expense(client, db_session, mock_telegram_send, mock_llm_parse_expense):
+    """다중 건 입력에서 수입/지출 혼합 처리"""
+    bot_user, household = await setup_bot_user_with_household(db_session, chat_id=70002)
+
+    mock_llm_parse_expense.return_value = [
+        {"amount": 3000000, "description": "월급", "category": "급여", "date": "2026-03-20", "type": "income"},
+        {"amount": 8000, "description": "점심", "category": "식비", "date": "2026-03-20", "type": "expense"},
+    ]
+
+    payload = {"message": {"chat": {"id": 70002}, "text": "월급 300만원, 점심 8000원"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    # Income 1건 + Expense 1건
+    result_income = await db_session.execute(select(Income))
+    assert len(result_income.scalars().all()) == 1
+
+    result_expense = await db_session.execute(select(Expense))
+    assert len(result_expense.scalars().all()) == 1
+
+    # 메시지에 수입과 지출 모두 언급
+    mock_telegram_send.assert_called_once()
+    sent = mock_telegram_send.call_args[0][1]
+    assert "수입" in sent
+    assert "지출" in sent or "기록" in sent
+
+
+# ── LLM 빈 응답 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_webhook_llm_returns_empty_dict(client, db_session, mock_telegram_send, mock_llm_parse_expense):
+    """LLM이 빈 dict를 반환하면 파싱 실패로 처리"""
+    await setup_bot_user_with_household(db_session, chat_id=70003)
+
+    mock_llm_parse_expense.return_value = {}
+
+    payload = {"message": {"chat": {"id": 70003}, "text": "잘 모르겠는 입력"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    # DB에 저장되지 않음
+    result = await db_session.execute(select(Expense))
+    assert len(result.scalars().all()) == 0
+
+
+@pytest.mark.asyncio
+async def test_webhook_llm_returns_empty_list(client, db_session, mock_telegram_send, mock_llm_parse_expense):
+    """LLM이 빈 list를 반환하면 에러 메시지 전송"""
+    await setup_bot_user_with_household(db_session, chat_id=70004)
+
+    mock_llm_parse_expense.return_value = []
+
+    payload = {"message": {"chat": {"id": 70004}, "text": "빈 응답 테스트"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    # DB에 저장되지 않음
+    result = await db_session.execute(select(Expense))
+    assert len(result.scalars().all()) == 0
+
+
+# ── /link 코드 없이 입력 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_link_without_code(client, db_session, mock_telegram_send):
+    """/link만 입력하면 사용법 안내 메시지 전송"""
+    chat_id = 70005
+    payload = {"message": {"chat": {"id": chat_id}, "text": "/link"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    mock_telegram_send.assert_called_once()
+    msg = mock_telegram_send.call_args[0][1]
+    assert "연동" in msg
+
+
+# ── /link 이미 연동된 사용자 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_link_already_linked_user(client, db_session, mock_telegram_send):
+    """이미 연동된 사용자가 다시 /link 시도"""
+    chat_id = 70006
+    web_user = User(
+        username="already_linked",
+        email="linked@test.com",
+        telegram_chat_id=str(chat_id),
+        telegram_link_code="RELINK",
+        telegram_link_code_expires_at=datetime.now(UTC) + timedelta(minutes=10),
+    )
+    db_session.add(web_user)
+    await db_session.flush()
+    household = Household(name="연동 테스트 가구")
+    db_session.add(household)
+    await db_session.flush()
+    member = HouseholdMember(household_id=household.id, user_id=web_user.id, role="owner")
+    db_session.add(member)
+    await db_session.commit()
+
+    payload = {"message": {"chat": {"id": chat_id}, "text": "/link RELINK"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    # 이미 연동됨 또는 연동 완료 메시지
+    mock_telegram_send.assert_called_once()
+    msg = mock_telegram_send.call_args[0][1]
+    assert "연동" in msg
+
+
+# ── /feedback 콜백 버튼 테스트 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_feedback_callback_button(client, db_session, mock_telegram_send):
+    """피드백 타입 콜백 버튼 클릭 시 안내 메시지"""
+    await setup_bot_user_with_household(db_session, chat_id=70007)
+
+    with patch("app.api.telegram.answer_callback_query", new_callable=AsyncMock):
+        callback_payload = {
+            "callback_query": {
+                "id": "cb_fb_type",
+                "message": {"chat": {"id": 70007}},
+                "data": "feedback_type:feature",
+            }
+        }
+        response = await client.post("/api/telegram/webhook", json=callback_payload)
+        assert response.status_code == 200
+
+
+# ── 연속 성공 후 Strike 리셋 확인 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_successful_parse_resets_strike(client, db_session, mock_telegram_send, mock_llm_parse_expense):
+    """파싱 성공 후 Strike 카운트가 직접 리셋됨 (서비스 레벨 검증)"""
+    from app.services.bot_strike_service import _error_counts, get_strike_count, increment_strike, reset_strike
+
+    _error_counts.clear()
+
+    # Strike를 2회 증가
+    increment_strike("telegram", "70008")
+    increment_strike("telegram", "70008")
+    assert get_strike_count("telegram", "70008") == 2
+
+    # reset 호출 후 0으로 돌아감
+    reset_strike("telegram", "70008")
+    assert get_strike_count("telegram", "70008") == 0
+
+    # 다시 1회 증가하면 1이어야 함
+    new_count = increment_strike("telegram", "70008")
+    assert new_count == 1
+
+    _error_counts.clear()
+
+
+# ── 비어있는 callback_query data ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_callback_empty_data(client, db_session, mock_telegram_send):
+    """callback_query.data가 비어있을 때 정상 처리"""
+    with patch("app.api.telegram.answer_callback_query", new_callable=AsyncMock):
+        callback_payload = {
+            "callback_query": {
+                "id": "cb_empty",
+                "message": {"chat": {"id": 12345}},
+                "data": "",
+            }
+        }
+        response = await client.post("/api/telegram/webhook", json=callback_payload)
+        assert response.status_code == 200
+
+
+# ── cmd:budget 콜백 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cmd_callback_budget(client, db_session, mock_telegram_send):
+    """cmd:budget 콜백이 예산 현황을 전송"""
+    await setup_bot_user_with_household(db_session, chat_id=70009)
+
+    with patch("app.api.telegram.answer_callback_query", new_callable=AsyncMock):
+        callback_payload = {
+            "callback_query": {
+                "id": "cb_cmd_budget",
+                "message": {"chat": {"id": 70009}},
+                "data": "cmd:budget",
+            }
+        }
+        response = await client.post("/api/telegram/webhook", json=callback_payload)
+        assert response.status_code == 200
+
+    assert mock_telegram_send.called
+    sent_message = mock_telegram_send.call_args[0][1]
+    assert "예산" in sent_message
+
+
+# ── 지출 저장 후 응답에 인라인 키보드 포함 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_expense_saved_has_inline_keyboard(client, db_session, mock_telegram_send, mock_llm_parse_expense):
+    """지출 저장 성공 시 응답에 삭제/카테고리 변경 인라인 키보드 포함"""
+    await setup_bot_user_with_household(db_session, chat_id=70010)
+
+    payload = {"message": {"chat": {"id": 70010}, "text": "점심 8000원"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    mock_telegram_send.assert_called_once()
+    call_kwargs = mock_telegram_send.call_args
+    # reply_markup에 inline_keyboard 포함
+    reply_markup = call_kwargs[1].get("reply_markup") if call_kwargs[1] else None
+    assert reply_markup is not None
+    assert "inline_keyboard" in reply_markup
+
+
+# ── 수입 저장 후 응답에 인라인 키보드 포함 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_income_saved_has_inline_keyboard(client, db_session, mock_telegram_send, mock_llm_parse_expense):
+    """수입 저장 성공 시 응답에 삭제/변환 인라인 키보드 포함"""
+    bot_user, household = await setup_bot_user_with_household(db_session, chat_id=70011)
+
+    cat = Category(name="급여", type="income", household_id=household.id)
+    db_session.add(cat)
+    await db_session.commit()
+
+    mock_llm_parse_expense.return_value = {
+        "amount": 3000000,
+        "description": "월급",
+        "category": "급여",
+        "date": "2026-03-20",
+        "type": "income",
+    }
+
+    payload = {"message": {"chat": {"id": 70011}, "text": "월급 300만원"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    mock_telegram_send.assert_called_once()
+    call_kwargs = mock_telegram_send.call_args
+    reply_markup = call_kwargs[1].get("reply_markup") if call_kwargs[1] else None
+    assert reply_markup is not None
+    assert "inline_keyboard" in reply_markup
+
+
+# ── 딥링크 /start 이미 연동된 사용자 ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_deeplink_already_linked(client, db_session, mock_telegram_send):
+    """이미 연동된 사용자가 딥링크로 재접속 시 환영 메시지"""
+    payload = {"message": {"chat": {"id": 70012}, "text": "/start"}}
+    response = await client.post("/api/telegram/webhook", json=payload)
+    assert response.status_code == 200
+
+    mock_telegram_send.assert_called_once()
+    msg = mock_telegram_send.call_args[0][1]
+    assert "환영" in msg or "HomeNRich" in msg


### PR DESCRIPTION
## Summary

- **#357**: Telegram/Kakao 봇 API 테스트 23개 추가 (수입/혼합 입력, 에러 처리, 연동, 콜백)
- **#358**: Expenses API 테스트 23개 추가 (통계, OCR, 검색 필터, 비교)

## 추가된 테스트 (46개)

| 파일 | 개수 | 주요 검증 |
|------|------|-----------|
| `test_api_telegram_extra.py` | 13 | 수입/혼합 입력, LLM 에러, /link 연동, 콜백 |
| `test_api_kakao_extra.py` | 10 | 콜백 모드, 자동 가구 생성, API 키 미설정 |
| `test_api_expenses_extra.py` | 23 | 통계(주간/월간/연간), OCR, 검색+필터, 비교 |

## Test plan

- [x] 전체 944 passed, 5 skipped
- [x] ruff lint/format 통과
- [ ] CI 통과

Closes #357
Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)