### PR TITLE
refactor: TransactionList 훅 추출 — 991→622줄 (#381, #382)

### DIFF
--- a/frontend/src/hooks/__tests__/useMonthlyTransactions.test.ts
+++ b/frontend/src/hooks/__tests__/useMonthlyTransactions.test.ts
@@ -1,0 +1,242 @@
+/**
+ * @file useMonthlyTransactions.test.ts
+ * @description useMonthlyTransactions 훅 테스트 — 월별 데이터 fetch, 필터링, 그룹핑
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+// react-router-dom mock
+const mockSearchParams = new URLSearchParams()
+const mockSetSearchParams = vi.fn((updater: (prev: URLSearchParams) => URLSearchParams) => {
+  if (typeof updater === 'function') {
+    const result = updater(mockSearchParams)
+    mockSearchParams.forEach((_v, k) => mockSearchParams.delete(k))
+    result.forEach((v, k) => mockSearchParams.set(k, v))
+  }
+})
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+}))
+
+vi.mock('../../stores/useHouseholdStore', () => ({
+  useHouseholdStore: (selector?: (state: Record<string, unknown>) => unknown) => {
+    const state = { activeHouseholdId: 1, households: [{ id: 1 }], isLoading: false }
+    return selector ? selector(state) : state
+  },
+}))
+
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn() }),
+}))
+
+import { useMonthlyTransactions } from '../useMonthlyTransactions'
+
+describe('useMonthlyTransactions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSearchParams.forEach((_v, k) => mockSearchParams.delete(k))
+  })
+
+  describe('초기 상태', () => {
+    it('현재 월로 시작한다 (URL 파라미터 없을 때)', () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      const now = new Date()
+      expect(result.current.currentYear).toBe(now.getFullYear())
+      expect(result.current.currentMonth).toBe(now.getMonth())
+    })
+
+    it('URL의 month 파라미터를 읽는다', () => {
+      mockSearchParams.set('month', '2025-06')
+
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.currentYear).toBe(2025)
+      expect(result.current.currentMonth).toBe(5) // 0-indexed
+    })
+
+    it('기본 필터는 all이다', () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.filter).toBe('all')
+    })
+
+    it('URL의 filter 파라미터를 읽는다', () => {
+      mockSearchParams.set('filter', 'expense')
+
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.filter).toBe('expense')
+    })
+  })
+
+  describe('데이터 로딩', () => {
+    it('activeHouseholdId가 있으면 데이터를 로드한다', async () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      // 초기 로딩 상태
+      expect(result.current.loading).toBe(true)
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      // MSW 핸들러가 카테고리를 반환
+      expect(result.current.categories.length).toBeGreaterThan(0)
+    })
+
+    it('activeHouseholdId가 null이면 데이터를 로드하지 않는다', async () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: null })
+      )
+
+      // loading이 true 상태로 유지 (fetchData가 early return)
+      expect(result.current.loading).toBe(true)
+      expect(result.current.expenses).toEqual([])
+      expect(result.current.incomes).toEqual([])
+    })
+
+    it('카테고리 맵이 생성된다', async () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      await waitFor(() => {
+        expect(result.current.categoryMap.size).toBeGreaterThan(0)
+      })
+
+      // categoryMap의 값이 Category 객체인지 확인
+      for (const [id, cat] of result.current.categoryMap) {
+        expect(typeof id).toBe('number')
+        expect(cat).toHaveProperty('name')
+      }
+    })
+  })
+
+  describe('월 레이블', () => {
+    it('현재 월의 한국어 레이블을 반환한다', () => {
+      mockSearchParams.set('month', '2025-03')
+
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.monthLabel).toBe('2025년 3월')
+    })
+  })
+
+  describe('그룹핑 및 요약', () => {
+    it('totalExpense와 totalIncome을 계산한다', async () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      // 숫자 타입이어야 한다
+      expect(typeof result.current.totalExpense).toBe('number')
+      expect(typeof result.current.totalIncome).toBe('number')
+    })
+
+    it('grouped가 Map<string, UnifiedTransaction[]> 형태이다', async () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(result.current.grouped).toBeInstanceOf(Map)
+    })
+
+    it('daySummaries가 날짜별 지출/수입 합계를 제공한다', async () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(result.current.daySummaries).toBeInstanceOf(Map)
+
+      for (const [key, summary] of result.current.daySummaries) {
+        expect(key).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+        expect(typeof summary.expense).toBe('number')
+        expect(typeof summary.income).toBe('number')
+      }
+    })
+  })
+
+  describe('상태 업데이터', () => {
+    it('setExpenses가 지출 목록을 업데이트한다', async () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      // setExpenses가 함수인지 확인
+      expect(typeof result.current.setExpenses).toBe('function')
+    })
+
+    it('setIncomes가 수입 목록을 업데이트한다', async () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(typeof result.current.setIncomes).toBe('function')
+    })
+
+    it('setPendingRecurring이 대기 중인 반복 거래를 업데이트한다', async () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+
+      expect(typeof result.current.setPendingRecurring).toBe('function')
+    })
+  })
+
+  describe('에러 처리', () => {
+    it('error 상태가 기본 false이다', () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.error).toBe(false)
+    })
+
+    it('fetchData 함수를 제공한다 (refetch용)', () => {
+      const { result } = renderHook(() =>
+        useMonthlyTransactions({ activeHouseholdId: 1 })
+      )
+
+      expect(typeof result.current.fetchData).toBe('function')
+    })
+  })
+})

--- a/frontend/src/hooks/__tests__/useTransactionSearch.test.ts
+++ b/frontend/src/hooks/__tests__/useTransactionSearch.test.ts
@@ -1,0 +1,269 @@
+/**
+ * @file useTransactionSearch.test.ts
+ * @description useTransactionSearch 훅 테스트 — 검색 상태, URL 파라미터, 최근 검색어 관리
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+// react-router-dom mock
+const mockSearchParams = new URLSearchParams()
+const mockSetSearchParams = vi.fn((updater: (prev: URLSearchParams) => URLSearchParams) => {
+  if (typeof updater === 'function') {
+    const result = updater(mockSearchParams)
+    // 반영: 실제 URL 파라미터 시뮬레이션
+    mockSearchParams.forEach((_v, k) => mockSearchParams.delete(k))
+    result.forEach((v, k) => mockSearchParams.set(k, v))
+  }
+})
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+}))
+
+vi.mock('../../stores/useHouseholdStore', () => ({
+  useHouseholdStore: (selector?: (state: Record<string, unknown>) => unknown) => {
+    const state = { activeHouseholdId: 1, households: [{ id: 1 }], isLoading: false }
+    return selector ? selector(state) : state
+  },
+}))
+
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn() }),
+}))
+
+import {
+  useTransactionSearch,
+  getRecentSearches,
+  addRecentSearch,
+  removeRecentSearch,
+} from '../useTransactionSearch'
+
+describe('useTransactionSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSearchParams.forEach((_v, k) => mockSearchParams.delete(k))
+    localStorage.clear()
+  })
+
+  describe('초기 상태', () => {
+    it('검색 모드가 아닌 기본 상태로 시작', () => {
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.isSearchMode).toBe(false)
+      expect(result.current.searchQuery).toBe('')
+      expect(result.current.searchResults).toEqual([])
+      expect(result.current.searchSummary).toBeNull()
+      expect(result.current.searchLoading).toBe(false)
+    })
+
+    it('URL에 search 파라미터가 있으면 검색 모드', () => {
+      mockSearchParams.set('search', '김치')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.isSearchMode).toBe(true)
+      expect(result.current.searchQuery).toBe('김치')
+    })
+  })
+
+  describe('검색 필터 상태', () => {
+    it('URL에서 type 필터를 읽는다', () => {
+      mockSearchParams.set('search', '')
+      mockSearchParams.set('type', 'expense')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.searchType).toBe('expense')
+    })
+
+    it('URL에서 category 필터를 읽는다', () => {
+      mockSearchParams.set('search', '')
+      mockSearchParams.set('category', '3')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.searchCategoryId).toBe(3)
+    })
+
+    it('URL에서 period 필터를 읽는다', () => {
+      mockSearchParams.set('search', '')
+      mockSearchParams.set('period', '3m')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.searchPeriod).toBe('3m')
+    })
+
+    it('필터가 있으면 hasSearchFilters가 true', () => {
+      mockSearchParams.set('search', '')
+      mockSearchParams.set('type', 'income')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.hasSearchFilters).toBe(true)
+    })
+  })
+
+  describe('검색 모드 진입/해제', () => {
+    it('enterSearchMode가 search 파라미터를 설정한다', () => {
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      act(() => result.current.enterSearchMode())
+
+      expect(mockSetSearchParams).toHaveBeenCalled()
+    })
+
+    it('exitSearchMode가 search 관련 파라미터를 제거한다', () => {
+      mockSearchParams.set('search', '테스트')
+      mockSearchParams.set('type', 'expense')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      act(() => result.current.exitSearchMode())
+
+      expect(mockSetSearchParams).toHaveBeenCalled()
+    })
+  })
+
+  describe('검색 실행', () => {
+    it('submitSearch가 비어있지 않은 검색어를 URL에 설정한다', () => {
+      mockSearchParams.set('search', '')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      act(() => result.current.submitSearch('김치찌개'))
+
+      expect(mockSetSearchParams).toHaveBeenCalled()
+    })
+
+    it('submitSearch가 빈 검색어는 무시한다', () => {
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      const callCount = mockSetSearchParams.mock.calls.length
+      act(() => result.current.submitSearch('   '))
+
+      expect(mockSetSearchParams.mock.calls.length).toBe(callCount)
+    })
+
+    it('fetchSearchResults가 검색 API를 호출하고 결과를 설정한다', async () => {
+      mockSearchParams.set('search', '김치')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      // MSW가 처리하므로 실제 API 호출됨
+      await act(async () => {
+        await result.current.fetchSearchResults()
+      })
+
+      await waitFor(() => {
+        expect(result.current.searchLoading).toBe(false)
+      })
+
+      // MSW fixture에 '김치찌개'가 있으므로 결과가 존재해야 함
+      expect(result.current.searchResults.length).toBeGreaterThan(0)
+      expect(result.current.searchSummary).not.toBeNull()
+    })
+
+    it('activeHouseholdId가 없으면 fetchSearchResults가 실행되지 않는다', async () => {
+      mockSearchParams.set('search', '김치')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: null })
+      )
+
+      await act(async () => {
+        await result.current.fetchSearchResults()
+      })
+
+      expect(result.current.searchResults).toEqual([])
+    })
+  })
+
+  describe('검색 결과 그룹핑', () => {
+    it('searchGrouped가 날짜별로 결과를 그룹핑한다', async () => {
+      mockSearchParams.set('search', '김치')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      await act(async () => {
+        await result.current.fetchSearchResults()
+      })
+
+      await waitFor(() => {
+        expect(result.current.searchGrouped.size).toBeGreaterThan(0)
+      })
+
+      // 모든 그룹의 키가 YYYY-MM-DD 형식인지 확인
+      for (const key of result.current.searchGrouped.keys()) {
+        expect(key).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      }
+    })
+  })
+})
+
+describe('최근 검색어 관리', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('getRecentSearches가 빈 배열을 반환한다 (초기 상태)', () => {
+    expect(getRecentSearches()).toEqual([])
+  })
+
+  it('addRecentSearch가 검색어를 추가한다', () => {
+    addRecentSearch('김치찌개')
+    expect(getRecentSearches()).toEqual(['김치찌개'])
+  })
+
+  it('addRecentSearch가 중복을 제거하고 최신을 앞에 배치한다', () => {
+    addRecentSearch('김치찌개')
+    addRecentSearch('된장찌개')
+    addRecentSearch('김치찌개')
+    expect(getRecentSearches()).toEqual(['김치찌개', '된장찌개'])
+  })
+
+  it('addRecentSearch가 최대 5개까지만 유지한다', () => {
+    for (let i = 0; i < 7; i++) {
+      addRecentSearch(`검색어${i}`)
+    }
+    expect(getRecentSearches().length).toBe(5)
+    expect(getRecentSearches()[0]).toBe('검색어6')
+  })
+
+  it('removeRecentSearch가 특정 검색어를 제거한다', () => {
+    addRecentSearch('김치찌개')
+    addRecentSearch('된장찌개')
+    removeRecentSearch('김치찌개')
+    expect(getRecentSearches()).toEqual(['된장찌개'])
+  })
+
+  it('localStorage가 깨진 데이터여도 빈 배열을 반환한다', () => {
+    localStorage.setItem('podo-recent-searches', '{invalid}')
+    expect(getRecentSearches()).toEqual([])
+  })
+})

--- a/frontend/src/hooks/useMonthlyTransactions.ts
+++ b/frontend/src/hooks/useMonthlyTransactions.ts
@@ -1,0 +1,193 @@
+/**
+ * @file useMonthlyTransactions.ts
+ * @description 월별 거래 데이터 fetch + 필터링 + 그룹핑 훅
+ * TransactionList에서 월 뷰 관련 데이터 로직을 추출하여 단일 책임 원칙을 따른다.
+ */
+
+import { useEffect, useState, useMemo, useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { expenseApi } from '../api/expenses'
+import { incomeApi } from '../api/income'
+import { recurringApi } from '../api/recurring'
+import { categoryApi } from '../api/categories'
+import { getMonthRange } from '../utils/calendar'
+import type { Expense, Income, Category, RecurringTransaction } from '../types'
+import type { UnifiedTransaction } from './useTransactionSearch'
+
+type FilterType = 'all' | 'expense' | 'income'
+
+interface UseMonthlyTransactionsOptions {
+  activeHouseholdId: number | null
+}
+
+export function useMonthlyTransactions({ activeHouseholdId }: UseMonthlyTransactionsOptions) {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // URL에서 월 파라미터 읽기 (YYYY-MM 형식)
+  const monthParam = searchParams.get('month')
+  const [currentYear, currentMonth] = useMemo(() => {
+    if (monthParam) {
+      const [y, m] = monthParam.split('-').map(Number)
+      if (y && m) return [y, m - 1] // 0-indexed
+    }
+    const now = new Date()
+    return [now.getFullYear(), now.getMonth()]
+  }, [monthParam])
+
+  const filter: FilterType = (searchParams.get('filter') as FilterType) || 'all'
+
+  // 데이터 상태
+  const [expenses, setExpenses] = useState<Expense[]>([])
+  const [incomes, setIncomes] = useState<Income[]>([])
+  const [categories, setCategories] = useState<Category[]>([])
+  const [pendingRecurring, setPendingRecurring] = useState<RecurringTransaction[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+
+  // URL 파라미터 업데이트
+  const setParams = useCallback((updates: Record<string, string | null>) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      for (const [k, v] of Object.entries(updates)) {
+        if (v === null) next.delete(k)
+        else next.set(k, v)
+      }
+      return next
+    }, { replace: true })
+  }, [setSearchParams])
+
+  // 월 이동
+  const navigateMonth = useCallback((delta: number) => {
+    const d = new Date(currentYear, currentMonth + delta, 1)
+    const pad = (n: number) => String(n).padStart(2, '0')
+    setParams({ month: `${d.getFullYear()}-${pad(d.getMonth() + 1)}` })
+  }, [currentYear, currentMonth, setParams])
+
+  // 필터 토글
+  const toggleFilter = useCallback((type: 'expense' | 'income') => {
+    setParams({ filter: filter === type ? null : type })
+  }, [filter, setParams])
+
+  // 카테고리 로드
+  useEffect(() => {
+    categoryApi.getAll().then(res => setCategories(res.data)).catch(() => {})
+  }, [])
+
+  // 데이터 로드
+  const fetchData = useCallback(async () => {
+    if (!activeHouseholdId) return
+    setLoading(true)
+    setError(false)
+    try {
+      const { start, end } = getMonthRange(currentYear, currentMonth)
+      const baseParams = {
+        start_date: start,
+        end_date: end,
+        limit: 1000,
+        household_id: activeHouseholdId,
+      }
+
+      const [expRes, incRes, pendingRes] = await Promise.all([
+        expenseApi.getAll(baseParams).catch(() => ({ data: [] as Expense[] })),
+        incomeApi.getAll(baseParams).catch(() => ({ data: [] as Income[] })),
+        recurringApi.getPending(activeHouseholdId).catch(() => ({ data: [] as RecurringTransaction[] })),
+      ])
+
+      setExpenses(expRes.data)
+      setIncomes(incRes.data)
+      setPendingRecurring(pendingRes?.data ?? [])
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [currentYear, currentMonth, activeHouseholdId])
+
+  useEffect(() => { fetchData() }, [fetchData])
+
+  // 카테고리 O(1) 조회용 Map
+  const categoryMap = useMemo(() => new Map(categories.map(c => [c.id, c])), [categories])
+
+  // 통합 + 정렬 + 그룹핑
+  const { grouped, totalExpense, totalIncome, daySummaries } = useMemo(() => {
+    const all: UnifiedTransaction[] = [
+      ...expenses.map(e => ({ ...e, type: 'expense' as const })),
+      ...incomes.map(i => ({ ...i, type: 'income' as const })),
+    ]
+
+    // 필터 적용
+    const filtered = filter === 'all' ? all : all.filter(t => t.type === filter)
+
+    // 날짜 역순 + 같은 날짜 내 id 역순
+    filtered.sort((a, b) => {
+      const dateCmp = b.date.localeCompare(a.date)
+      if (dateCmp !== 0) return dateCmp
+      return b.id - a.id
+    })
+
+    // 날짜별 그룹핑
+    const grouped = new Map<string, UnifiedTransaction[]>()
+    for (const tx of filtered) {
+      const dateKey = tx.date.slice(0, 10)
+      const group = grouped.get(dateKey)
+      if (group) group.push(tx)
+      else grouped.set(dateKey, [tx])
+    }
+
+    // 요약 (항상 전체 데이터 기준)
+    let totalExpense = 0
+    let totalIncome = 0
+    for (const e of expenses) totalExpense += e.amount
+    for (const i of incomes) totalIncome += i.amount
+
+    // 캘린더 날짜별 요약 (필터 반영)
+    const daySummaries = new Map<string, { expense: number; income: number }>()
+    const calendarSource = filter === 'all' ? all : all.filter(t => t.type === filter)
+    for (const tx of calendarSource) {
+      const key = tx.date.slice(0, 10)
+      const s = daySummaries.get(key) ?? { expense: 0, income: 0 }
+      if (tx.type === 'expense') s.expense += tx.amount
+      else s.income += tx.amount
+      daySummaries.set(key, s)
+    }
+
+    return { grouped, totalExpense, totalIncome, daySummaries }
+  }, [expenses, incomes, filter])
+
+  const monthLabel = `${currentYear}년 ${currentMonth + 1}월`
+
+  return {
+    // 날짜 네비게이션
+    currentYear,
+    currentMonth,
+    monthLabel,
+    navigateMonth,
+
+    // 필터
+    filter,
+    toggleFilter,
+
+    // 데이터
+    expenses,
+    incomes,
+    categories,
+    categoryMap,
+    pendingRecurring,
+    setPendingRecurring,
+
+    // 상태 업데이터 (카테고리 변경 등에서 사용)
+    setExpenses,
+    setIncomes,
+
+    // 그룹핑된 데이터
+    grouped,
+    totalExpense,
+    totalIncome,
+    daySummaries,
+
+    // 로딩/에러
+    loading,
+    error,
+    fetchData,
+  }
+}

--- a/frontend/src/hooks/useTransactionSearch.ts
+++ b/frontend/src/hooks/useTransactionSearch.ts
@@ -1,0 +1,307 @@
+/**
+ * @file useTransactionSearch.ts
+ * @description 거래 검색 로직 훅 — 검색 state, URL 파라미터, 무한스크롤, 최근 검색어 관리
+ * TransactionList에서 검색 관련 로직을 추출하여 단일 책임 원칙을 따른다.
+ */
+
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { expenseApi } from '../api/expenses'
+import { incomeApi } from '../api/income'
+import { useToast } from './useToast'
+import { getLocalDateString } from '../utils/format'
+import type { Expense, Income } from '../types'
+
+// 최근 검색어 localStorage 관리
+const RECENT_SEARCHES_KEY = 'podo-recent-searches'
+const MAX_RECENT_SEARCHES = 5
+const SEARCH_PAGE_SIZE = 30
+
+export interface UnifiedTransaction {
+  id: number
+  type: 'expense' | 'income'
+  date: string
+  description: string
+  amount: number
+  category_id: number | null
+  exclude_from_stats?: boolean
+  raw_input?: string | null
+}
+
+export function getRecentSearches(): string[] {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(RECENT_SEARCHES_KEY) || '[]')
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+export function addRecentSearch(query: string): void {
+  const searches = getRecentSearches().filter(s => s !== query)
+  searches.unshift(query)
+  localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(searches.slice(0, MAX_RECENT_SEARCHES)))
+}
+
+export function removeRecentSearch(query: string): void {
+  const searches = getRecentSearches().filter(s => s !== query)
+  localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(searches))
+}
+
+/** 기간 프리셋 → 날짜 범위 계산 */
+function getSearchDateRange(period: string): { start_date?: string; end_date?: string } {
+  if (period === 'all') return {}
+  const now = new Date()
+  const end = getLocalDateString(now)
+  let start: Date
+  switch (period) {
+    case '1m': start = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()); break
+    case '3m': start = new Date(now.getFullYear(), now.getMonth() - 3, now.getDate()); break
+    case '6m': start = new Date(now.getFullYear(), now.getMonth() - 6, now.getDate()); break
+    case 'year': start = new Date(now.getFullYear(), 0, 1); break
+    default: return {}
+  }
+  return { start_date: getLocalDateString(start), end_date: end }
+}
+
+interface UseTransactionSearchOptions {
+  activeHouseholdId: number | null
+}
+
+export function useTransactionSearch({ activeHouseholdId }: UseTransactionSearchOptions) {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { addToast } = useToast()
+
+  // URL 파라미터 읽기
+  const searchQuery = searchParams.get('search') ?? ''
+  const isSearchMode = searchParams.has('search')
+  const searchType = (searchParams.get('type') as 'all' | 'expense' | 'income') || 'all'
+  const searchCategoryId = searchParams.get('category') ? Number(searchParams.get('category')) : null
+  const searchPeriod = (searchParams.get('period') as 'all' | '1m' | '3m' | '6m' | 'year') || 'all'
+  const hasSearchFilters = !!(searchCategoryId || searchPeriod !== 'all' || searchType !== 'all')
+
+  // 검색 결과 상태
+  const [searchResults, setSearchResults] = useState<UnifiedTransaction[]>([])
+  const [searchSummary, setSearchSummary] = useState<{ total_count: number; total_amount: number } | null>(null)
+  const [searchLoading, setSearchLoading] = useState(false)
+
+  // 무한 스크롤 상태
+  const [searchHasMore, setSearchHasMore] = useState(false)
+  const [searchLoadingMore, setSearchLoadingMore] = useState(false)
+  const searchOffsetRef = useRef(0)
+  const loadMoreRef = useRef<HTMLDivElement>(null)
+
+  // 최근 검색어
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const [recentSearches, setRecentSearches] = useState<string[]>(getRecentSearches())
+
+  // 검색 필터 드롭다운 상태
+  const [openFilter, setOpenFilter] = useState<'type' | 'period' | null>(null)
+
+  // URL 파라미터 업데이트
+  const setParams = useCallback((updates: Record<string, string | null>) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      for (const [k, v] of Object.entries(updates)) {
+        if (v === null) next.delete(k)
+        else next.set(k, v)
+      }
+      return next
+    }, { replace: true })
+  }, [setSearchParams])
+
+  // 검색 모드 진입
+  const enterSearchMode = useCallback(() => {
+    setParams({ search: '', month: null, filter: null })
+  }, [setParams])
+
+  // 검색 모드 해제 → 월 뷰 복귀
+  const exitSearchMode = useCallback(() => {
+    setParams({ search: null, type: null, category: null, period: null, member: null })
+    setOpenFilter(null)
+  }, [setParams])
+
+  // 검색 실행
+  const submitSearch = useCallback((value: string) => {
+    const trimmed = value.trim()
+    if (trimmed) {
+      setParams({ search: trimmed })
+      addRecentSearch(trimmed)
+      setRecentSearches(getRecentSearches())
+    }
+  }, [setParams])
+
+  // 검색 필터 변경
+  const setSearchFilter = useCallback((key: string, value: string | null) => {
+    setParams({ [key]: value })
+    setOpenFilter(null)
+  }, [setParams])
+
+  // 검색 API 호출 (append=true: 무한 스크롤 추가 로드)
+  const fetchSearchResults = useCallback(async (append = false) => {
+    if (!activeHouseholdId || (!searchQuery && !hasSearchFilters)) return
+
+    if (append) {
+      setSearchLoadingMore(true)
+    } else {
+      setSearchLoading(true)
+      searchOffsetRef.current = 0
+    }
+
+    try {
+      const offset = append ? searchOffsetRef.current : 0
+      const dateRange = getSearchDateRange(searchPeriod)
+      const baseParams = {
+        query: searchQuery || undefined,
+        skip: offset,
+        limit: SEARCH_PAGE_SIZE,
+        household_id: activeHouseholdId,
+        ...dateRange,
+        ...(searchCategoryId && { category_id: searchCategoryId }),
+      }
+
+      const fetchExpenses = searchType !== 'income'
+      const fetchIncomes = searchType !== 'expense'
+
+      const promises: Promise<{ data: unknown }>[] = [
+        fetchExpenses ? expenseApi.getAll(baseParams) : Promise.resolve({ data: [] as Expense[] }),
+        fetchIncomes ? incomeApi.getAll(baseParams) : Promise.resolve({ data: [] as Income[] }),
+      ]
+      if (!append) {
+        promises.push(
+          fetchExpenses ? expenseApi.searchSummary(baseParams) : Promise.resolve({ data: { total_count: 0, total_amount: 0 } }),
+          fetchIncomes ? incomeApi.searchSummary(baseParams) : Promise.resolve({ data: { total_count: 0, total_amount: 0 } }),
+        )
+      }
+
+      const results = await Promise.all(promises)
+      const expData = (results[0].data as Expense[]) ?? []
+      const incData = (results[1].data as Income[]) ?? []
+
+      const newItems: UnifiedTransaction[] = [
+        ...expData.map(e => ({ ...e, type: 'expense' as const })),
+        ...incData.map(i => ({ ...i, type: 'income' as const })),
+      ]
+      newItems.sort((a, b) => b.date.localeCompare(a.date) || b.id - a.id)
+
+      if (append) {
+        setSearchResults(prev => [...prev, ...newItems])
+      } else {
+        setSearchResults(newItems)
+        const expSummary = results[2].data as { total_count: number; total_amount: number }
+        const incSummary = results[3].data as { total_count: number; total_amount: number }
+        setSearchSummary({
+          total_count: expSummary.total_count + incSummary.total_count,
+          total_amount: expSummary.total_amount + incSummary.total_amount,
+        })
+      }
+
+      searchOffsetRef.current = offset + SEARCH_PAGE_SIZE
+      setSearchHasMore(newItems.length >= SEARCH_PAGE_SIZE)
+    } catch {
+      addToast('error', '검색에 실패했습니다')
+    } finally {
+      setSearchLoading(false)
+      setSearchLoadingMore(false)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- addToast는 안정적 참조
+  }, [searchQuery, activeHouseholdId, searchType, searchCategoryId, searchPeriod])
+
+  // 검색어 또는 필터 변경 시 검색 실행
+  useEffect(() => {
+    if (isSearchMode) {
+      if (searchQuery || hasSearchFilters) {
+        fetchSearchResults()
+      } else {
+        setSearchResults([])
+        setSearchSummary(null)
+      }
+    } else {
+      setSearchResults([])
+      setSearchSummary(null)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchSearchResults 내부에서 동일 state 참조
+  }, [isSearchMode, searchQuery, searchType, searchCategoryId, searchPeriod])
+
+  // 검색 모드 진입 시 인풋 포커스
+  useEffect(() => {
+    if (isSearchMode && searchInputRef.current) {
+      searchInputRef.current.focus()
+    }
+  }, [isSearchMode])
+
+  // 무한 스크롤: IntersectionObserver
+  useEffect(() => {
+    if (!loadMoreRef.current || !searchHasMore || searchLoadingMore) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          fetchSearchResults(true)
+        }
+      },
+      { threshold: 0.1 },
+    )
+
+    observer.observe(loadMoreRef.current)
+    return () => observer.disconnect()
+  }, [searchHasMore, searchLoadingMore, fetchSearchResults])
+
+  // 드롭다운 외부 클릭 시 닫기
+  useEffect(() => {
+    if (!openFilter) return
+    const handleClick = () => setOpenFilter(null)
+    document.addEventListener('pointerdown', handleClick)
+    return () => document.removeEventListener('pointerdown', handleClick)
+  }, [openFilter])
+
+  // 검색 결과 날짜별 그룹핑
+  const searchGrouped = useMemo(() => {
+    const grouped = new Map<string, UnifiedTransaction[]>()
+    for (const tx of searchResults) {
+      const dateKey = tx.date.slice(0, 10)
+      const group = grouped.get(dateKey)
+      if (group) group.push(tx)
+      else grouped.set(dateKey, [tx])
+    }
+    return grouped
+  }, [searchResults])
+
+  return {
+    // URL 상태
+    searchQuery,
+    isSearchMode,
+    searchType,
+    searchCategoryId,
+    searchPeriod,
+    hasSearchFilters,
+
+    // 검색 결과
+    searchResults,
+    searchSummary,
+    searchLoading,
+    searchGrouped,
+
+    // 무한 스크롤
+    searchHasMore,
+    searchLoadingMore,
+    loadMoreRef,
+
+    // 최근 검색어
+    searchInputRef,
+    recentSearches,
+    setRecentSearches,
+
+    // 필터 드롭다운
+    openFilter,
+    setOpenFilter,
+
+    // 액션
+    setParams,
+    enterSearchMode,
+    exitSearchMode,
+    submitSearch,
+    setSearchFilter,
+    fetchSearchResults,
+  }
+}

--- a/frontend/src/pages/TransactionList.tsx
+++ b/frontend/src/pages/TransactionList.tsx
@@ -1,15 +1,14 @@
 /**
  * @file TransactionList.tsx
  * @description 통합 거래 목록 페이지 — 월별 캘린더 + 날짜별 그룹핑
+ * 검색 로직은 useTransactionSearch, 월별 데이터는 useMonthlyTransactions에 위임한다.
  */
 
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react'
-import { useSearchParams } from 'react-router-dom'
 import PeriodNavigator from '../components/stats/PeriodNavigator'
 import { expenseApi } from '../api/expenses'
 import { incomeApi } from '../api/income'
 import { recurringApi } from '../api/recurring'
-import { categoryApi } from '../api/categories'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
 import MiniCalendar from '../components/MiniCalendar'
@@ -19,83 +18,25 @@ import CategoryBottomSheet from '../components/CategoryBottomSheet'
 import PullToRefresh from '../components/PullToRefresh'
 import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
-import type { Expense, Income, Category, RecurringTransaction } from '../types'
-import { formatAmount , getLocalDateString } from '../utils/format'
-import { getMonthRange, formatDateHeader } from '../utils/calendar'
-import {
-  groupTransactionsByDate, filterByType, calcTotals, calcDaySummaries,
-  type UnifiedTransaction,
-} from '../utils/transactionUtils'
+import { formatAmount } from '../utils/format'
+import { formatDateHeader } from '../utils/calendar'
 import { Search, X } from 'lucide-react'
 import WelcomeCard from '../components/WelcomeCard'
 import { useAuth } from '../contexts/AuthContext'
-
-type FilterType = 'all' | 'expense' | 'income'
-
-// 최근 검색어 localStorage 관리
-const RECENT_SEARCHES_KEY = 'podo-recent-searches'
-const MAX_RECENT_SEARCHES = 5
-
-function getRecentSearches(): string[] {
-  try {
-    const parsed = JSON.parse(localStorage.getItem(RECENT_SEARCHES_KEY) || '[]')
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-function addRecentSearch(query: string): void {
-  const searches = getRecentSearches().filter(s => s !== query)
-  searches.unshift(query)
-  localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(searches.slice(0, MAX_RECENT_SEARCHES)))
-}
-
-function removeRecentSearch(query: string): void {
-  const searches = getRecentSearches().filter(s => s !== query)
-  localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(searches))
-}
+import { useTransactionSearch, getRecentSearches, removeRecentSearch } from '../hooks/useTransactionSearch'
+import type { UnifiedTransaction } from '../hooks/useTransactionSearch'
+import { useMonthlyTransactions } from '../hooks/useMonthlyTransactions'
 
 export default function TransactionList() {
-  const [searchParams, setSearchParams] = useSearchParams()
   const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
   const { addToast } = useToast()
   const { user } = useAuth()
 
-  // URL에서 월 파라미터 읽기 (YYYY-MM 형식)
-  const monthParam = searchParams.get('month')
-  const [currentYear, currentMonth] = useMemo(() => {
-    if (monthParam) {
-      const [y, m] = monthParam.split('-').map(Number)
-      if (y && m) return [y, m - 1] // 0-indexed
-    }
-    const now = new Date()
-    return [now.getFullYear(), now.getMonth()]
-  }, [monthParam])
+  // 월별 거래 데이터 훅
+  const monthly = useMonthlyTransactions({ activeHouseholdId })
 
-  const filter: FilterType = (searchParams.get('filter') as FilterType) || 'all'
-
-  // 검색 모드
-  const searchQuery = searchParams.get('search') ?? ''
-  const isSearchMode = searchParams.has('search')
-  const searchInputRef = useRef<HTMLInputElement>(null)
-  const [recentSearches, setRecentSearches] = useState<string[]>(getRecentSearches())
-
-  // 검색 필터 URL 파라미터
-  const searchType = (searchParams.get('type') as 'all' | 'expense' | 'income') || 'all'
-  const searchCategoryId = searchParams.get('category') ? Number(searchParams.get('category')) : null
-  const searchPeriod = (searchParams.get('period') as 'all' | '1m' | '3m' | '6m' | 'year') || 'all'
-
-  // 검색 필터 활성 여부 — 검색어 없이 필터만으로도 결과 표시 (#329)
-  const hasSearchFilters = !!(searchCategoryId || searchPeriod !== 'all' || searchType !== 'all')
-
-
-  const [expenses, setExpenses] = useState<Expense[]>([])
-  const [incomes, setIncomes] = useState<Income[]>([])
-  const [categories, setCategories] = useState<Category[]>([])
-  const [pendingRecurring, setPendingRecurring] = useState<RecurringTransaction[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(false)
+  // 검색 훅
+  const search = useTransactionSearch({ activeHouseholdId })
 
   // 웰컴 카드 상태
   const [welcomeDismissed, setWelcomeDismissed] = useState(() =>
@@ -119,35 +60,21 @@ export default function TransactionList() {
     localStorage.setItem('podo-welcome-dismissed', 'true')
   }, [])
 
-  // 검색 결과 상태
-  const [searchResults, setSearchResults] = useState<UnifiedTransaction[]>([])
-  const [searchSummary, setSearchSummary] = useState<{ total_count: number; total_amount: number } | null>(null)
-  const [searchLoading, setSearchLoading] = useState(false)
-
-  // 검색 무한 스크롤 상태
-  const [searchHasMore, setSearchHasMore] = useState(false)
-  const [searchLoadingMore, setSearchLoadingMore] = useState(false)
-  const searchOffsetRef = useRef(0)
-  const loadMoreRef = useRef<HTMLDivElement>(null)
-  const SEARCH_PAGE_SIZE = 30
-
-  // 검색 필터 드롭다운 상태
-  const [openFilter, setOpenFilter] = useState<'type' | 'period' | null>(null)
-  // 카테고리 바텀시트: 검색 필터용 vs 거래 카테고리 변경용 구분
-  const [isFilterCategorySheet, setIsFilterCategorySheet] = useState(false)
+  // 웰컴 카드 단계 갱신 — 거래 추가 후 돌아왔을 때 반영
+  useEffect(() => {
+    if (!welcomeDismissed && !monthly.loading) {
+      setTotalTransactionCount(prev =>
+        Math.max(prev, monthly.expenses.length + monthly.incomes.length)
+      )
+    }
+  }, [welcomeDismissed, monthly.loading, monthly.expenses.length, monthly.incomes.length])
 
   // 카테고리 바텀시트 상태
   const [sheetOpen, setSheetOpen] = useState(false)
   const [sheetTarget, setSheetTarget] = useState<UnifiedTransaction | null>(null)
   const [sheetSaving, setSheetSaving] = useState(false)
-
-  // 드롭다운 외부 클릭 시 닫기
-  useEffect(() => {
-    if (!openFilter) return
-    const handleClick = () => setOpenFilter(null)
-    document.addEventListener('pointerdown', handleClick)
-    return () => document.removeEventListener('pointerdown', handleClick)
-  }, [openFilter])
+  // 카테고리 바텀시트: 검색 필터용 vs 거래 카테고리 변경용 구분
+  const [isFilterCategorySheet, setIsFilterCategorySheet] = useState(false)
 
   // 날짜 섹션 ref 맵
   const dateRefs = useRef<Map<string, HTMLDivElement>>(new Map())
@@ -158,272 +85,24 @@ export default function TransactionList() {
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
   }, [])
 
-  // URL 파라미터 업데이트
-  const setParams = useCallback((updates: Record<string, string | null>) => {
-    setSearchParams(prev => {
-      const next = new URLSearchParams(prev)
-      for (const [k, v] of Object.entries(updates)) {
-        if (v === null) next.delete(k)
-        else next.set(k, v)
-      }
-      return next
-    }, { replace: true })
-  }, [setSearchParams])
-
-  // 월 이동
-  const navigateMonth = useCallback((delta: number) => {
-    const d = new Date(currentYear, currentMonth + delta, 1)
-    const pad = (n: number) => String(n).padStart(2, '0')
-    setParams({ month: `${d.getFullYear()}-${pad(d.getMonth() + 1)}` })
-  }, [currentYear, currentMonth, setParams])
-
-  // 필터 토글
-  const toggleFilter = useCallback((type: 'expense' | 'income') => {
-    setParams({ filter: filter === type ? null : type })
-  }, [filter, setParams])
-
-  // 검색 모드 진입
-  const enterSearchMode = useCallback(() => {
-    setParams({ search: '', month: null, filter: null })
-  }, [setParams])
-
-  // 검색 모드 해제 → 월 뷰 복귀 (필터 파라미터도 전부 제거)
-  const exitSearchMode = useCallback(() => {
-    setParams({ search: null, type: null, category: null, period: null, member: null })
-    setOpenFilter(null)
-  }, [setParams])
-
-  // 검색 실행
-  const submitSearch = useCallback((value: string) => {
-    const trimmed = value.trim()
-    if (trimmed) {
-      setParams({ search: trimmed })
-      addRecentSearch(trimmed)
-      setRecentSearches(getRecentSearches())
-    }
-  }, [setParams])
-
-  // 검색 필터 변경
-  const setSearchFilter = useCallback((key: string, value: string | null) => {
-    setParams({ [key]: value })
-    setOpenFilter(null)
-  }, [setParams])
-
-  // 기간 프리셋 → 날짜 범위 계산
-  const getSearchDateRange = useCallback((period: string): { start_date?: string; end_date?: string } => {
-    if (period === 'all') return {}
-    const now = new Date()
-    const end = getLocalDateString(now)
-    let start: Date
-    switch (period) {
-      case '1m': start = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()); break
-      case '3m': start = new Date(now.getFullYear(), now.getMonth() - 3, now.getDate()); break
-      case '6m': start = new Date(now.getFullYear(), now.getMonth() - 6, now.getDate()); break
-      case 'year': start = new Date(now.getFullYear(), 0, 1); break
-      default: return {}
-    }
-    return { start_date: getLocalDateString(start), end_date: end }
-  }, [])
-
-  // 검색 실행 (append=true: 무한 스크롤로 추가 로드)
-  const fetchSearchResults = useCallback(async (append = false) => {
-    if (!activeHouseholdId || (!searchQuery && !hasSearchFilters)) return
-
-    if (append) {
-      setSearchLoadingMore(true)
-    } else {
-      setSearchLoading(true)
-      searchOffsetRef.current = 0
-    }
-
-    try {
-      const offset = append ? searchOffsetRef.current : 0
-      const dateRange = getSearchDateRange(searchPeriod)
-      const baseParams = {
-        query: searchQuery || undefined,
-        skip: offset,
-        limit: SEARCH_PAGE_SIZE,
-        household_id: activeHouseholdId,
-        ...dateRange,
-        ...(searchCategoryId && { category_id: searchCategoryId }),
-      }
-
-      // 타입 필터: 해당 타입만 fetch
-      const fetchExpenses = searchType !== 'income'
-      const fetchIncomes = searchType !== 'expense'
-
-      // 첫 로드: 데이터 + 합계, 추가 로드: 데이터만
-      const promises: Promise<{ data: unknown }>[] = [
-        fetchExpenses ? expenseApi.getAll(baseParams) : Promise.resolve({ data: [] as Expense[] }),
-        fetchIncomes ? incomeApi.getAll(baseParams) : Promise.resolve({ data: [] as Income[] }),
-      ]
-      if (!append) {
-        promises.push(
-          fetchExpenses ? expenseApi.searchSummary(baseParams) : Promise.resolve({ data: { total_count: 0, total_amount: 0 } }),
-          fetchIncomes ? incomeApi.searchSummary(baseParams) : Promise.resolve({ data: { total_count: 0, total_amount: 0 } }),
-        )
-      }
-
-      const results = await Promise.all(promises)
-      const expData = (results[0].data as Expense[]) ?? []
-      const incData = (results[1].data as Income[]) ?? []
-
-      const newItems: UnifiedTransaction[] = [
-        ...expData.map(e => ({ ...e, type: 'expense' as const })),
-        ...incData.map(i => ({ ...i, type: 'income' as const })),
-      ]
-      newItems.sort((a, b) => b.date.localeCompare(a.date) || b.id - a.id)
-
-      if (append) {
-        setSearchResults(prev => [...prev, ...newItems])
-      } else {
-        setSearchResults(newItems)
-        const expSummary = results[2].data as { total_count: number; total_amount: number }
-        const incSummary = results[3].data as { total_count: number; total_amount: number }
-        setSearchSummary({
-          total_count: expSummary.total_count + incSummary.total_count,
-          total_amount: expSummary.total_amount + incSummary.total_amount,
-        })
-      }
-
-      searchOffsetRef.current = offset + SEARCH_PAGE_SIZE
-      setSearchHasMore(newItems.length >= SEARCH_PAGE_SIZE)
-    } catch {
-      addToast('error', '검색에 실패했습니다')
-    } finally {
-      setSearchLoading(false)
-      setSearchLoadingMore(false)
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- addToast는 안정적 참조
-  }, [searchQuery, activeHouseholdId, searchType, searchCategoryId, searchPeriod, getSearchDateRange])
-
-  // 검색어 또는 필터 변경 시 검색 실행
-  useEffect(() => {
-    if (isSearchMode) {
-      if (searchQuery || hasSearchFilters) {
-        fetchSearchResults()
-      } else {
-        setSearchResults([])
-        setSearchSummary(null)
-      }
-    } else {
-      setSearchResults([])
-      setSearchSummary(null)
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchSearchResults 내부에서 동일 state 참조
-  }, [isSearchMode, searchQuery, searchType, searchCategoryId, searchPeriod])
-
-  // 검색 모드 진입 시 인풋 포커스
-  useEffect(() => {
-    if (isSearchMode && searchInputRef.current) {
-      searchInputRef.current.focus()
-    }
-  }, [isSearchMode])
-
-  // 무한 스크롤: IntersectionObserver로 sentinel 감지 → 추가 로드
-  useEffect(() => {
-    if (!loadMoreRef.current || !searchHasMore || searchLoadingMore) return
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting) {
-          fetchSearchResults(true)
-        }
-      },
-      { threshold: 0.1 },
-    )
-
-    observer.observe(loadMoreRef.current)
-    return () => observer.disconnect()
-  }, [searchHasMore, searchLoadingMore, fetchSearchResults])
-
-  // 카테고리 로드
-  useEffect(() => {
-    categoryApi.getAll().then(res => setCategories(res.data)).catch(() => {})
-  }, [])
-
-  // 데이터 로드
-  const fetchData = useCallback(async () => {
-    // 가구 로딩 전 API 호출 방지 (#149)
-    if (!activeHouseholdId) return
-    setLoading(true)
-    setError(false)
-    try {
-      const { start, end } = getMonthRange(currentYear, currentMonth)
-      const baseParams = {
-        start_date: start,
-        end_date: end,
-        limit: 1000,
-        household_id: activeHouseholdId,
-      }
-
-      const [expRes, incRes, pendingRes] = await Promise.all([
-        expenseApi.getAll(baseParams).catch(() => ({ data: [] as Expense[] })),
-        incomeApi.getAll(baseParams).catch(() => ({ data: [] as Income[] })),
-        recurringApi.getPending(activeHouseholdId).catch(() => ({ data: [] as RecurringTransaction[] })),
-      ])
-
-      setExpenses(expRes.data)
-      setIncomes(incRes.data)
-      setPendingRecurring(pendingRes?.data ?? [])
-      // 웰컴 카드 단계 갱신 — 거래 추가 후 돌아왔을 때 반영
-      if (!welcomeDismissed) {
-        setTotalTransactionCount((prev) => Math.max(prev, expRes.data.length + incRes.data.length))
-      }
-    } catch {
-      setError(true)
-    } finally {
-      setLoading(false)
-    }
-  }, [currentYear, currentMonth, activeHouseholdId])
-
-  useEffect(() => { fetchData() }, [fetchData])
-
-  // 카테고리 O(1) 조회용 Map — TransactionItem에 배열 대신 전달 (#180)
-  const categoryMap = useMemo(() => new Map(categories.map(c => [c.id, c])), [categories])
-
-  // 통합 + 정렬 + 그룹핑 (순수 유틸 함수 사용)
-  const { grouped, totalExpense, totalIncome, daySummaries } = useMemo(() => {
-    const all: UnifiedTransaction[] = [
-      ...expenses.map(e => ({ ...e, type: 'expense' as const })),
-      ...incomes.map(i => ({ ...i, type: 'income' as const })),
-    ]
-
-    const filtered = filterByType(all, filter)
-    const grouped = groupTransactionsByDate(filtered)
-    const { totalExpense, totalIncome } = calcTotals(expenses, incomes)
-    const calendarSource = filterByType(all, filter)
-    const daySummaries = calcDaySummaries(calendarSource)
-
-    return { grouped, totalExpense, totalIncome, daySummaries }
-  }, [expenses, incomes, filter])
-
-  // 검색 결과 날짜별 그룹핑 (순수 유틸 함수 사용)
-  const searchGrouped = useMemo(
-    () => groupTransactionsByDate(searchResults),
-    [searchResults],
-  )
-
-  // TransactionItem.onCategoryClick 안정화 — 데이터 변경 시에만 재생성 (#240)
-  // 검색 모드: 카테고리 뱃지 클릭 → 카테고리 필터 토글 (#323)
-  // 월 뷰: 카테고리 뱃지 클릭 → 카테고리 변경 바텀시트
+  // TransactionItem.onCategoryClick 안정화
   const categoryClickHandlers = useMemo(() => {
     const handlers = new Map<string, () => void>()
 
-    if (isSearchMode) {
-      for (const txs of searchGrouped.values()) {
+    if (search.isSearchMode) {
+      for (const txs of search.searchGrouped.values()) {
         for (const tx of txs) {
           handlers.set(`${tx.type}-${tx.id}`, () => {
             if (tx.category_id) {
-              // 같은 카테고리 재클릭 시 필터 해제 (토글)
-              setSearchFilter('category',
-                searchCategoryId === tx.category_id ? null : String(tx.category_id))
+              setIsFilterCategorySheet(false)
+              search.setSearchFilter('category',
+                search.searchCategoryId === tx.category_id ? null : String(tx.category_id))
             }
           })
         }
       }
     } else {
-      for (const txs of grouped.values()) {
+      for (const txs of monthly.grouped.values()) {
         for (const tx of txs) {
           handlers.set(`${tx.type}-${tx.id}`, () => {
             setIsFilterCategorySheet(false)
@@ -435,7 +114,7 @@ export default function TransactionList() {
     }
     return handlers
   // eslint-disable-next-line react-hooks/exhaustive-deps -- setSearchFilter는 useCallback 안정 참조
-  }, [grouped, searchGrouped, isSearchMode, searchCategoryId])
+  }, [monthly.grouped, search.searchGrouped, search.isSearchMode, search.searchCategoryId])
 
   // 캘린더 날짜 클릭 → 스크롤
   const handleDateClick = useCallback((dateString: string) => {
@@ -447,25 +126,23 @@ export default function TransactionList() {
 
   // 카테고리 변경 (거래 카테고리 수정 또는 검색 필터 설정)
   const handleCategorySelect = useCallback(async (categoryId: number | null) => {
-    // 검색 필터용 카테고리 선택
     if (isFilterCategorySheet) {
-      setSearchFilter('category', categoryId ? String(categoryId) : null)
+      search.setSearchFilter('category', categoryId ? String(categoryId) : null)
       setSheetOpen(false)
       setIsFilterCategorySheet(false)
       return
     }
-    // 거래 카테고리 변경
     if (!sheetTarget) return
     setSheetSaving(true)
     try {
       if (sheetTarget.type === 'expense') {
         await expenseApi.update(sheetTarget.id, { category_id: categoryId ?? undefined })
-        setExpenses(prev => prev.map(e =>
+        monthly.setExpenses(prev => prev.map(e =>
           e.id === sheetTarget.id ? { ...e, category_id: categoryId } : e
         ))
       } else {
         await incomeApi.update(sheetTarget.id, { category_id: categoryId ?? undefined })
-        setIncomes(prev => prev.map(i =>
+        monthly.setIncomes(prev => prev.map(i =>
           i.id === sheetTarget.id ? { ...i, category_id: categoryId } : i
         ))
       }
@@ -476,18 +153,17 @@ export default function TransactionList() {
       setSheetSaving(false)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- addToast, setSearchFilter는 안정적 참조
-  }, [sheetTarget, isFilterCategorySheet, setSearchFilter])
+  }, [sheetTarget, isFilterCategorySheet, search.setSearchFilter])
 
-  const monthLabel = `${currentYear}년 ${currentMonth + 1}월`
-
+  const { fetchData } = monthly
   const handleRefresh = useCallback(async () => {
     await fetchData()
   }, [fetchData])
 
-  if (error) {
+  if (monthly.error) {
     return (
       <div className="space-y-4">
-        <ErrorState onRetry={fetchData} />
+        <ErrorState onRetry={monthly.fetchData} />
       </div>
     )
   }
@@ -496,24 +172,24 @@ export default function TransactionList() {
     <PullToRefresh onRefresh={handleRefresh}>
     <div className="space-y-4">
       {/* 월 네비게이션 / 검색 바 */}
-      {isSearchMode ? (
+      {search.isSearchMode ? (
         <div className="flex items-center gap-2">
           <div className="flex-1 relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--text-muted)]" />
             <input
-              key={searchQuery}
-              ref={searchInputRef}
+              key={search.searchQuery}
+              ref={search.searchInputRef}
               type="search"
-              defaultValue={searchQuery}
+              defaultValue={search.searchQuery}
               placeholder="거래 내역 검색"
               onKeyDown={(e) => {
-                if (e.key === 'Enter') submitSearch(e.currentTarget.value)
+                if (e.key === 'Enter') search.submitSearch(e.currentTarget.value)
               }}
               className="w-full pl-9 pr-4 py-2.5 rounded-xl border border-[var(--border-default)] bg-[var(--surface-card)] text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-grape-300 focus:border-grape-300"
             />
           </div>
           <button
-            onClick={exitSearchMode}
+            onClick={search.exitSearchMode}
             className="p-2 rounded-xl hover:bg-[var(--surface-hover)] transition-colors"
             aria-label="검색 닫기"
           >
@@ -522,9 +198,9 @@ export default function TransactionList() {
         </div>
       ) : (
         <div className="relative">
-          <PeriodNavigator label={monthLabel} onPrev={() => navigateMonth(-1)} onNext={() => navigateMonth(1)} />
+          <PeriodNavigator label={monthly.monthLabel} onPrev={() => monthly.navigateMonth(-1)} onNext={() => monthly.navigateMonth(1)} />
           <button
-            onClick={enterSearchMode}
+            onClick={search.enterSearchMode}
             className="absolute right-0 top-1/2 -translate-y-1/2 p-2 rounded-xl hover:bg-[var(--surface-hover)] transition-colors"
             aria-label="검색"
           >
@@ -534,53 +210,53 @@ export default function TransactionList() {
       )}
 
       {/* 요약 + 필터 (월 뷰 전용) */}
-      {!isSearchMode && (
+      {!search.isSearchMode && (
         <div className="flex items-center justify-center gap-6">
           <button
-            onClick={() => toggleFilter('expense')}
+            onClick={() => monthly.toggleFilter('expense')}
             className={`text-center transition-opacity ${
-              filter === 'income' ? 'opacity-40' : ''
+              monthly.filter === 'income' ? 'opacity-40' : ''
             }`}
           >
             <div className="text-xs text-[var(--text-tertiary)]">지출</div>
-            <div className={`text-base font-bold ${filter !== 'income' ? 'text-grape-600' : 'text-[var(--text-muted)]'}`}>
-              {formatAmount(totalExpense)}
+            <div className={`text-base font-bold ${monthly.filter !== 'income' ? 'text-grape-600' : 'text-[var(--text-muted)]'}`}>
+              {formatAmount(monthly.totalExpense)}
             </div>
           </button>
           <div className="w-px h-8 bg-[var(--border-default)]" />
           <button
-            onClick={() => toggleFilter('income')}
+            onClick={() => monthly.toggleFilter('income')}
             className={`text-center transition-opacity ${
-              filter === 'expense' ? 'opacity-40' : ''
+              monthly.filter === 'expense' ? 'opacity-40' : ''
             }`}
           >
             <div className="text-xs text-[var(--text-tertiary)]">수입</div>
-            <div className={`text-base font-bold ${filter !== 'expense' ? 'text-leaf-600' : 'text-[var(--text-muted)]'}`}>
-              {formatAmount(totalIncome)}
+            <div className={`text-base font-bold ${monthly.filter !== 'expense' ? 'text-leaf-600' : 'text-[var(--text-muted)]'}`}>
+              {formatAmount(monthly.totalIncome)}
             </div>
           </button>
         </div>
       )}
 
       {/* 온보딩 웰컴 카드 */}
-      {!welcomeDismissed && !loading && !isSearchMode && (
+      {!welcomeDismissed && !monthly.loading && !search.isSearchMode && (
         <WelcomeCard
-          transactionCount={Math.max(totalTransactionCount, expenses.length + incomes.length)}
+          transactionCount={Math.max(totalTransactionCount, monthly.expenses.length + monthly.incomes.length)}
           isBotLinked={!!user?.is_telegram_linked || !!user?.is_kakao_linked}
           onDismiss={handleWelcomeDismiss}
         />
       )}
 
       {/* 반복 거래 알림 (월 뷰 전용) */}
-      {!isSearchMode && (
+      {!search.isSearchMode && (
         <PendingRecurring
-          items={pendingRecurring}
+          items={monthly.pendingRecurring}
           onExecute={async (id) => {
             try {
               await recurringApi.execute(id)
               addToast('success', '거래가 등록되었습니다')
-              setPendingRecurring((prev) => prev.filter((r) => r.id !== id))
-              fetchData()
+              monthly.setPendingRecurring((prev) => prev.filter((r) => r.id !== id))
+              monthly.fetchData()
             } catch {
               addToast('error', '반복 거래 등록에 실패했습니다')
             }
@@ -589,7 +265,7 @@ export default function TransactionList() {
             try {
               const res = await recurringApi.skip(id)
               addToast('success', `다음 예정일: ${res.data.next_due_date}`)
-              setPendingRecurring((prev) => prev.filter((r) => r.id !== id))
+              monthly.setPendingRecurring((prev) => prev.filter((r) => r.id !== id))
             } catch {
               addToast('error', '건너뛰기에 실패했습니다')
             }
@@ -598,12 +274,12 @@ export default function TransactionList() {
       )}
 
       {/* 미니 캘린더 (월 뷰 전용) */}
-      {!isSearchMode && (
+      {!search.isSearchMode && (
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-3">
           <MiniCalendar
-            year={currentYear}
-            month={currentMonth}
-            daySummaries={daySummaries}
+            year={monthly.currentYear}
+            month={monthly.currentMonth}
+            daySummaries={monthly.daySummaries}
             onDateClick={handleDateClick}
             today={todayString}
           />
@@ -611,21 +287,21 @@ export default function TransactionList() {
       )}
 
       {/* 검색 필터 칩 */}
-      {isSearchMode && (
+      {search.isSearchMode && (
         <div className="flex gap-2 flex-wrap relative">
           {/* 지출/수입 */}
           <div className="relative" onPointerDown={(e) => e.stopPropagation()}>
             <button
-              onClick={() => setOpenFilter(openFilter === 'type' ? null : 'type')}
+              onClick={() => search.setOpenFilter(search.openFilter === 'type' ? null : 'type')}
               className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                searchType !== 'all'
+                search.searchType !== 'all'
                   ? 'bg-grape-600 text-white'
                   : 'bg-[var(--surface-hover)] text-[var(--text-secondary)]'
               }`}
             >
-              {searchType === 'all' ? '지출/수입' : searchType === 'expense' ? '지출만' : '수입만'}
+              {search.searchType === 'all' ? '지출/수입' : search.searchType === 'expense' ? '지출만' : '수입만'}
             </button>
-            {openFilter === 'type' && (
+            {search.openFilter === 'type' && (
               <div className="absolute top-full left-0 mt-1 bg-[var(--surface-card)] rounded-xl shadow-lg border border-[var(--border-default)] py-1 z-20 min-w-[120px]">
                 {[
                   { value: 'all', label: '전체' },
@@ -634,9 +310,9 @@ export default function TransactionList() {
                 ].map(opt => (
                   <button
                     key={opt.value}
-                    onClick={() => setSearchFilter('type', opt.value === 'all' ? null : opt.value)}
+                    onClick={() => search.setSearchFilter('type', opt.value === 'all' ? null : opt.value)}
                     className={`w-full text-left px-4 py-2 text-sm hover:bg-[var(--surface-hover)] ${
-                      searchType === opt.value ? 'text-grape-600 font-medium' : 'text-[var(--text-primary)]'
+                      search.searchType === opt.value ? 'text-grape-600 font-medium' : 'text-[var(--text-primary)]'
                     }`}
                   >
                     {opt.label}
@@ -649,40 +325,38 @@ export default function TransactionList() {
           {/* 카테고리 */}
           <button
             onClick={() => {
-              if (searchCategoryId) {
-                // 이미 선택된 상태 → 필터 해제
-                setSearchFilter('category', null)
+              if (search.searchCategoryId) {
+                search.setSearchFilter('category', null)
               } else {
-                // 검색 필터용 바텀시트 열기
                 setIsFilterCategorySheet(true)
                 setSheetTarget(null)
                 setSheetOpen(true)
               }
             }}
             className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-              searchCategoryId
+              search.searchCategoryId
                 ? 'bg-grape-600 text-white'
                 : 'bg-[var(--surface-hover)] text-[var(--text-secondary)]'
             }`}
           >
-            {searchCategoryId
-              ? `${categoryMap.get(searchCategoryId)?.name ?? '카테고리'} ✕`
+            {search.searchCategoryId
+              ? `${monthly.categoryMap.get(search.searchCategoryId)?.name ?? '카테고리'} ✕`
               : '카테고리'}
           </button>
 
           {/* 기간 */}
           <div className="relative" onPointerDown={(e) => e.stopPropagation()}>
             <button
-              onClick={() => setOpenFilter(openFilter === 'period' ? null : 'period')}
+              onClick={() => search.setOpenFilter(search.openFilter === 'period' ? null : 'period')}
               className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                searchPeriod !== 'all'
+                search.searchPeriod !== 'all'
                   ? 'bg-grape-600 text-white'
                   : 'bg-[var(--surface-hover)] text-[var(--text-secondary)]'
               }`}
             >
-              {{ all: '기간: 전체', '1m': '최근 1개월', '3m': '최근 3개월', '6m': '최근 6개월', year: '올해' }[searchPeriod]}
+              {{ all: '기간: 전체', '1m': '최근 1개월', '3m': '최근 3개월', '6m': '최근 6개월', year: '올해' }[search.searchPeriod]}
             </button>
-            {openFilter === 'period' && (
+            {search.openFilter === 'period' && (
               <div className="absolute top-full left-0 mt-1 bg-[var(--surface-card)] rounded-xl shadow-lg border border-[var(--border-default)] py-1 z-20 min-w-[130px]">
                 {[
                   { value: 'all', label: '전체' },
@@ -693,9 +367,9 @@ export default function TransactionList() {
                 ].map(opt => (
                   <button
                     key={opt.value}
-                    onClick={() => setSearchFilter('period', opt.value === 'all' ? null : opt.value)}
+                    onClick={() => search.setSearchFilter('period', opt.value === 'all' ? null : opt.value)}
                     className={`w-full text-left px-4 py-2 text-sm hover:bg-[var(--surface-hover)] ${
-                      searchPeriod === opt.value ? 'text-grape-600 font-medium' : 'text-[var(--text-primary)]'
+                      search.searchPeriod === opt.value ? 'text-grape-600 font-medium' : 'text-[var(--text-primary)]'
                     }`}
                   >
                     {opt.label}
@@ -710,17 +384,17 @@ export default function TransactionList() {
       )}
 
       {/* 검색 모드 — 빈 검색어: 최근 검색 + 카테고리 바로가기 */}
-      {isSearchMode && !searchQuery && !hasSearchFilters && (
+      {search.isSearchMode && !search.searchQuery && !search.hasSearchFilters && (
         <div className="space-y-4">
           {/* 최근 검색 */}
-          {recentSearches.length > 0 && (
+          {search.recentSearches.length > 0 && (
             <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4">
               <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-3">최근 검색</h3>
               <div className="space-y-1">
-                {recentSearches.map(query => (
+                {search.recentSearches.map(query => (
                   <div key={query} className="flex items-center justify-between group">
                     <button
-                      onClick={() => submitSearch(query)}
+                      onClick={() => search.submitSearch(query)}
                       className="flex-1 text-left py-1.5 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
                     >
                       {query}
@@ -728,7 +402,7 @@ export default function TransactionList() {
                     <button
                       onClick={() => {
                         removeRecentSearch(query)
-                        setRecentSearches(getRecentSearches())
+                        search.setRecentSearches(getRecentSearches())
                       }}
                       className="p-1 opacity-0 group-hover:opacity-100 text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-opacity"
                       aria-label={`${query} 삭제`}
@@ -742,14 +416,14 @@ export default function TransactionList() {
           )}
 
           {/* 카테고리 바로가기 */}
-          {categories.length > 0 && (
+          {monthly.categories.length > 0 && (
             <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4">
               <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-3">카테고리로 보기</h3>
               <div className="flex flex-wrap gap-2">
-                {categories.slice(0, 8).map(cat => (
+                {monthly.categories.slice(0, 8).map(cat => (
                   <button
                     key={cat.id}
-                    onClick={() => setSearchFilter('category', String(cat.id))}
+                    onClick={() => search.setSearchFilter('category', String(cat.id))}
                     className="px-3 py-1.5 rounded-lg text-xs font-medium bg-[var(--surface-hover)] text-[var(--text-secondary)] hover:bg-grape-50 hover:text-grape-600 transition-colors"
                   >
                     {cat.name}
@@ -760,7 +434,7 @@ export default function TransactionList() {
           )}
 
           {/* 최근 검색도 카테고리도 없을 때 기본 안내 */}
-          {recentSearches.length === 0 && categories.length === 0 && (
+          {search.recentSearches.length === 0 && monthly.categories.length === 0 && (
             <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-12 text-center">
               <Search className="w-8 h-8 mx-auto mb-2 text-[var(--text-muted)] opacity-50" />
               <p className="text-sm text-[var(--text-tertiary)]">검색어를 입력하세요</p>
@@ -770,23 +444,23 @@ export default function TransactionList() {
       )}
 
       {/* 검색 결과 합계 바 */}
-      {isSearchMode && (searchQuery || hasSearchFilters) && searchSummary && !searchLoading && (
+      {search.isSearchMode && (search.searchQuery || search.hasSearchFilters) && search.searchSummary && !search.searchLoading && (
         <div className="px-1 text-sm text-[var(--text-secondary)]">
-          {searchQuery ? (
-            <span className="font-medium text-[var(--text-primary)]">&ldquo;{searchQuery}&rdquo;</span>
+          {search.searchQuery ? (
+            <span className="font-medium text-[var(--text-primary)]">&ldquo;{search.searchQuery}&rdquo;</span>
           ) : (
             <span className="font-medium text-[var(--text-primary)]">필터 검색</span>
           )}
           {' \u00b7 '}
-          {searchSummary.total_count}건
+          {search.searchSummary.total_count}건
           {' \u00b7 총 '}
-          {formatAmount(searchSummary.total_amount)}
+          {formatAmount(search.searchSummary.total_amount)}
         </div>
       )}
 
       {/* 검색 결과 리스트 */}
-      {isSearchMode && (searchQuery || hasSearchFilters) && (
-        searchLoading ? (
+      {search.isSearchMode && (search.searchQuery || search.hasSearchFilters) && (
+        search.searchLoading ? (
           <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] overflow-hidden">
             {[1, 2, 3].map(i => (
               <div key={i}>
@@ -805,7 +479,7 @@ export default function TransactionList() {
               </div>
             ))}
           </div>
-        ) : searchGrouped.size === 0 ? (
+        ) : search.searchGrouped.size === 0 ? (
           <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-12 text-center">
             <Search className="w-8 h-8 mx-auto mb-2 text-[var(--text-muted)] opacity-50" />
             <p className="text-sm text-[var(--text-primary)] font-medium mb-1">검색 결과가 없습니다</p>
@@ -814,7 +488,7 @@ export default function TransactionList() {
         ) : (
           <>
             <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] overflow-hidden">
-              {Array.from(searchGrouped.entries()).map(([dateKey, txs]) => (
+              {Array.from(search.searchGrouped.entries()).map(([dateKey, txs]) => (
                 <div key={dateKey}>
                   <div className="bg-[var(--surface-elevated)] px-4 py-2 border-b border-[var(--border-subtle)]">
                     <span className="text-xs font-semibold text-[var(--text-secondary)]">
@@ -830,7 +504,7 @@ export default function TransactionList() {
                         description={tx.description}
                         amount={tx.amount}
                         categoryId={tx.category_id}
-                        categoryMap={categoryMap}
+                        categoryMap={monthly.categoryMap}
                         excludeFromStats={tx.exclude_from_stats}
                         rawInput={tx.raw_input}
                         onCategoryClick={categoryClickHandlers.get(`${tx.type}-${tx.id}`) ?? (() => {})}
@@ -842,9 +516,9 @@ export default function TransactionList() {
             </div>
 
             {/* 무한 스크롤 sentinel */}
-            {searchHasMore && (
-              <div ref={loadMoreRef} data-testid="search-load-more" className="py-4 text-center">
-                {searchLoadingMore ? (
+            {search.searchHasMore && (
+              <div ref={search.loadMoreRef} data-testid="search-load-more" className="py-4 text-center">
+                {search.searchLoadingMore ? (
                   <div className="animate-spin rounded-full border-b-2 border-grape-600 w-5 h-5 mx-auto" />
                 ) : (
                   <span className="text-xs text-[var(--text-muted)]">스크롤하여 더 보기</span>
@@ -853,7 +527,7 @@ export default function TransactionList() {
             )}
 
             {/* 모든 결과 로드 완료 */}
-            {!searchHasMore && searchResults.length > 0 && (
+            {!search.searchHasMore && search.searchResults.length > 0 && (
               <p className="text-center text-xs text-[var(--text-muted)] py-2">
                 모든 검색 결과를 불러왔습니다
               </p>
@@ -863,9 +537,9 @@ export default function TransactionList() {
       )}
 
       {/* 월 뷰 거래 리스트 (검색 모드가 아닐 때만) */}
-      {!isSearchMode && (
+      {!search.isSearchMode && (
         <>
-          {loading ? (
+          {monthly.loading ? (
             <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] overflow-hidden">
               {/* 스켈레톤 UI */}
               {[1, 2, 3].map(i => (
@@ -885,16 +559,16 @@ export default function TransactionList() {
                 </div>
               ))}
             </div>
-          ) : grouped.size === 0 ? (
+          ) : monthly.grouped.size === 0 ? (
             <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]">
               <EmptyState
-                title={filter === 'all' ? '거래 내역이 없습니다' : `${filter === 'expense' ? '지출' : '수입'} 내역이 없습니다`}
+                title={monthly.filter === 'all' ? '거래 내역이 없습니다' : `${monthly.filter === 'expense' ? '지출' : '수입'} 내역이 없습니다`}
                 description="이번 달의 거래를 추가해보세요."
               />
             </div>
           ) : (
             <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] overflow-hidden">
-              {Array.from(grouped.entries()).map(([dateKey, txs]) => (
+              {Array.from(monthly.grouped.entries()).map(([dateKey, txs]) => (
                 <div key={dateKey}>
                   {/* 스티키 날짜 헤더 */}
                   <div
@@ -915,7 +589,7 @@ export default function TransactionList() {
                         description={tx.description}
                         amount={tx.amount}
                         categoryId={tx.category_id}
-                        categoryMap={categoryMap}
+                        categoryMap={monthly.categoryMap}
                         excludeFromStats={tx.exclude_from_stats}
                         rawInput={tx.raw_input}
                         onCategoryClick={categoryClickHandlers.get(`${tx.type}-${tx.id}`)!}
@@ -934,10 +608,10 @@ export default function TransactionList() {
         isOpen={sheetOpen}
         onClose={() => { setSheetOpen(false); setIsFilterCategorySheet(false) }}
         onSelect={handleCategorySelect}
-        categories={categories}
-        currentCategoryId={isFilterCategorySheet ? searchCategoryId : (sheetTarget?.category_id ?? null)}
+        categories={monthly.categories}
+        currentCategoryId={isFilterCategorySheet ? search.searchCategoryId : (sheetTarget?.category_id ?? null)}
         transactionType={isFilterCategorySheet
-          ? (searchType === 'income' ? 'income' : 'expense')
+          ? (search.searchType === 'income' ? 'income' : 'expense')
           : (sheetTarget?.type ?? 'expense')}
         saving={sheetSaving}
         title={isFilterCategorySheet ? '카테고리 선택' : undefined}


### PR DESCRIPTION
## Summary

TransactionList(991줄)에서 2개 훅 추출. 로직 코드 제거되고 JSX만 남음.

- `useTransactionSearch` (307줄): 검색+필터+무한스크롤
- `useMonthlyTransactions` (193줄): 월별 데이터+그룹핑
- TransactionList: **991→622줄 (-369줄)**
- 훅 테스트 35개 추가

## Test plan

- [x] 761 tests passed (기존 726 + 신규 35)
- [x] lint 0 에러, build 성공
- [ ] CI 통과

Closes #381
Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)