### PR TITLE
test: 서비스 + LLM 프로바이더 테스트 강화 (#359, #363)

### DIFF
--- a/backend/alembic/versions/d367e7848291_seed_system_categories_and_relink_.py
+++ b/backend/alembic/versions/d367e7848291_seed_system_categories_and_relink_.py
@@ -102,7 +102,7 @@ def upgrade() -> None:
         if new_sys_id is None:
             continue
         old_cats = conn.execute(
-            sa.text("SELECT id FROM categories WHERE name = :name " "AND NOT (user_id IS NULL AND household_id IS NULL)"),
+            sa.text("SELECT id FROM categories WHERE name = :name AND NOT (user_id IS NULL AND household_id IS NULL)"),
             {"name": old_name},
         ).fetchall()
         for (old_id,) in old_cats:
@@ -114,7 +114,7 @@ def upgrade() -> None:
         if sys_id is None:
             continue
         dup_cats = conn.execute(
-            sa.text("SELECT id FROM categories WHERE name = :name AND id != :sys_id " "AND NOT (user_id IS NULL AND household_id IS NULL)"),
+            sa.text("SELECT id FROM categories WHERE name = :name AND id != :sys_id AND NOT (user_id IS NULL AND household_id IS NULL)"),
             {"name": sys_name, "sys_id": sys_id},
         ).fetchall()
         for (dup_id,) in dup_cats:
@@ -134,7 +134,7 @@ def upgrade() -> None:
             ).fetchone()
             if existing is None:
                 conn.execute(
-                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) " "VALUES (:hh, NULL, :src, :target)"),
+                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) VALUES (:hh, NULL, :src, :target)"),
                     {"hh": hh_id, "src": old_name, "target": new_sys_id},
                 )
 

--- a/backend/alembic/versions/f5g6h7i8j9k0_migrate_legacy_categories.py
+++ b/backend/alembic/versions/f5g6h7i8j9k0_migrate_legacy_categories.py
@@ -85,7 +85,7 @@ def upgrade() -> None:
 
         # 이 이름의 비시스템 카테고리 전부 조회
         old_cats = conn.execute(
-            sa.text("SELECT id FROM categories WHERE name = :name " "AND NOT (user_id IS NULL AND household_id IS NULL)"),
+            sa.text("SELECT id FROM categories WHERE name = :name AND NOT (user_id IS NULL AND household_id IS NULL)"),
             {"name": old_name},
         ).fetchall()
 
@@ -108,7 +108,7 @@ def upgrade() -> None:
             ).fetchone()
             if existing is None:
                 conn.execute(
-                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) " "VALUES (:hh, NULL, :src, :target)"),
+                    sa.text("INSERT INTO category_mappings (household_id, user_id, source_name, target_category_id) VALUES (:hh, NULL, :src, :target)"),
                     {"hh": hh_id, "src": old_name, "target": sys_id},
                 )
 

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -266,7 +266,7 @@ async def _handle_start_command(chat_id: int, user_text: str, bot_user: Any, db:
             }
             await send_telegram_message(
                 chat_id,
-                "🔗 연동 완료! 이제 포도가계부를 사용할 수 있어요 🍇\n\n" "말하듯 편하게 지출을 입력해보세요.\n" '"점심 김치찌개 8000원"',
+                '🔗 연동 완료! 이제 포도가계부를 사용할 수 있어요 🍇\n\n말하듯 편하게 지출을 입력해보세요.\n"점심 김치찌개 8000원"',
                 reply_markup=reply_markup,
             )
             return {"ok": True}

--- a/backend/app/services/bot_messages.py
+++ b/backend/app/services/bot_messages.py
@@ -98,12 +98,12 @@ def format_parse_error(strike: int | str = 1) -> str:
     if isinstance(strike, str):
         strike = 1
     if strike <= 1:
-        return "🤔 금액을 찾지 못했어요\n\n" "이렇게 입력해보세요:\n" '"점심 김치찌개 8000원"'
+        return '🤔 금액을 찾지 못했어요\n\n이렇게 입력해보세요:\n"점심 김치찌개 8000원"'
     elif strike == 2:
-        return "😅 아직 이해하지 못했어요\n\n" "다른 방식으로 입력해볼까요?\n" '"8000원 점심" 처럼 금액을 먼저 써도 돼요'
+        return '😅 아직 이해하지 못했어요\n\n다른 방식으로 입력해볼까요?\n"8000원 점심" 처럼 금액을 먼저 써도 돼요'
     else:
         # strike >= 3
-        return "제가 아직 이해하기 어려운 표현인 것 같아요 😊\n\n" "아래 버튼으로 도움말을 확인해보세요"
+        return "제가 아직 이해하기 어려운 표현인 것 같아요 😊\n\n아래 버튼으로 도움말을 확인해보세요"
 
 
 def format_unknown_input(**kwargs) -> str:
@@ -137,12 +137,7 @@ def format_help_message(platform: str = "telegram") -> str:
         )
     else:
         commands = (
-            "\n명령어:\n"
-            "/report — 이번 달 지출 요약\n"
-            "/budget — 예산 현황\n"
-            "/link 코드 — 웹 계정 연동\n"
-            "피드백 [내용] — 의견이나 버그 신고\n"
-            "/help — 이 도움말"
+            "\n명령어:\n/report — 이번 달 지출 요약\n/budget — 예산 현황\n/link 코드 — 웹 계정 연동\n피드백 [내용] — 의견이나 버그 신고\n/help — 이 도움말"
         )
 
     return base + commands
@@ -161,24 +156,12 @@ def format_welcome_message() -> str:
 
 def format_link_usage_message() -> str:
     """연동 코드 사용법 (텔레그램)"""
-    return (
-        "🔗 웹 계정 연동 방법\n\n"
-        "1. 포도가계부 웹 → 설정 → 텔레그램 연동\n"
-        "2. 코드를 발급받아 아래처럼 입력\n\n"
-        "/link ABC123\n\n"
-        "⏰ 코드는 15분 후 만료돼요"
-    )
+    return "🔗 웹 계정 연동 방법\n\n1. 포도가계부 웹 → 설정 → 텔레그램 연동\n2. 코드를 발급받아 아래처럼 입력\n\n/link ABC123\n\n⏰ 코드는 15분 후 만료돼요"
 
 
 def format_kakao_link_usage_message() -> str:
     """연동 코드 사용법 (카카오톡)"""
-    return (
-        "🔗 웹 계정 연동 방법\n\n"
-        "1. 포도가계부 웹 → 설정 → 카카오톡 연동\n"
-        "2. 코드를 발급받아 아래처럼 입력\n\n"
-        "연동 ABC123\n\n"
-        "⏰ 코드는 15분 후 만료돼요"
-    )
+    return "🔗 웹 계정 연동 방법\n\n1. 포도가계부 웹 → 설정 → 카카오톡 연동\n2. 코드를 발급받아 아래처럼 입력\n\n연동 ABC123\n\n⏰ 코드는 15분 후 만료돼요"
 
 
 def format_delete_confirm(amount: float, description: str, **kwargs) -> str:
@@ -340,10 +323,4 @@ def format_feedback_received() -> str:
 
 def format_feedback_guide() -> str:
     """피드백 사용법 안내 메시지"""
-    return (
-        "💬 피드백을 보내주세요!\n\n"
-        "예시:\n"
-        "· 피드백 검색 기능이 있으면 좋겠어요\n"
-        "· 버그 카테고리가 안 보여요\n\n"
-        "'버그'로 시작하면 버그 신고로 분류돼요."
-    )
+    return "💬 피드백을 보내주세요!\n\n예시:\n· 피드백 검색 기능이 있으면 좋겠어요\n· 버그 카테고리가 안 보여요\n\n'버그'로 시작하면 버그 신고로 분류돼요."

--- a/backend/tests/integration/test_api_expenses.py
+++ b/backend/tests/integration/test_api_expenses.py
@@ -326,7 +326,7 @@ async def test_create_expense_with_date_only_format(authenticated_client, test_u
         "date": "2026-02-11",
     }
     response = await authenticated_client.post("/api/expenses", json=payload)
-    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 지출 생성이 실패함. " "ExpenseCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
+    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 지출 생성이 실패함. ExpenseCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
     data = response.json()
     assert data["description"] == "전기차충전"
     assert data["amount"] == 11680

--- a/backend/tests/integration/test_api_income.py
+++ b/backend/tests/integration/test_api_income.py
@@ -207,7 +207,7 @@ async def test_create_income_with_date_only_format(authenticated_client, test_us
         "date": "2026-02-01",  # LLM이 반환하는 형식 — 시간 없는 날짜
     }
     response = await authenticated_client.post("/api/income", json=payload)
-    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 수입 생성이 실패함. " "IncomeCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
+    assert response.status_code == 201, "YYYY-MM-DD 형식 날짜로 수입 생성이 실패함. IncomeCreate.date 필드가 날짜만 있는 문자열을 허용해야 합니다."
     data = response.json()
     assert data["description"] == "2월 월급"
     assert data["amount"] == 3500000

--- a/backend/tests/unit/test_budget_service.py
+++ b/backend/tests/unit/test_budget_service.py
@@ -1,0 +1,400 @@
+"""budget_service 단위 테스트 (#359)
+
+get_budget_alerts, get_category_overview의 비즈니스 로직을
+AsyncSession 모킹으로 검증합니다. DB 없이 순수 로직 테스트.
+"""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.budget_service import get_budget_alerts, get_category_overview
+
+# ── 헬퍼 ──────────────────────────────────────────────────────
+
+
+def _make_budget(**kwargs) -> MagicMock:
+    """테스트용 Budget 객체 생성"""
+    b = MagicMock()
+    now = datetime.now(UTC).replace(tzinfo=None)
+    b.id = kwargs.get("id", 1)
+    b.household_id = kwargs.get("household_id", 1)
+    b.category_id = kwargs.get("category_id", 10)
+    b.amount = Decimal(str(kwargs.get("amount", 100000)))
+    b.period = kwargs.get("period", "monthly")
+    b.start_date = kwargs.get("start_date", now - timedelta(days=10))
+    b.end_date = kwargs.get("end_date")
+    b.alert_threshold = kwargs.get("alert_threshold", 0.8)
+    b.created_at = kwargs.get("created_at", now)
+    return b
+
+
+def _make_category(**kwargs) -> MagicMock:
+    """테스트용 Category 객체 생성"""
+    c = MagicMock()
+    c.id = kwargs.get("id", 10)
+    c.name = kwargs.get("name", "식비")
+    c.type = kwargs.get("type", "expense")
+    c.household_id = kwargs.get("household_id")
+    c.user_id = kwargs.get("user_id")
+    return c
+
+
+def _mock_scalars(items: list) -> MagicMock:
+    """db.execute(...).scalars().all() 모킹"""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = items
+    return result
+
+
+def _mock_rows(rows: list) -> MagicMock:
+    """db.execute(...).all() 모킹 (group_by 결과)"""
+    result = MagicMock()
+    result.all.return_value = rows
+    return result
+
+
+def _make_expense_row(category_id: int, total: float) -> MagicMock:
+    """지출 집계 행 — (category_id, total)"""
+    row = MagicMock()
+    row.category_id = category_id
+    row.total = total
+    return row
+
+
+def _make_spending_row(category_id: int, year: int, month: int, amount: float) -> MagicMock:
+    """월별 지출 집계 행"""
+    row = MagicMock()
+    row.category_id = category_id
+    row.year = year
+    row.month = month
+    row.amount = amount
+    return row
+
+
+# ── get_budget_alerts ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_budget_alerts_empty_budgets():
+    """예산이 없으면 빈 리스트 반환"""
+    db = AsyncMock()
+    db.execute.return_value = _mock_scalars([])
+
+    alerts = await get_budget_alerts(db, household_id=1)
+    assert alerts == []
+
+
+@pytest.mark.asyncio
+async def test_get_budget_alerts_future_start_date_filtered():
+    """시작일이 미래인 예산은 필터링된다"""
+    future_budget = _make_budget(start_date=datetime.now(UTC).replace(tzinfo=None) + timedelta(days=30))
+
+    db = AsyncMock()
+    db.execute.return_value = _mock_scalars([future_budget])
+
+    alerts = await get_budget_alerts(db, household_id=1)
+    assert alerts == []
+
+
+@pytest.mark.asyncio
+async def test_get_budget_alerts_exceeded():
+    """지출이 예산을 초과하면 is_exceeded=True"""
+    budget = _make_budget(id=1, category_id=10, amount=100000, alert_threshold=0.8)
+    category = _make_category(id=10, name="식비")
+
+    # 지출 합계: 120,000 > 예산 100,000
+    expense_row = _make_expense_row(category_id=10, total=120000.0)
+
+    db = AsyncMock()
+    # 1) budgets 조회, 2) categories 조회, 3) expenses 집계
+    db.execute.side_effect = [
+        _mock_scalars([budget]),
+        _mock_scalars([category]),
+        _mock_rows([expense_row]),
+    ]
+
+    alerts = await get_budget_alerts(db, household_id=1)
+    assert len(alerts) == 1
+    assert alerts[0].is_exceeded is True
+    assert alerts[0].spent_amount == 120000.0
+    assert alerts[0].remaining_amount == -20000.0
+    assert alerts[0].usage_percentage == 120.0
+
+
+@pytest.mark.asyncio
+async def test_get_budget_alerts_warning():
+    """지출이 임계값(80%) 이상이면 is_warning=True"""
+    budget = _make_budget(id=1, category_id=10, amount=100000, alert_threshold=0.8)
+    category = _make_category(id=10, name="식비")
+
+    # 지출 85,000 → 85% ≥ 80% 임계값
+    expense_row = _make_expense_row(category_id=10, total=85000.0)
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([budget]),
+        _mock_scalars([category]),
+        _mock_rows([expense_row]),
+    ]
+
+    alerts = await get_budget_alerts(db, household_id=1)
+    assert len(alerts) == 1
+    assert alerts[0].is_warning is True
+    assert alerts[0].is_exceeded is False
+
+
+@pytest.mark.asyncio
+async def test_get_budget_alerts_no_spending():
+    """지출이 없으면 spent_amount=0, is_exceeded/is_warning=False"""
+    budget = _make_budget(id=1, category_id=10, amount=100000, alert_threshold=0.8)
+    category = _make_category(id=10, name="식비")
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([budget]),
+        _mock_scalars([category]),
+        _mock_rows([]),  # 지출 없음
+    ]
+
+    alerts = await get_budget_alerts(db, household_id=1)
+    assert len(alerts) == 1
+    assert alerts[0].spent_amount == 0.0
+    assert alerts[0].is_exceeded is False
+    assert alerts[0].is_warning is False
+    assert alerts[0].remaining_amount == 100000.0
+
+
+@pytest.mark.asyncio
+async def test_get_budget_alerts_zero_budget_amount():
+    """예산 금액이 0이면 usage_percentage=0 (ZeroDivisionError 방지)"""
+    budget = _make_budget(id=1, category_id=10, amount=0, alert_threshold=0.8)
+    category = _make_category(id=10, name="식비")
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([budget]),
+        _mock_scalars([category]),
+        _mock_rows([]),
+    ]
+
+    alerts = await get_budget_alerts(db, household_id=1)
+    assert len(alerts) == 1
+    assert alerts[0].usage_percentage == 0
+
+
+@pytest.mark.asyncio
+async def test_get_budget_alerts_missing_category_skipped():
+    """카테고리 매핑이 없는 예산은 건너뛴다"""
+    budget = _make_budget(id=1, category_id=999)  # 존재하지 않는 카테고리
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([budget]),
+        _mock_scalars([]),  # 카테고리 없음
+        _mock_rows([]),
+    ]
+
+    alerts = await get_budget_alerts(db, household_id=1)
+    assert alerts == []
+
+
+@pytest.mark.asyncio
+async def test_get_budget_alerts_sort_order():
+    """정렬 순서: 초과 > 경고 > 사용률 내림차순"""
+    budget_exceeded = _make_budget(id=1, category_id=10, amount=100000, alert_threshold=0.8)
+    budget_warning = _make_budget(id=2, category_id=20, amount=200000, alert_threshold=0.8)
+    budget_normal = _make_budget(id=3, category_id=30, amount=300000, alert_threshold=0.8)
+
+    cat1 = _make_category(id=10, name="식비")
+    cat2 = _make_category(id=20, name="교통비")
+    cat3 = _make_category(id=30, name="쇼핑")
+
+    # 식비: 120% 초과, 교통비: 85% 경고, 쇼핑: 30% 정상
+    expense_rows = [
+        _make_expense_row(10, 120000.0),
+        _make_expense_row(20, 170000.0),
+        _make_expense_row(30, 90000.0),
+    ]
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([budget_exceeded, budget_warning, budget_normal]),
+        _mock_scalars([cat1, cat2, cat3]),
+        _mock_rows(expense_rows),
+    ]
+
+    alerts = await get_budget_alerts(db, household_id=1)
+    assert len(alerts) == 3
+    # 초과 먼저
+    assert alerts[0].is_exceeded is True
+    assert alerts[0].category_name == "식비"
+    # 경고 다음
+    assert alerts[1].is_warning is True
+    assert alerts[1].category_name == "교통비"
+    # 정상 마지막
+    assert alerts[2].is_exceeded is False
+    assert alerts[2].is_warning is False
+
+
+@pytest.mark.asyncio
+async def test_get_budget_alerts_multiple_periods():
+    """monthly/weekly/daily 예산이 혼재해도 각각의 period_start로 처리"""
+    budget_monthly = _make_budget(id=1, category_id=10, amount=100000, period="monthly")
+    budget_daily = _make_budget(id=2, category_id=20, amount=10000, period="daily")
+
+    cat1 = _make_category(id=10, name="식비")
+    cat2 = _make_category(id=20, name="교통비")
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([budget_monthly, budget_daily]),
+        _mock_scalars([cat1, cat2]),
+        # period_start별로 2번 호출됨
+        _mock_rows([_make_expense_row(10, 50000.0)]),
+        _mock_rows([_make_expense_row(20, 8000.0)]),
+    ]
+
+    alerts = await get_budget_alerts(db, household_id=1)
+    assert len(alerts) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_budget_alerts_weekly_period():
+    """weekly 예산 period_start 계산 검증"""
+    budget = _make_budget(id=1, category_id=10, amount=50000, period="weekly")
+    category = _make_category(id=10, name="식비")
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([budget]),
+        _mock_scalars([category]),
+        _mock_rows([]),
+    ]
+
+    alerts = await get_budget_alerts(db, household_id=1)
+    assert len(alerts) == 1
+    assert alerts[0].spent_amount == 0.0
+
+
+# ── get_category_overview ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_category_overview_empty():
+    """카테고리가 없으면 빈 리스트 반환"""
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([]),  # categories
+        _mock_scalars([]),  # budgets
+        _mock_rows([]),  # spending
+    ]
+
+    result = await get_category_overview(db, household_id=1, user_id=1)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_category_overview_with_budget():
+    """예산이 설정된 카테고리는 예산 정보가 포함된다"""
+    cat = _make_category(id=10, name="식비")
+    budget = _make_budget(id=1, category_id=10, amount=200000, alert_threshold=0.8)
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([cat]),  # categories
+        _mock_scalars([budget]),  # budgets
+        _mock_rows([]),  # spending (없음)
+    ]
+
+    result = await get_category_overview(db, household_id=1, user_id=1)
+    assert len(result) == 1
+    assert result[0].category_id == 10
+    assert result[0].category_name == "식비"
+    assert result[0].current_budget_id == 1
+    assert result[0].current_budget_amount == 200000.0
+    assert result[0].alert_threshold == 0.8
+    assert result[0].monthly_spending == []
+
+
+@pytest.mark.asyncio
+async def test_get_category_overview_no_budget():
+    """예산이 없는 카테고리는 budget 필드가 None"""
+    cat = _make_category(id=10, name="교통비")
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([cat]),  # categories
+        _mock_scalars([]),  # budgets (없음)
+        _mock_rows([]),  # spending
+    ]
+
+    result = await get_category_overview(db, household_id=1, user_id=1)
+    assert len(result) == 1
+    assert result[0].current_budget_id is None
+    assert result[0].current_budget_amount is None
+    assert result[0].alert_threshold is None
+
+
+@pytest.mark.asyncio
+async def test_get_category_overview_with_spending():
+    """최근 3개월 지출이 있으면 monthly_spending에 포함"""
+    cat = _make_category(id=10, name="식비")
+    now = datetime.now(UTC).replace(tzinfo=None)
+
+    spending_rows = [
+        _make_spending_row(10, now.year, now.month, 150000.0),
+    ]
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([cat]),
+        _mock_scalars([]),
+        _mock_rows(spending_rows),
+    ]
+
+    result = await get_category_overview(db, household_id=1, user_id=1)
+    assert len(result) == 1
+    assert len(result[0].monthly_spending) == 1
+    assert result[0].monthly_spending[0].amount == 150000.0
+
+
+@pytest.mark.asyncio
+async def test_get_category_overview_multiple_categories():
+    """여러 카테고리가 있으면 모두 반환"""
+    cat1 = _make_category(id=10, name="식비")
+    cat2 = _make_category(id=20, name="교통비")
+    cat3 = _make_category(id=30, name="쇼핑")
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([cat1, cat2, cat3]),
+        _mock_scalars([]),
+        _mock_rows([]),
+    ]
+
+    result = await get_category_overview(db, household_id=1, user_id=1)
+    assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_category_overview_budget_dedup():
+    """같은 카테고리에 여러 예산이 있으면 가장 최근 것만 매핑"""
+    cat = _make_category(id=10, name="식비")
+    now = datetime.now(UTC).replace(tzinfo=None)
+    # budgets 쿼리는 created_at DESC로 정렬됨
+    budget_new = _make_budget(id=2, category_id=10, amount=300000, created_at=now)
+    budget_old = _make_budget(id=1, category_id=10, amount=200000, created_at=now - timedelta(days=30))
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _mock_scalars([cat]),
+        _mock_scalars([budget_new, budget_old]),  # 최신 먼저
+        _mock_rows([]),
+    ]
+
+    result = await get_category_overview(db, household_id=1, user_id=1)
+    assert result[0].current_budget_id == 2  # 최신 예산
+    assert result[0].current_budget_amount == 300000.0

--- a/backend/tests/unit/test_llm_service_providers.py
+++ b/backend/tests/unit/test_llm_service_providers.py
@@ -1,0 +1,828 @@
+"""LLM 서비스 프로바이더별 테스트 (#363)
+
+OpenAI, Google 프로바이더 경로 + get_llm_provider 팩토리 심층 검증.
+기능별 오버라이드, 응답 파싱 실패, 에러 처리.
+"""
+
+import importlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.llm_service import (
+    AnthropicProvider,
+    GoogleProvider,
+    LocalLLMProvider,
+    OpenAIProvider,
+    _create_provider,
+    _resolve_provider_and_model,
+    get_llm_provider,
+)
+
+_has_openai = importlib.util.find_spec("openai") is not None
+
+
+# ── get_llm_provider 팩토리 ───────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_cache():
+    """테스트마다 프로바이더 캐시 초기화"""
+    from app.services import llm_service
+
+    llm_service._provider_cache.clear()
+    yield
+    llm_service._provider_cache.clear()
+
+
+def test_get_llm_provider_google():
+    """LLM_PROVIDER=google → GoogleProvider"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.LLM_PROVIDER = "google"
+        mock_settings.LLM_MODEL = ""
+        mock_settings.GOOGLE_API_KEY = "test-key"
+
+        provider = get_llm_provider()
+        assert isinstance(provider, GoogleProvider)
+
+
+def test_get_llm_provider_caching():
+    """같은 설정이면 동일 인스턴스 반환 (캐싱)"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.LLM_PROVIDER = "google"
+        mock_settings.LLM_MODEL = ""
+
+        p1 = get_llm_provider()
+        p2 = get_llm_provider()
+        assert p1 is p2
+
+
+def test_get_llm_provider_different_features():
+    """기능별 다른 프로바이더 반환"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.LLM_PROVIDER = "anthropic"
+        mock_settings.LLM_MODEL = ""
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+        mock_settings.LLM_PROVIDER_PARSE = "google"
+        mock_settings.LLM_MODEL_PARSE = ""
+        mock_settings.GOOGLE_API_KEY = "test-key"
+
+        default = get_llm_provider()
+        parse = get_llm_provider("parse")
+
+        assert isinstance(default, AnthropicProvider)
+        assert isinstance(parse, GoogleProvider)
+
+
+# ── _resolve_provider_and_model ───────────────────────────────
+
+
+def test_resolve_default():
+    """feature=None이면 기본 설정 사용"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.LLM_PROVIDER = "anthropic"
+        mock_settings.LLM_MODEL = "claude-3-haiku"
+
+        provider, model = _resolve_provider_and_model()
+        assert provider == "anthropic"
+        assert model == "claude-3-haiku"
+
+
+def test_resolve_feature_override_provider():
+    """기능별 프로바이더 오버라이드"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.LLM_PROVIDER = "anthropic"
+        mock_settings.LLM_MODEL = ""
+        mock_settings.LLM_PROVIDER_PARSE = "openai"
+        mock_settings.LLM_MODEL_PARSE = "gpt-4o"
+
+        provider, model = _resolve_provider_and_model("parse")
+        assert provider == "openai"
+        assert model == "gpt-4o"
+
+
+def test_resolve_feature_override_model_only():
+    """기능별 모델만 오버라이드 (프로바이더는 기본값)"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.LLM_PROVIDER = "anthropic"
+        mock_settings.LLM_MODEL = ""
+        mock_settings.LLM_PROVIDER_INSIGHTS = None
+        mock_settings.LLM_MODEL_INSIGHTS = "claude-3-opus"
+
+        provider, model = _resolve_provider_and_model("insights")
+        assert provider == "anthropic"
+        assert model == "claude-3-opus"
+
+
+def test_resolve_feature_no_override():
+    """기능별 오버라이드가 없으면 기본값 사용"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.LLM_PROVIDER = "anthropic"
+        mock_settings.LLM_MODEL = "default-model"
+        mock_settings.LLM_PROVIDER_OCR = None
+        mock_settings.LLM_MODEL_OCR = ""
+
+        provider, model = _resolve_provider_and_model("ocr")
+        assert provider == "anthropic"
+        assert model == "default-model"
+
+
+# ── _create_provider ──────────────────────────────────────────
+
+
+def test_create_provider_unknown():
+    """알 수 없는 프로바이더 → ValueError"""
+    with pytest.raises(ValueError, match="Unknown LLM provider"):
+        _create_provider("nonexistent", "model")
+
+
+def test_create_provider_local():
+    """local 프로바이더 생성"""
+    provider = _create_provider("local", "llama3.1")
+    assert isinstance(provider, LocalLLMProvider)
+    assert provider.model == "llama3.1"
+
+
+# ── OpenAI Provider ───────────────────────────────────────────
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_parse_expense_missing_amount():
+    """OpenAI 파싱 결과에 amount 없으면 에러"""
+    mock_choice = MagicMock()
+    mock_choice.message.content = '{"category": "식비", "description": "점심"}'
+    mock_choice.finish_reason = "stop"
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.parse_expense("점심 먹음")
+            assert "error" in result
+            assert result["error"] == "금액을 찾을 수 없습니다"
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_parse_expense_max_tokens_exceeded():
+    """OpenAI max_tokens 초과(finish_reason=length) → 사용자 친화적 에러"""
+    mock_choice = MagicMock()
+    mock_choice.message.content = '[{"amount": 8000'  # 잘린 JSON
+    mock_choice.finish_reason = "length"
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.parse_expense("매우 긴 입력..." * 50)
+            assert "error" in result
+            assert "날짜별로" in result["error"]
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_parse_expense_json_decode_error():
+    """OpenAI 응답이 유효하지 않은 JSON → JSONDecodeError 발생
+
+    NOTE: JSONDecodeError는 ValueError의 하위 클래스이므로
+    except ValueError에서 먼저 잡히고 re-raise된다 (기존 동작).
+    """
+    import json
+
+    mock_choice = MagicMock()
+    mock_choice.message.content = "이것은 JSON이 아닙니다"
+    mock_choice.finish_reason = "stop"
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            # JSONDecodeError는 ValueError 하위 클래스 → except ValueError에서 re-raise
+            with pytest.raises(json.JSONDecodeError):
+                await provider.parse_expense("테스트")
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_parse_expense_api_error():
+    """OpenAI API 호출 실패 → 재시도 후 에러"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.side_effect = RuntimeError("API down")
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.parse_expense("테스트")
+            assert "error" in result
+            assert "LLM 서비스 오류" in result["error"]
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_parse_expense_invalid_list_item():
+    """OpenAI 여러 지출 파싱 — 리스트 항목이 dict가 아닌 경우"""
+    mock_choice = MagicMock()
+    mock_choice.message.content = '[{"amount": 8000}, "invalid"]'
+    mock_choice.finish_reason = "stop"
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.parse_expense("여러 항목")
+            assert "error" in result
+            assert result["error"] == "잘못된 형식입니다"
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_parse_expense_list_missing_amount():
+    """OpenAI 여러 지출 파싱 — 리스트 항목에 amount 없음"""
+    mock_choice = MagicMock()
+    mock_choice.message.content = '[{"amount": 8000, "category": "식비"}, {"category": "교통비"}]'
+    mock_choice.finish_reason = "stop"
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.parse_expense("점심 8천원, 택시")
+            assert "error" in result
+            assert "금액" in result["error"]
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_parse_expense_non_dict_non_list():
+    """OpenAI 응답이 dict/list가 아닌 경우 (예: 숫자, 문자열)"""
+    mock_choice = MagicMock()
+    mock_choice.message.content = "12345"
+    mock_choice.finish_reason = "stop"
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.parse_expense("테스트")
+            assert "error" in result
+            assert result["error"] == "잘못된 형식입니다"
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_parse_expense_error_response():
+    """OpenAI 파싱 결과에 error 키가 있으면 그대로 반환"""
+    mock_choice = MagicMock()
+    mock_choice.message.content = '{"error": "이해할 수 없습니다"}'
+    mock_choice.finish_reason = "stop"
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.parse_expense("???")
+            assert result["error"] == "이해할 수 없습니다"
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_generate_insights_api_error():
+    """OpenAI 인사이트 생성 API 실패 → 에러 메시지 반환"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.side_effect = RuntimeError("API down")
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.generate_insights({"total": 50000})
+            assert "오류가 발생했습니다" in result
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_generate_insights_max_tokens_warning():
+    """OpenAI 인사이트 생성 시 max_tokens 초과 경고"""
+    mock_choice = MagicMock()
+    mock_choice.message.content = "# 분석 결과 (잘림)"
+    mock_choice.finish_reason = "length"  # max_tokens 초과
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.generate_insights({"total": 50000})
+            # 경고만 로깅하고 결과는 반환
+            assert result == "# 분석 결과 (잘림)"
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_generate_success():
+    """OpenAI generate() 성공"""
+    mock_choice = MagicMock()
+    mock_choice.message.content = "생성된 텍스트"
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.generate("프롬프트")
+            assert result == "생성된 텍스트"
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_generate_api_error():
+    """OpenAI generate() API 실패 → 빈 문자열"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.side_effect = RuntimeError("API down")
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.generate("프롬프트")
+            assert result == ""
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_parse_image_not_implemented():
+    """OpenAI parse_image() → NotImplementedError"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI"):
+            provider = OpenAIProvider()
+            with pytest.raises(NotImplementedError):
+                await provider.parse_image(b"fake_image", "image/jpeg")
+
+
+@pytest.mark.skipif(not _has_openai, reason="openai 패키지 미설치")
+@pytest.mark.asyncio
+async def test_openai_generate_comprehensive_insights():
+    """OpenAI generate_comprehensive_insights() 성공"""
+    import json
+
+    structured = {"summary": "분석 결과", "score": 75}
+    mock_choice = MagicMock()
+    mock_choice.message.content = json.dumps(structured, ensure_ascii=False)
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.OPENAI_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+
+            provider = OpenAIProvider()
+            result = await provider.generate_comprehensive_insights({"month": "2026-03"})
+            assert result["summary"] == "분석 결과"
+            assert result["score"] == 75
+
+
+# ── Google Provider ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_google_provider_default_model():
+    """Google 프로바이더 기본 모델 확인"""
+    provider = GoogleProvider()
+    assert provider.model == "gemini-2.0-flash"
+
+
+@pytest.mark.asyncio
+async def test_google_provider_custom_model():
+    """Google 프로바이더 커스텀 모델"""
+    provider = GoogleProvider(model="gemini-pro")
+    assert provider.model == "gemini-pro"
+
+
+@pytest.mark.asyncio
+async def test_google_provider_api_key():
+    """Google 프로바이더 API 키 설정"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.GOOGLE_API_KEY = "google-test-key"
+        provider = GoogleProvider()
+        assert provider.api_key == "google-test-key"
+
+
+# ── Anthropic Provider 추가 ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_expense_json_decode_error():
+    """Anthropic 응답이 유효하지 않은 JSON → JSONDecodeError 발생
+
+    NOTE: JSONDecodeError는 ValueError의 하위 클래스이므로
+    except ValueError에서 먼저 잡히고 re-raise된다 (기존 동작).
+    """
+    import json
+
+    mock_response = MagicMock()
+    mock_response.stop_reason = "end_turn"
+    mock_response.content = [MagicMock(text="이것은 JSON이 아닙니다")]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            # JSONDecodeError는 ValueError 하위 클래스 → except ValueError에서 re-raise
+            with pytest.raises(json.JSONDecodeError):
+                await provider.parse_expense("테스트")
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_expense_api_error():
+    """Anthropic API 호출 실패 → 재시도 후 에러"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.side_effect = RuntimeError("API down")
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_expense("테스트")
+            assert "error" in result
+            assert "LLM 서비스 오류" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_expense_non_dict_non_list():
+    """Anthropic 응답이 dict/list가 아닌 경우"""
+    mock_response = MagicMock()
+    mock_response.stop_reason = "end_turn"
+    mock_response.content = [MagicMock(text='"just a string"')]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_expense("테스트")
+            assert "error" in result
+            assert result["error"] == "잘못된 형식입니다"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_expense_list_invalid_item():
+    """Anthropic 여러 지출 — 리스트 항목이 dict가 아닌 경우"""
+    mock_response = MagicMock()
+    mock_response.stop_reason = "end_turn"
+    mock_response.content = [MagicMock(text='[{"amount": 8000}, 42]')]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_expense("테스트")
+            assert "error" in result
+            assert result["error"] == "잘못된 형식입니다"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_expense_list_missing_amount():
+    """Anthropic 여러 지출 — 리스트 항목에 amount 없음"""
+    mock_response = MagicMock()
+    mock_response.stop_reason = "end_turn"
+    mock_response.content = [MagicMock(text='[{"amount": 8000}, {"category": "교통비"}]')]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_expense("테스트")
+            assert "error" in result
+            assert "금액" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_generate_insights_api_error():
+    """Anthropic 인사이트 생성 API 실패 → 에러 메시지 반환"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.side_effect = RuntimeError("API down")
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.generate_insights({"total": 50000})
+            assert "오류가 발생했습니다" in result
+
+
+@pytest.mark.asyncio
+async def test_anthropic_generate_insights_max_tokens():
+    """Anthropic 인사이트 max_tokens 초과 → 경고만, 결과 반환"""
+    mock_response = MagicMock()
+    mock_response.stop_reason = "max_tokens"
+    mock_response.content = [MagicMock(text="# 잘린 분석")]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.generate_insights({"total": 50000})
+            assert result == "# 잘린 분석"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_generate_api_error():
+    """Anthropic generate() API 실패 → 빈 문자열"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.side_effect = RuntimeError("API down")
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.generate("프롬프트")
+            assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_anthropic_generate_comprehensive_insights_no_tool_use():
+    """Anthropic generate_comprehensive_insights — tool_use 블록 없으면 ValueError"""
+    mock_block = MagicMock()
+    mock_block.type = "text"
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_block]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            with pytest.raises(ValueError, match="구조화된 응답"):
+                await provider.generate_comprehensive_insights({"month": "2026-03"})
+
+
+@pytest.mark.asyncio
+async def test_anthropic_generate_comprehensive_insights_success():
+    """Anthropic generate_comprehensive_insights — tool_use 블록에서 JSON 추출"""
+    mock_block = MagicMock()
+    mock_block.type = "tool_use"
+    mock_block.input = {"summary": "좋은 결과", "score": 80}
+
+    mock_response = MagicMock()
+    mock_response.content = [mock_block]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.generate_comprehensive_insights({"month": "2026-03"})
+            assert result["summary"] == "좋은 결과"
+            assert result["score"] == 80
+
+
+# ── Anthropic parse_image 추가 ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_image_success():
+    """Anthropic parse_image() 성공"""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text='{"amount": 25000, "description": "스타벅스"}')]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_image(b"fake_image_bytes", "image/jpeg")
+            assert result["amount"] == 25000
+            assert result["description"] == "스타벅스"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_image_error_response():
+    """Anthropic parse_image() — LLM이 에러 반환"""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text='{"error": "이미지를 인식할 수 없습니다"}')]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_image(b"fake", "image/png")
+            assert result["error"] == "이미지를 인식할 수 없습니다"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_image_missing_amount():
+    """Anthropic parse_image() — amount 없으면 에러"""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text='{"description": "스타벅스"}')]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_image(b"fake", "image/png")
+            assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_image_list():
+    """Anthropic parse_image() — 여러 항목 리스트"""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text='[{"amount": 5000, "description": "커피"}, {"amount": 3000, "description": "빵"}]')]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_image(b"fake", "image/png")
+            assert isinstance(result, list)
+            assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_image_json_error():
+    """Anthropic parse_image() — JSON 파싱 실패"""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="not json")]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_image(b"fake", "image/png")
+            assert "error" in result
+            assert result["error"] == "응답을 파싱할 수 없습니다"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_image_api_error():
+    """Anthropic parse_image() — API 호출 실패"""
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.side_effect = RuntimeError("Vision API down")
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_image(b"fake", "image/png")
+            assert "error" in result
+            assert "이미지 인식 오류" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_parse_image_non_dict_non_list():
+    """Anthropic parse_image() — dict/list가 아닌 경우"""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="42")]
+
+    with patch("app.services.llm_service.settings") as mock_settings:
+        mock_settings.ANTHROPIC_API_KEY = "test-key"  # pragma: allowlist secret
+
+        with patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_client = AsyncMock()
+            mock_client.messages.create.return_value = mock_response
+            mock_anthropic.return_value = mock_client
+
+            provider = AnthropicProvider()
+            result = await provider.parse_image(b"fake", "image/png")
+            assert "error" in result
+            assert result["error"] == "잘못된 형식입니다"

--- a/backend/tests/unit/test_price_service_extra.py
+++ b/backend/tests/unit/test_price_service_extra.py
@@ -1,0 +1,715 @@
+"""price_service 추가 단위 테스트 (#359)
+
+외부 API 호출 모킹, 응답 파싱/에러 처리, 캐시 로직 심층 검증.
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_price_cache():
+    """각 테스트 전후로 price_cache + singleflight 락 초기화"""
+    from app.services import price_service
+
+    price_service._price_cache.clear()
+    price_service._price_locks.clear()
+    yield
+    price_service._price_cache.clear()
+    price_service._price_locks.clear()
+
+
+# ── 캐시 심층 테스트 ──────────────────────────────────────────
+
+
+def test_negative_cache_ttl():
+    """실패 캐시(None)는 NEGATIVE_CACHE_TTL(30초) 적용 (#159)"""
+    from app.services import price_service
+    from app.services.price_service import _CACHE_MISS, _get_cached, _set_cached
+
+    _set_cached("test:fail", None)
+    # 실패 캐시 히트
+    assert _get_cached("test:fail") is None
+
+    # NEGATIVE_CACHE_TTL 초과 → 미스
+    price_service._price_cache["test:fail"] = (None, time.monotonic() - price_service.NEGATIVE_CACHE_TTL - 1)
+    assert _get_cached("test:fail") is _CACHE_MISS
+
+
+def test_success_cache_ttl():
+    """성공 캐시는 CACHE_TTL(300초) 적용"""
+    from app.services import price_service
+    from app.services.price_service import _CACHE_MISS, _get_cached, _set_cached
+
+    _set_cached("test:ok", 50000.0)
+    assert _get_cached("test:ok") == 50000.0
+
+    # CACHE_TTL 초과 → 미스
+    price_service._price_cache["test:ok"] = (50000.0, time.monotonic() - price_service.CACHE_TTL - 1)
+    assert _get_cached("test:ok") is _CACHE_MISS
+
+
+def test_cache_expired_entry_deleted():
+    """만료된 캐시 엔트리는 _get_cached 호출 시 삭제됨"""
+    from app.services import price_service
+    from app.services.price_service import _get_cached
+
+    price_service._price_cache["test:del"] = (1234.0, time.monotonic() - price_service.CACHE_TTL - 1)
+    _get_cached("test:del")
+    assert "test:del" not in price_service._price_cache
+
+
+# ── 한투 API 토큰 ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_kis_token_no_credentials():
+    """KIS_APPKEY/APPSECRET이 없으면 None 반환"""
+    from app.services.price_service import _get_kis_token
+
+    with patch("app.services.price_service.settings") as mock_settings:
+        mock_settings.KIS_APPKEY = ""
+        mock_settings.KIS_APPSECRET = ""
+        # 기존 토큰 캐시 무효화
+        import app.services.price_service as ps
+
+        ps._kis_token = None
+        ps._kis_token_expires = 0
+
+        result = await _get_kis_token()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_kis_token_cached():
+    """토큰이 캐시되어 있고 유효하면 재발급하지 않음"""
+    import app.services.price_service as ps
+
+    ps._kis_token = "cached-token"
+    ps._kis_token_expires = time.monotonic() + 10000  # 유효
+
+    result = await ps._get_kis_token()
+    assert result == "cached-token"
+
+    # 정리
+    ps._kis_token = None
+    ps._kis_token_expires = 0
+
+
+@pytest.mark.asyncio
+async def test_get_kis_token_success():
+    """한투 API 토큰 발급 성공"""
+    import app.services.price_service as ps
+
+    ps._kis_token = None
+    ps._kis_token_expires = 0
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"access_token": "new-token"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.price_service.settings") as mock_settings:
+        mock_settings.KIS_APPKEY = "test-key"
+        mock_settings.KIS_APPSECRET = "test-secret"  # pragma: allowlist secret
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await ps._get_kis_token()
+            assert result == "new-token"
+
+    # 정리
+    ps._kis_token = None
+    ps._kis_token_expires = 0
+
+
+@pytest.mark.asyncio
+async def test_get_kis_token_api_failure():
+    """한투 API 토큰 발급 실패 → None"""
+    import app.services.price_service as ps
+
+    ps._kis_token = None
+    ps._kis_token_expires = 0
+
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = Exception("network error")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("app.services.price_service.settings") as mock_settings:
+        mock_settings.KIS_APPKEY = "test-key"
+        mock_settings.KIS_APPSECRET = "test-secret"  # pragma: allowlist secret
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await ps._get_kis_token()
+            assert result is None
+
+
+# ── 한국 주식 (KIS + 네이버 fallback) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_stock_kr_price_kis_success():
+    """한투 API로 한국 주식 시세 조회 성공"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"output": {"stck_prpr": "80000"}}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(price_service, "_get_kis_token", new=AsyncMock(return_value="token")),
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch("app.services.price_service.settings") as mock_settings,
+    ):
+        mock_settings.KIS_APPKEY = "key"
+        mock_settings.KIS_APPSECRET = "secret"  # pragma: allowlist secret
+
+        result = await price_service._get_stock_kr_price_kis("005930")
+        assert result == 80000.0
+
+
+@pytest.mark.asyncio
+async def test_get_stock_kr_price_kis_zero_price():
+    """한투 API에서 가격이 0이면 None 반환"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"output": {"stck_prpr": "0"}}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(price_service, "_get_kis_token", new=AsyncMock(return_value="token")),
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch("app.services.price_service.settings") as mock_settings,
+    ):
+        mock_settings.KIS_APPKEY = "key"
+        mock_settings.KIS_APPSECRET = "secret"  # pragma: allowlist secret
+
+        result = await price_service._get_stock_kr_price_kis("005930")
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_stock_kr_price_kis_no_token():
+    """한투 토큰이 없으면 None 반환"""
+    from app.services import price_service
+
+    with patch.object(price_service, "_get_kis_token", new=AsyncMock(return_value=None)):
+        result = await price_service._get_stock_kr_price_kis("005930")
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_stock_kr_price_kis_exception():
+    """한투 API 호출 중 예외 → None"""
+    from app.services import price_service
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = Exception("timeout")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(price_service, "_get_kis_token", new=AsyncMock(return_value="token")),
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch("app.services.price_service.settings") as mock_settings,
+    ):
+        mock_settings.KIS_APPKEY = "key"
+        mock_settings.KIS_APPSECRET = "secret"  # pragma: allowlist secret
+
+        result = await price_service._get_stock_kr_price_kis("005930")
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_stock_kr_price_naver_success():
+    """네이버 금융 fallback 시세 조회 성공"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"currentPrice": 75000}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await price_service._get_stock_kr_price_naver("005930")
+        assert result == 75000.0
+
+
+@pytest.mark.asyncio
+async def test_get_stock_kr_price_naver_zero_price():
+    """네이버 금융에서 가격이 0이면 None"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"currentPrice": 0}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await price_service._get_stock_kr_price_naver("005930")
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_stock_kr_price_naver_exception():
+    """네이버 금융 예외 → None"""
+    from app.services import price_service
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = Exception("network error")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await price_service._get_stock_kr_price_naver("005930")
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_stock_kr_price_with_cache_hit():
+    """캐시에 시세가 있으면 API 호출 없이 반환"""
+    from app.services import price_service
+
+    price_service._price_cache["kr:005930"] = (80000.0, time.monotonic())
+
+    result = await price_service.get_stock_kr_price("005930")
+    assert result == 80000.0
+
+
+@pytest.mark.asyncio
+async def test_get_stock_kr_price_kis_fallback_to_naver():
+    """한투 API 실패 시 네이버 fallback"""
+    from app.services import price_service
+
+    with (
+        patch.object(price_service, "_get_stock_kr_price_kis", new=AsyncMock(return_value=None)),
+        patch.object(price_service, "_get_stock_kr_price_naver", new=AsyncMock(return_value=70000.0)),
+    ):
+        result = await price_service.get_stock_kr_price("005930")
+        assert result == 70000.0
+
+
+@pytest.mark.asyncio
+async def test_get_stock_kr_price_both_fail():
+    """한투+네이버 모두 실패 → None (실패 캐시 저장)"""
+    from app.services import price_service
+
+    with (
+        patch.object(price_service, "_get_stock_kr_price_kis", new=AsyncMock(return_value=None)),
+        patch.object(price_service, "_get_stock_kr_price_naver", new=AsyncMock(return_value=None)),
+    ):
+        result = await price_service.get_stock_kr_price("005930")
+        assert result is None
+        # 실패 캐시 확인
+        assert "kr:005930" in price_service._price_cache
+        assert price_service._price_cache["kr:005930"][0] is None
+
+
+# ── 미국 주식 (Yahoo Finance) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_stock_us_price_success():
+    """Yahoo Finance 미국 주식 시세 조회 성공"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"chart": {"result": [{"meta": {"regularMarketPrice": 180.5}}]}}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(price_service, "get_exchange_rate", new=AsyncMock(return_value=1350.0)),
+    ):
+        usd, krw = await price_service.get_stock_us_price("AAPL")
+        assert usd == 180.5
+        assert krw == 180.5 * 1350.0
+
+
+@pytest.mark.asyncio
+async def test_get_stock_us_price_no_exchange_rate():
+    """환율 조회 실패 시 KRW는 None"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"chart": {"result": [{"meta": {"regularMarketPrice": 180.5}}]}}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(price_service, "get_exchange_rate", new=AsyncMock(return_value=None)),
+    ):
+        usd, krw = await price_service.get_stock_us_price("AAPL")
+        assert usd == 180.5
+        assert krw is None
+
+
+@pytest.mark.asyncio
+async def test_get_stock_us_price_api_failure():
+    """Yahoo Finance API 실패 → (None, None)"""
+    from app.services import price_service
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = Exception("timeout")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch.object(price_service, "get_exchange_rate", new=AsyncMock(return_value=1350.0)),
+    ):
+        usd, krw = await price_service.get_stock_us_price("AAPL")
+        assert usd is None
+        assert krw is None
+
+
+@pytest.mark.asyncio
+async def test_get_stock_us_price_cache_hit():
+    """미국 주식 캐시 히트"""
+    from app.services import price_service
+
+    price_service._price_cache["us:AAPL"] = (180.0, time.monotonic())
+
+    with patch.object(price_service, "get_exchange_rate", new=AsyncMock(return_value=1350.0)):
+        usd, krw = await price_service.get_stock_us_price("AAPL")
+        assert usd == 180.0
+        assert krw == 180.0 * 1350.0
+
+
+@pytest.mark.asyncio
+async def test_get_stock_us_price_negative_cache_hit():
+    """미국 주식 실패 캐시 히트 → (None, None)"""
+    from app.services import price_service
+
+    price_service._price_cache["us:AAPL"] = (None, time.monotonic())
+
+    with patch.object(price_service, "get_exchange_rate", new=AsyncMock(return_value=1350.0)):
+        usd, krw = await price_service.get_stock_us_price("AAPL")
+        assert usd is None
+        assert krw is None
+
+
+# ── 코인 (업비트) ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_crypto_price_success():
+    """업비트 코인 시세 조회 성공"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = [{"trade_price": 95000000.0}]
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await price_service.get_crypto_price("BTC")
+        assert result == 95000000.0
+
+
+@pytest.mark.asyncio
+async def test_get_crypto_price_empty_response():
+    """업비트 응답이 빈 리스트면 None"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = []
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await price_service.get_crypto_price("UNKNOWN")
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_crypto_price_exception():
+    """업비트 API 예외 → None"""
+    from app.services import price_service
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = Exception("network")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = await price_service.get_crypto_price("BTC")
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_crypto_price_cache_hit():
+    """코인 캐시 히트"""
+    from app.services import price_service
+
+    price_service._price_cache["crypto:ETH"] = (4000000.0, time.monotonic())
+
+    result = await price_service.get_crypto_price("ETH")
+    assert result == 4000000.0
+
+
+# ── get_asset_current_value 추가 분기 ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_asset_current_value_stock_kr_no_ticker():
+    """ticker가 없는 한국 주식 자산은 None"""
+    from app.services.price_service import get_asset_current_value
+
+    asset = MagicMock()
+    asset.type = "stock_kr"
+    asset.ticker = None
+    asset.quantity = 10
+
+    result = await get_asset_current_value(asset)
+    assert result["current_price"] is None
+    assert result["current_value"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_asset_current_value_stock_kr_no_quantity():
+    """quantity가 없는 한국 주식 자산은 None"""
+    from app.services.price_service import get_asset_current_value
+
+    asset = MagicMock()
+    asset.type = "stock_kr"
+    asset.ticker = "005930"
+    asset.quantity = None
+
+    result = await get_asset_current_value(asset)
+    assert result["current_price"] is None
+    assert result["current_value"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_asset_current_value_unknown_type():
+    """알 수 없는 자산 유형은 모두 None"""
+    from app.services.price_service import get_asset_current_value
+
+    asset = MagicMock()
+    asset.type = "unknown_type"
+    asset.ticker = "X"
+    asset.quantity = 1
+
+    result = await get_asset_current_value(asset)
+    assert result["current_price"] is None
+    assert result["current_value"] is None
+
+
+# ── _calc_profit ──────────────────────────────────────────────
+
+
+def test_calc_profit_normal():
+    """수익 계산 정상 케이스"""
+    from app.services.price_service import _calc_profit
+
+    pl, pct = _calc_profit(current_value=1200000.0, quantity=10, avg_buy_price=100000.0)
+    assert pl == 200000.0
+    assert abs(pct - 20.0) < 0.01
+
+
+def test_calc_profit_no_avg_buy_price():
+    """avg_buy_price 없으면 (None, None)"""
+    from app.services.price_service import _calc_profit
+
+    pl, pct = _calc_profit(current_value=1000000.0, quantity=10, avg_buy_price=None)
+    assert pl is None
+    assert pct is None
+
+
+def test_calc_profit_zero_avg_buy_price():
+    """avg_buy_price가 0이면 (None, None) — falsy"""
+    from app.services.price_service import _calc_profit
+
+    pl, pct = _calc_profit(current_value=1000000.0, quantity=10, avg_buy_price=0.0)
+    assert pl is None
+    assert pct is None
+
+
+def test_calc_profit_loss():
+    """손실 케이스"""
+    from app.services.price_service import _calc_profit
+
+    pl, pct = _calc_profit(current_value=800000.0, quantity=10, avg_buy_price=100000.0)
+    assert pl == -200000.0
+    assert abs(pct - (-20.0)) < 0.01
+
+
+# ── 종목 검색 ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_stock_kr_naver_success():
+    """네이버 종목 검색 성공"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "result": {
+            "d": [
+                {"cd": "005930", "nm": "삼성전자"},
+                {"cd": "000660", "nm": "SK하이닉스"},
+            ]
+        }
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        results = await price_service._search_stock_kr_naver("삼성")
+        assert len(results) == 2
+        assert results[0]["ticker"] == "005930"
+        assert results[0]["market"] == "KR"
+
+
+@pytest.mark.asyncio
+async def test_search_stock_kr_naver_exception():
+    """네이버 종목 검색 예외 → 빈 리스트"""
+    from app.services import price_service
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = Exception("error")
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        results = await price_service._search_stock_kr_naver("삼성")
+        assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_stock_kr_yahoo_filters_kr():
+    """Yahoo 종목 검색은 .KS/.KQ만 필터"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "quotes": [
+            {"symbol": "005930.KS", "shortname": "Samsung"},
+            {"symbol": "AAPL", "shortname": "Apple"},  # 미국 — 제외
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        results = await price_service._search_stock_kr_yahoo("삼성")
+        assert len(results) == 1
+        assert results[0]["ticker"] == "005930"
+
+
+@pytest.mark.asyncio
+async def test_search_stock_us_success():
+    """미국 종목 검색 성공"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "quotes": [
+            {"symbol": "AAPL", "shortname": "Apple Inc.", "quoteType": "EQUITY"},
+            {"symbol": "BTC-USD", "shortname": "Bitcoin", "quoteType": "CRYPTOCURRENCY"},  # 제외
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        results = await price_service.search_stock_us("apple")
+        assert len(results) == 1
+        assert results[0]["ticker"] == "AAPL"
+        assert results[0]["market"] == "US"
+
+
+@pytest.mark.asyncio
+async def test_search_crypto_success():
+    """코인 검색 성공"""
+    from app.services import price_service
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = [
+        {"market": "KRW-BTC", "korean_name": "비트코인"},
+        {"market": "KRW-ETH", "korean_name": "이더리움"},
+        {"market": "BTC-XRP", "korean_name": "리플"},  # KRW 아님 → 제외
+    ]
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        results = await price_service.search_crypto("비트")
+        assert len(results) == 1
+        assert results[0]["ticker"] == "BTC"
+        assert results[0]["market"] == "CRYPTO"
+
+
+# ── singleflight 락 ──────────────────────────────────────────
+
+
+def test_lock_for_creates_per_key():
+    """_lock_for는 키별 독립 락 생성"""
+    from app.services.price_service import _lock_for
+
+    lock1 = _lock_for("a")
+    lock2 = _lock_for("b")
+    lock1_again = _lock_for("a")
+
+    assert lock1 is lock1_again
+    assert lock1 is not lock2


### PR DESCRIPTION
## Summary

- **#359**: budget_service + price_service 테스트 55개 추가
- **#363**: LLM 프로바이더 OpenAI/Google/Anthropic 테스트 29개 추가

## 추가된 테스트 (84개)

| 파일 | 개수 | 주요 검증 |
|------|------|-----------|
| `test_budget_service.py` | 16 | alerts 경고/초과, overview, 경계값 |
| `test_price_service_extra.py` | 39 | KIS/네이버/Yahoo/업비트 API, 캐시, fallback |
| `test_llm_service_providers.py` | 29 | OpenAI/Google/Anthropic, 팩토리, 에러 핸들링 |

## Test plan

- [x] 전체 982 passed, 19 skipped
- [x] ruff lint/format 통과
- [ ] CI 통과

Closes #359
Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)