### PR TITLE
refactor: HouseholdDetail 탭 + RecurringList 모달 분리 (#386, #387)

### DIFF
--- a/frontend/src/components/household/InvitationsTab.tsx
+++ b/frontend/src/components/household/InvitationsTab.tsx
@@ -1,0 +1,107 @@
+/**
+ * @file InvitationsTab.tsx
+ * @description 가구 초대 관리 탭 컴포넌트
+ * 초대 목록 표시, 초대 링크 복사, 초대 취소 기능을 제공한다.
+ */
+
+import { Link2 } from 'lucide-react'
+import type { HouseholdInvitation } from '../../types'
+
+interface InvitationsTabProps {
+  /** 초대 목록 */
+  invitations: HouseholdInvitation[]
+  /** 초대 모달 열기 핸들러 */
+  onOpenInviteModal: () => void
+  /** 초대 취소 핸들러 */
+  onCancelInvitation: (invitationId: number) => Promise<void>
+  /** 초대 링크 복사 핸들러 */
+  onCopyInviteLink: (token: string) => Promise<void>
+}
+
+/** 상태 텍스트 매핑 */
+const STATUS_TEXT: Record<string, string> = {
+  pending: '대기 중',
+  accepted: '수락됨',
+  rejected: '거절됨',
+  expired: '만료됨',
+}
+
+/** 상태별 배지 색상 */
+const STATUS_COLOR: Record<string, string> = {
+  pending: 'bg-yellow-100 text-yellow-600',
+  accepted: 'bg-green-100 text-green-600',
+  rejected: 'bg-warm-100 text-warm-600',
+  expired: 'bg-warm-100 text-[var(--text-muted)]',
+}
+
+export default function InvitationsTab({
+  invitations,
+  onOpenInviteModal,
+  onCancelInvitation,
+  onCopyInviteLink,
+}: InvitationsTabProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <button
+          onClick={onOpenInviteModal}
+          className="px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
+        >
+          + 멤버 초대
+        </button>
+      </div>
+
+      {invitations.length === 0 ? (
+        <div className="text-center py-8 text-sm text-[var(--text-muted)]">
+          보낸 초대가 없습니다
+        </div>
+      ) : (
+        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] overflow-hidden">
+          <div className="divide-y divide-[var(--border-default)]">
+            {invitations.map((inv) => {
+              const isPending = inv.status === 'pending'
+
+              return (
+                <div key={inv.id} className="flex items-center justify-between p-4">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-[var(--text-primary)] truncate">
+                      {inv.invitee_email}
+                    </p>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span className={`text-xs px-2 py-0.5 rounded-full ${STATUS_COLOR[inv.status] || ''}`}>
+                        {STATUS_TEXT[inv.status] || inv.status}
+                      </span>
+                      <span className="text-xs text-[var(--text-muted)]">
+                        {inv.role === 'admin' ? '관리자' : '멤버'}
+                      </span>
+                    </div>
+                  </div>
+                  {isPending && (
+                    <div className="flex items-center gap-2 ml-3">
+                      {inv.token && (
+                        <button
+                          onClick={() => onCopyInviteLink(inv.token!)}
+                          className="text-xs text-grape-600 hover:text-grape-700 font-medium flex items-center gap-1"
+                          title="초대 링크 복사"
+                        >
+                          <Link2 className="w-3.5 h-3.5" />
+                          링크 복사
+                        </button>
+                      )}
+                      <button
+                        onClick={() => onCancelInvitation(inv.id)}
+                        className="text-xs text-rose-600 hover:text-rose-700 font-medium"
+                      >
+                        취소
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/household/MembersTab.tsx
+++ b/frontend/src/components/household/MembersTab.tsx
@@ -1,0 +1,131 @@
+/**
+ * @file MembersTab.tsx
+ * @description 가구 멤버 목록 탭 컴포넌트
+ * 멤버 테이블, 역할 변경, 추방/탈퇴 기능을 제공한다.
+ */
+
+import type { HouseholdDetail, HouseholdMember, MemberRole } from '../../types'
+import { formatDate, formatRole, getRoleBadgeColor } from '../../utils/household'
+
+interface MembersTabProps {
+  /** 가구 상세 정보 */
+  household: HouseholdDetail
+  /** 현재 로그인 유저 ID */
+  currentUserId: number
+  /** 멤버 관리 가능 여부 판단 함수 */
+  canManageMember: (member: HouseholdMember, currentUserId: number) => boolean
+  /** 역할 변경 핸들러 */
+  onRoleChange: (userId: number, newRole: MemberRole) => void
+  /** 멤버 추방 핸들러 */
+  onRemoveMember: (userId: number, username: string) => void
+  /** 가구 탈퇴 핸들러 */
+  onLeave: () => void
+}
+
+export default function MembersTab({
+  household,
+  currentUserId,
+  canManageMember,
+  onRoleChange,
+  onRemoveMember,
+  onLeave,
+}: MembersTabProps) {
+  return (
+    <div className="space-y-4">
+      <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead className="bg-[var(--surface-elevated)] border-b border-[var(--border-default)]">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
+                  이름
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
+                  이메일
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
+                  역할
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
+                  가입일
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
+                  관리
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--border-default)]">
+              {household.members.map((member) => {
+                const isMe = member.user_id === currentUserId
+                const canManage = canManageMember(member, currentUserId)
+
+                return (
+                  <tr key={member.user_id} className="hover:bg-[var(--surface-hover)]">
+                    <td className="px-4 py-3 text-sm font-medium text-[var(--text-primary)]">
+                      {member.username}
+                      {isMe && (
+                        <span className="ml-2 text-xs text-[var(--text-tertiary)]">(나)</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-[var(--text-secondary)]">
+                      {member.email || '-'}
+                    </td>
+                    <td className="px-4 py-3">
+                      {canManage ? (
+                        <select
+                          value={member.role}
+                          onChange={(e) =>
+                            onRoleChange(
+                              member.user_id,
+                              e.target.value as MemberRole
+                            )
+                          }
+                          className="text-sm px-2 py-1 border border-[var(--input-border)] rounded bg-[var(--surface-card)] focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                        >
+                          <option value="member">멤버</option>
+                          <option value="admin">관리자</option>
+                        </select>
+                      ) : (
+                        <span
+                          className={`inline-block text-xs px-2 py-1 rounded-full ${getRoleBadgeColor(
+                            member.role
+                          )}`}
+                        >
+                          {formatRole(member.role)}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-[var(--text-secondary)]">
+                      {formatDate(member.joined_at)}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-right">
+                      {canManage ? (
+                        <button
+                          onClick={() =>
+                            onRemoveMember(member.user_id, member.username)
+                          }
+                          className="text-rose-600 hover:text-rose-700 font-medium"
+                        >
+                          추방
+                        </button>
+                      ) : isMe && (member.role !== 'owner' || household.members.length > 1) ? (
+                        <button
+                          onClick={onLeave}
+                          className="text-rose-600 hover:text-rose-700 font-medium"
+                        >
+                          탈퇴
+                        </button>
+                      ) : (
+                        <span className="text-[var(--text-muted)]">-</span>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/household/SettingsTab.tsx
+++ b/frontend/src/components/household/SettingsTab.tsx
@@ -1,0 +1,151 @@
+/**
+ * @file SettingsTab.tsx
+ * @description 가구 설정 탭 컴포넌트
+ * 가구 이름/설명 수정, 가구 삭제(owner만) 기능을 제공한다.
+ */
+
+import { useState, useMemo } from 'react'
+import type { HouseholdDetail, UpdateHouseholdDto } from '../../types'
+
+interface SettingsTabProps {
+  /** 가구 상세 정보 */
+  household: HouseholdDetail
+  /** 소유자 여부 */
+  isOwner: boolean
+  /** 가구 정보 수정 핸들러 */
+  onUpdate: (data: UpdateHouseholdDto) => Promise<void>
+  /** 가구 삭제 핸들러 */
+  onDelete: () => void
+}
+
+export default function SettingsTab({
+  household,
+  isOwner,
+  onUpdate,
+  onDelete,
+}: SettingsTabProps) {
+  const [editMode, setEditMode] = useState(false)
+
+  /** 가구 정보가 변경되면 폼 데이터를 동기화 (editMode가 아닐 때만) */
+  const initialFormData = useMemo<UpdateHouseholdDto>(() => ({
+    name: household.name,
+    description: household.description || '',
+  }), [household.name, household.description])
+
+  const [formData, setFormData] = useState<UpdateHouseholdDto>(initialFormData)
+
+  // editMode가 아닌 경우 household 변경에 따라 동기화
+  if (!editMode && (formData.name !== initialFormData.name || formData.description !== initialFormData.description)) {
+    setFormData(initialFormData)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await onUpdate(formData)
+    setEditMode(false)
+  }
+
+  const handleCancel = () => {
+    setEditMode(false)
+    setFormData({
+      name: household.name,
+      description: household.description || '',
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 가구 정보 수정 */}
+      <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-6">
+        <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-4">
+          가구 정보
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="name"
+              className="block text-sm font-medium text-[var(--text-secondary)] mb-1"
+            >
+              가구 이름
+            </label>
+            <input
+              id="name"
+              type="text"
+              value={formData.name}
+              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+              disabled={!editMode}
+              required
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="description"
+              className="block text-sm font-medium text-[var(--text-secondary)] mb-1"
+            >
+              설명
+            </label>
+            <textarea
+              id="description"
+              value={formData.description}
+              onChange={(e) =>
+                setFormData({ ...formData, description: e.target.value })
+              }
+              className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500 resize-none"
+              rows={3}
+              disabled={!editMode}
+            />
+          </div>
+
+          <div className="flex gap-3">
+            {editMode ? (
+              <>
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="px-4 py-2 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-card)] border border-[var(--input-border)] rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
+                >
+                  취소
+                </button>
+                <button
+                  type="submit"
+                  className="px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
+                >
+                  저장
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setEditMode(true)}
+                className="px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
+              >
+                수정
+              </button>
+            )}
+          </div>
+        </form>
+      </div>
+
+      {/* 가구 삭제 (owner만) */}
+      {isOwner && (
+        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-rose-200 p-6">
+          <h2 className="text-lg font-semibold text-rose-600 mb-2">
+            위험 영역
+          </h2>
+          <p className="text-sm text-[var(--text-secondary)] mb-4">
+            가구를 삭제하면 모든 데이터가 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.
+          </p>
+          <button
+            onClick={onDelete}
+            className="px-4 py-2 text-sm font-medium text-white bg-rose-600 rounded-lg hover:bg-rose-700 transition-colors"
+          >
+            가구 삭제
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/household/__tests__/InvitationsTab.test.tsx
+++ b/frontend/src/components/household/__tests__/InvitationsTab.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @file InvitationsTab.test.tsx
+ * @description 초대 탭 컴포넌트 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import InvitationsTab from '../InvitationsTab'
+import type { HouseholdInvitation } from '../../../types'
+
+const mockInvitations: HouseholdInvitation[] = [
+  {
+    id: 1,
+    household_id: 1,
+    invitee_email: 'test@example.com',
+    role: 'member',
+    status: 'pending',
+    token: 'abc123',
+    expires_at: '2026-12-31T00:00:00Z',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    household_id: 1,
+    invitee_email: 'accepted@example.com',
+    role: 'admin',
+    status: 'accepted',
+    expires_at: '2026-12-31T00:00:00Z',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+const defaultProps = {
+  invitations: mockInvitations,
+  onOpenInviteModal: vi.fn(),
+  onCancelInvitation: vi.fn().mockResolvedValue(undefined),
+  onCopyInviteLink: vi.fn().mockResolvedValue(undefined),
+}
+
+describe('InvitationsTab', () => {
+  it('초대 목록을 표시한다', () => {
+    render(<InvitationsTab {...defaultProps} />)
+    expect(screen.getByText('test@example.com')).toBeInTheDocument()
+    expect(screen.getByText('accepted@example.com')).toBeInTheDocument()
+  })
+
+  it('초대 상태를 한국어로 표시한다', () => {
+    render(<InvitationsTab {...defaultProps} />)
+    expect(screen.getByText('대기 중')).toBeInTheDocument()
+    expect(screen.getByText('수락됨')).toBeInTheDocument()
+  })
+
+  it('대기 중 초대에 취소 버튼을 표시한다', () => {
+    render(<InvitationsTab {...defaultProps} />)
+    expect(screen.getByText('취소')).toBeInTheDocument()
+  })
+
+  it('대기 중 초대에 링크 복사 버튼을 표시한다', () => {
+    render(<InvitationsTab {...defaultProps} />)
+    expect(screen.getByText('링크 복사')).toBeInTheDocument()
+  })
+
+  it('+ 멤버 초대 버튼을 표시한다', () => {
+    render(<InvitationsTab {...defaultProps} />)
+    expect(screen.getByText('+ 멤버 초대')).toBeInTheDocument()
+  })
+
+  it('멤버 초대 버튼 클릭 시 onOpenInviteModal을 호출한다', async () => {
+    const user = userEvent.setup()
+    render(<InvitationsTab {...defaultProps} />)
+    await user.click(screen.getByText('+ 멤버 초대'))
+    expect(defaultProps.onOpenInviteModal).toHaveBeenCalled()
+  })
+
+  it('링크 복사 버튼 클릭 시 onCopyInviteLink를 호출한다', async () => {
+    const user = userEvent.setup()
+    render(<InvitationsTab {...defaultProps} />)
+    await user.click(screen.getByText('링크 복사'))
+    expect(defaultProps.onCopyInviteLink).toHaveBeenCalledWith('abc123')
+  })
+
+  it('취소 버튼 클릭 시 onCancelInvitation을 호출한다', async () => {
+    const user = userEvent.setup()
+    render(<InvitationsTab {...defaultProps} />)
+    await user.click(screen.getByText('취소'))
+    expect(defaultProps.onCancelInvitation).toHaveBeenCalledWith(1)
+  })
+
+  it('초대가 없으면 빈 상태 메시지를 표시한다', () => {
+    render(<InvitationsTab {...defaultProps} invitations={[]} />)
+    expect(screen.getByText('보낸 초대가 없습니다')).toBeInTheDocument()
+  })
+
+  it('역할을 한국어로 표시한다', () => {
+    render(<InvitationsTab {...defaultProps} />)
+    expect(screen.getByText('관리자')).toBeInTheDocument()
+    // mockInvitations[0]의 role='member'
+    expect(screen.getAllByText('멤버').length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/components/household/__tests__/MembersTab.test.tsx
+++ b/frontend/src/components/household/__tests__/MembersTab.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @file MembersTab.test.tsx
+ * @description 멤버 탭 컴포넌트 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MembersTab from '../MembersTab'
+import type { HouseholdDetail } from '../../../types'
+
+const mockHousehold: HouseholdDetail = {
+  id: 1,
+  name: '우리집',
+  description: '가족 가계부',
+  currency: 'KRW',
+  my_role: 'owner',
+  member_count: 2,
+  created_at: '2026-01-01T00:00:00Z',
+  members: [
+    {
+      user_id: 1,
+      username: '홍길동',
+      email: 'hong@example.com',
+      role: 'owner',
+      joined_at: '2026-01-01T00:00:00Z',
+    },
+    {
+      user_id: 2,
+      username: '김철수',
+      email: 'kim@example.com',
+      role: 'member',
+      joined_at: '2026-02-01T00:00:00Z',
+    },
+  ],
+}
+
+const defaultProps = {
+  household: mockHousehold,
+  currentUserId: 1,
+  canManageMember: (member: { user_id: number; role: string }, currentUserId: number) =>
+    member.user_id !== currentUserId && member.role !== 'owner',
+  onRoleChange: vi.fn(),
+  onRemoveMember: vi.fn(),
+  onLeave: vi.fn(),
+}
+
+describe('MembersTab', () => {
+  it('멤버 이름을 표시한다', () => {
+    render(<MembersTab {...defaultProps} />)
+    expect(screen.getByText('홍길동')).toBeInTheDocument()
+    expect(screen.getByText('김철수')).toBeInTheDocument()
+  })
+
+  it('멤버 이메일을 표시한다', () => {
+    render(<MembersTab {...defaultProps} />)
+    expect(screen.getByText('hong@example.com')).toBeInTheDocument()
+    expect(screen.getByText('kim@example.com')).toBeInTheDocument()
+  })
+
+  it('자기 자신에게 (나) 표시를 한다', () => {
+    render(<MembersTab {...defaultProps} />)
+    expect(screen.getByText('(나)')).toBeInTheDocument()
+  })
+
+  it('관리 가능한 멤버에 추방 버튼을 표시한다', () => {
+    render(<MembersTab {...defaultProps} />)
+    expect(screen.getByText('추방')).toBeInTheDocument()
+  })
+
+  it('추방 버튼 클릭 시 onRemoveMember를 호출한다', async () => {
+    const user = userEvent.setup()
+    render(<MembersTab {...defaultProps} />)
+    await user.click(screen.getByText('추방'))
+    expect(defaultProps.onRemoveMember).toHaveBeenCalledWith(2, '김철수')
+  })
+
+  it('관리 가능한 멤버에 역할 드롭다운을 표시한다', () => {
+    render(<MembersTab {...defaultProps} />)
+    // 김철수(member)에 대한 select가 있어야 함
+    const selects = screen.getAllByRole('combobox')
+    expect(selects.length).toBe(1)
+    expect(selects[0]).toHaveValue('member')
+  })
+
+  it('관리 권한이 없으면 추방 버튼 대신 탈퇴 버튼이 표시된다', () => {
+    const cannotManage = () => false
+    render(
+      <MembersTab
+        {...defaultProps}
+        canManageMember={cannotManage}
+        currentUserId={2}
+      />
+    )
+    // 김철수(userId=2)의 탈퇴 버튼
+    expect(screen.getByText('탈퇴')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/household/__tests__/SettingsTab.test.tsx
+++ b/frontend/src/components/household/__tests__/SettingsTab.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @file SettingsTab.test.tsx
+ * @description 설정 탭 컴포넌트 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SettingsTab from '../SettingsTab'
+import type { HouseholdDetail } from '../../../types'
+
+const mockHousehold: HouseholdDetail = {
+  id: 1,
+  name: '우리집',
+  description: '가족 가계부',
+  currency: 'KRW',
+  my_role: 'owner',
+  member_count: 2,
+  created_at: '2026-01-01T00:00:00Z',
+  members: [],
+}
+
+const defaultProps = {
+  household: mockHousehold,
+  isOwner: true,
+  onUpdate: vi.fn().mockResolvedValue(undefined),
+  onDelete: vi.fn(),
+}
+
+describe('SettingsTab', () => {
+  it('가구 이름을 표시한다', () => {
+    render(<SettingsTab {...defaultProps} />)
+    expect(screen.getByDisplayValue('우리집')).toBeInTheDocument()
+  })
+
+  it('가구 설명을 표시한다', () => {
+    render(<SettingsTab {...defaultProps} />)
+    expect(screen.getByDisplayValue('가족 가계부')).toBeInTheDocument()
+  })
+
+  it('수정 버튼을 표시한다', () => {
+    render(<SettingsTab {...defaultProps} />)
+    expect(screen.getByText('수정')).toBeInTheDocument()
+  })
+
+  it('수정 버튼 클릭 시 편집 모드로 전환한다', async () => {
+    const user = userEvent.setup()
+    render(<SettingsTab {...defaultProps} />)
+    await user.click(screen.getByText('수정'))
+    // 편집 모드에서는 저장/취소 버튼이 표시됨
+    expect(screen.getByText('저장')).toBeInTheDocument()
+    expect(screen.getByText('취소')).toBeInTheDocument()
+  })
+
+  it('취소 시 편집 모드를 종료하고 원래 값으로 복원한다', async () => {
+    const user = userEvent.setup()
+    render(<SettingsTab {...defaultProps} />)
+    await user.click(screen.getByText('수정'))
+    const input = screen.getByDisplayValue('우리집')
+    await user.clear(input)
+    await user.type(input, '새 이름')
+    await user.click(screen.getByText('취소'))
+    expect(screen.getByDisplayValue('우리집')).toBeInTheDocument()
+  })
+
+  it('owner에게 가구 삭제 영역을 표시한다', () => {
+    render(<SettingsTab {...defaultProps} />)
+    expect(screen.getByText('위험 영역')).toBeInTheDocument()
+    expect(screen.getByText('가구 삭제')).toBeInTheDocument()
+  })
+
+  it('owner가 아니면 삭제 영역을 숨긴다', () => {
+    render(<SettingsTab {...defaultProps} isOwner={false} />)
+    expect(screen.queryByText('위험 영역')).not.toBeInTheDocument()
+  })
+
+  it('삭제 버튼 클릭 시 onDelete를 호출한다', async () => {
+    const user = userEvent.setup()
+    render(<SettingsTab {...defaultProps} />)
+    await user.click(screen.getByText('가구 삭제'))
+    expect(defaultProps.onDelete).toHaveBeenCalled()
+  })
+
+  it('입력 필드가 편집 모드가 아니면 비활성화되어 있다', () => {
+    render(<SettingsTab {...defaultProps} />)
+    const nameInput = screen.getByDisplayValue('우리집')
+    expect(nameInput).toBeDisabled()
+  })
+})

--- a/frontend/src/components/recurring/FrequencyFields.tsx
+++ b/frontend/src/components/recurring/FrequencyFields.tsx
@@ -1,0 +1,133 @@
+/**
+ * @file FrequencyFields.tsx
+ * @description 반복 거래 빈도별 조건부 필드 컴포넌트
+ * frequency 값에 따라 반복일, 요일, 반복 월, 반복 주기 필드를 표시한다.
+ */
+
+type Frequency = 'monthly' | 'weekly' | 'yearly' | 'custom'
+
+interface FrequencyFieldsProps {
+  /** 선택된 빈도 */
+  frequency: Frequency
+  /** 반복일 (monthly, yearly) */
+  dayOfMonth: string
+  /** 요일 (weekly) — 0=월, 6=일 */
+  dayOfWeek: string
+  /** 반복 월 (yearly) — 1~12 */
+  monthOfYear: string
+  /** 반복 주기 일수 (custom) */
+  interval: string
+  /** 시작일 */
+  startDate: string
+  /** 필드 변경 핸들러 */
+  onChange: (field: string, value: string) => void
+}
+
+const INPUT_CLASSES = 'w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500'
+
+export default function FrequencyFields({
+  frequency,
+  dayOfMonth,
+  dayOfWeek,
+  monthOfYear,
+  interval,
+  startDate,
+  onChange,
+}: FrequencyFieldsProps) {
+  return (
+    <>
+      {/* 빈도 선택 */}
+      <div>
+        <label htmlFor="reclist-frequency" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 빈도</label>
+        <select
+          id="reclist-frequency"
+          value={frequency}
+          onChange={(e) => onChange('frequency', e.target.value)}
+          className={INPUT_CLASSES}
+        >
+          <option value="monthly">매월</option>
+          <option value="weekly">매주</option>
+          <option value="yearly">매년</option>
+          <option value="custom">사용자 지정</option>
+        </select>
+      </div>
+
+      {/* 반복일 (monthly, yearly) */}
+      {(frequency === 'monthly' || frequency === 'yearly') && (
+        <div>
+          <label htmlFor="reclist-day-of-month" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복일</label>
+          <input
+            id="reclist-day-of-month"
+            type="number"
+            value={dayOfMonth}
+            onChange={(e) => onChange('day_of_month', e.target.value)}
+            min="1"
+            max="31"
+            className={INPUT_CLASSES}
+          />
+        </div>
+      )}
+
+      {/* 요일 (weekly) */}
+      {frequency === 'weekly' && (
+        <div>
+          <label htmlFor="reclist-day-of-week" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">요일</label>
+          <select
+            id="reclist-day-of-week"
+            value={dayOfWeek}
+            onChange={(e) => onChange('day_of_week', e.target.value)}
+            className={INPUT_CLASSES}
+          >
+            {['월', '화', '수', '목', '금', '토', '일'].map((d, i) => (
+              <option key={i} value={i}>{d}요일</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* 반복 월 (yearly) */}
+      {frequency === 'yearly' && (
+        <div>
+          <label htmlFor="reclist-month-of-year" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 월</label>
+          <select
+            id="reclist-month-of-year"
+            value={monthOfYear}
+            onChange={(e) => onChange('month_of_year', e.target.value)}
+            className={INPUT_CLASSES}
+          >
+            {Array.from({ length: 12 }, (_, i) => (
+              <option key={i + 1} value={i + 1}>{i + 1}월</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* 반복 주기 (custom) */}
+      {frequency === 'custom' && (
+        <div>
+          <label htmlFor="reclist-interval" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 주기 (일)</label>
+          <input
+            id="reclist-interval"
+            type="number"
+            value={interval}
+            onChange={(e) => onChange('interval', e.target.value)}
+            min="1"
+            className={INPUT_CLASSES}
+          />
+        </div>
+      )}
+
+      {/* 시작일 */}
+      <div>
+        <label htmlFor="reclist-start-date" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">시작일</label>
+        <input
+          id="reclist-start-date"
+          type="date"
+          value={startDate}
+          onChange={(e) => onChange('start_date', e.target.value)}
+          className={INPUT_CLASSES}
+        />
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/recurring/RecurringModal.tsx
+++ b/frontend/src/components/recurring/RecurringModal.tsx
@@ -1,0 +1,184 @@
+/**
+ * @file RecurringModal.tsx
+ * @description 반복 거래 추가/수정 모달 컴포넌트
+ * 추가 시: 유형, 설명, 금액, 카테고리, 빈도, 시작일, 종료일
+ * 수정 시: 설명, 금액, 카테고리, 종료일만 수정 가능
+ */
+
+import { X } from 'lucide-react'
+import type { Category } from '../../types'
+import FrequencyFields from './FrequencyFields'
+
+/** 모달 폼 데이터 타입 */
+export interface RecurringFormData {
+  type: 'expense' | 'income'
+  amount: string
+  description: string
+  category_id: string
+  frequency: 'monthly' | 'weekly' | 'yearly' | 'custom'
+  day_of_month: string
+  day_of_week: string
+  month_of_year: string
+  interval: string
+  start_date: string
+  end_date: string
+}
+
+interface RecurringModalProps {
+  /** 수정 모드 여부 (null이면 추가) */
+  editingId: number | null
+  /** 폼 데이터 */
+  formData: RecurringFormData
+  /** 폼 데이터 변경 핸들러 */
+  onFormChange: (data: RecurringFormData) => void
+  /** 카테고리 목록 (타입 필터링 전) */
+  categories: Category[]
+  /** 제출 중 여부 */
+  submitting: boolean
+  /** 폼 제출 핸들러 */
+  onSubmit: (e: React.FormEvent) => void
+  /** 모달 닫기 핸들러 */
+  onClose: () => void
+}
+
+const INPUT_CLASSES = 'w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500'
+
+export default function RecurringModal({
+  editingId,
+  formData,
+  onFormChange,
+  categories,
+  submitting,
+  onSubmit,
+  onClose,
+}: RecurringModalProps) {
+  /** 타입에 맞는 카테고리만 필터 */
+  const filteredCategories = categories.filter(
+    (c) => c.type === formData.type || c.type === 'both'
+  )
+
+  /** 필드 변경 헬퍼 */
+  const updateField = (field: string, value: string) => {
+    onFormChange({ ...formData, [field]: value })
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true" aria-labelledby="recurring-modal-title">
+      <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between p-5 border-b border-[var(--border-subtle)]">
+          <h2 id="recurring-modal-title" className="text-lg font-semibold text-[var(--text-primary)]">
+            {editingId ? '반복 거래 수정' : '반복 거래 추가'}
+          </h2>
+          <button onClick={onClose} className="p-1 rounded-md hover:bg-[var(--surface-hover)]" aria-label="닫기">
+            <X className="w-5 h-5 text-[var(--text-tertiary)]" />
+          </button>
+        </div>
+        <form onSubmit={onSubmit} className="p-5 space-y-4">
+          {/* 타입 선택 (추가 시에만) */}
+          {!editingId && (
+            <div>
+              <span className="block text-sm font-medium text-[var(--text-secondary)] mb-2">유형</span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => onFormChange({ ...formData, type: 'expense', category_id: '' })}
+                  className={`flex-1 py-2 rounded-xl text-sm font-medium transition-colors ${
+                    formData.type === 'expense' ? 'bg-grape-100 text-grape-600' : 'bg-[var(--surface-hover)] text-[var(--text-secondary)]'
+                  }`}
+                >
+                  지출
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onFormChange({ ...formData, type: 'income', category_id: '' })}
+                  className={`flex-1 py-2 rounded-xl text-sm font-medium transition-colors ${
+                    formData.type === 'income' ? 'bg-leaf-100 text-leaf-600' : 'bg-[var(--surface-hover)] text-[var(--text-secondary)]'
+                  }`}
+                >
+                  수입
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* 설명 */}
+          <div>
+            <label htmlFor="reclist-description" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">설명</label>
+            <input
+              id="reclist-description"
+              type="text"
+              value={formData.description}
+              onChange={(e) => updateField('description', e.target.value)}
+              placeholder="예: 넷플릭스, 월급"
+              className={INPUT_CLASSES}
+            />
+          </div>
+
+          {/* 금액 */}
+          <div>
+            <label htmlFor="reclist-amount" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">금액</label>
+            <input
+              id="reclist-amount"
+              type="number"
+              value={formData.amount}
+              onChange={(e) => updateField('amount', e.target.value)}
+              placeholder="0"
+              min="1"
+              className={INPUT_CLASSES}
+            />
+          </div>
+
+          {/* 카테고리 */}
+          <div>
+            <label htmlFor="reclist-category" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">카테고리</label>
+            <select
+              id="reclist-category"
+              value={formData.category_id}
+              onChange={(e) => updateField('category_id', e.target.value)}
+              className={INPUT_CLASSES}
+            >
+              <option value="">선택 안 함</option>
+              {filteredCategories.map((c) => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* 빈도 필드 (추가 시에만) */}
+          {!editingId && (
+            <FrequencyFields
+              frequency={formData.frequency}
+              dayOfMonth={formData.day_of_month}
+              dayOfWeek={formData.day_of_week}
+              monthOfYear={formData.month_of_year}
+              interval={formData.interval}
+              startDate={formData.start_date}
+              onChange={updateField}
+            />
+          )}
+
+          {/* 종료일 (항상 표시) */}
+          <div>
+            <label htmlFor="reclist-end-date" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">종료일 (선택)</label>
+            <input
+              id="reclist-end-date"
+              type="date"
+              value={formData.end_date}
+              onChange={(e) => updateField('end_date', e.target.value)}
+              className={INPUT_CLASSES}
+            />
+          </div>
+
+          {/* 저장 버튼 */}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full py-3 bg-grape-600 text-white rounded-xl text-sm font-medium shadow-sm hover:bg-grape-700 transition-colors disabled:opacity-50"
+          >
+            {submitting ? '저장 중...' : editingId ? '수정하기' : '추가하기'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/recurring/__tests__/FrequencyFields.test.tsx
+++ b/frontend/src/components/recurring/__tests__/FrequencyFields.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @file FrequencyFields.test.tsx
+ * @description 빈도별 조건부 필드 컴포넌트 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import FrequencyFields from '../FrequencyFields'
+
+const defaultProps = {
+  frequency: 'monthly' as const,
+  dayOfMonth: '25',
+  dayOfWeek: '0',
+  monthOfYear: '1',
+  interval: '14',
+  startDate: '2026-01-01',
+  onChange: vi.fn(),
+}
+
+describe('FrequencyFields', () => {
+  it('빈도 선택 드롭다운을 표시한다', () => {
+    render(<FrequencyFields {...defaultProps} />)
+    expect(screen.getByLabelText('반복 빈도')).toBeInTheDocument()
+  })
+
+  it('monthly일 때 반복일 필드를 표시한다', () => {
+    render(<FrequencyFields {...defaultProps} frequency="monthly" />)
+    expect(screen.getByLabelText('반복일')).toBeInTheDocument()
+    expect(screen.queryByLabelText('요일')).not.toBeInTheDocument()
+  })
+
+  it('weekly일 때 요일 필드를 표시한다', () => {
+    render(<FrequencyFields {...defaultProps} frequency="weekly" />)
+    expect(screen.getByLabelText('요일')).toBeInTheDocument()
+    expect(screen.queryByLabelText('반복일')).not.toBeInTheDocument()
+  })
+
+  it('yearly일 때 반복일과 반복 월 필드를 표시한다', () => {
+    render(<FrequencyFields {...defaultProps} frequency="yearly" />)
+    expect(screen.getByLabelText('반복일')).toBeInTheDocument()
+    expect(screen.getByLabelText('반복 월')).toBeInTheDocument()
+  })
+
+  it('custom일 때 반복 주기 필드를 표시한다', () => {
+    render(<FrequencyFields {...defaultProps} frequency="custom" />)
+    expect(screen.getByLabelText('반복 주기 (일)')).toBeInTheDocument()
+    expect(screen.queryByLabelText('반복일')).not.toBeInTheDocument()
+  })
+
+  it('시작일 필드를 항상 표시한다', () => {
+    render(<FrequencyFields {...defaultProps} />)
+    expect(screen.getByLabelText('시작일')).toBeInTheDocument()
+  })
+
+  it('빈도 변경 시 onChange를 호출한다', async () => {
+    const user = userEvent.setup()
+    render(<FrequencyFields {...defaultProps} />)
+    await user.selectOptions(screen.getByLabelText('반복 빈도'), 'weekly')
+    expect(defaultProps.onChange).toHaveBeenCalledWith('frequency', 'weekly')
+  })
+
+  it('반복일 값이 올바르게 표시된다', () => {
+    render(<FrequencyFields {...defaultProps} dayOfMonth="15" />)
+    expect(screen.getByLabelText('반복일')).toHaveValue(15)
+  })
+})

--- a/frontend/src/components/recurring/__tests__/RecurringModal.test.tsx
+++ b/frontend/src/components/recurring/__tests__/RecurringModal.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @file RecurringModal.test.tsx
+ * @description 반복 거래 모달 컴포넌트 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import RecurringModal from '../RecurringModal'
+import type { RecurringFormData } from '../RecurringModal'
+import type { Category } from '../../../types'
+
+const emptyForm: RecurringFormData = {
+  type: 'expense',
+  amount: '',
+  description: '',
+  category_id: '',
+  frequency: 'monthly',
+  day_of_month: '25',
+  day_of_week: '0',
+  month_of_year: '1',
+  interval: '14',
+  start_date: '2026-01-01',
+  end_date: '',
+}
+
+const mockCategories: Category[] = [
+  { id: 1, name: '식비', type: 'expense', description: null, sort_order: 1, is_system: true, created_at: '2026-01-01T00:00:00Z' },
+  { id: 2, name: '급여', type: 'income', description: null, sort_order: 2, is_system: true, created_at: '2026-01-01T00:00:00Z' },
+  { id: 3, name: '기타', type: 'both', description: null, sort_order: 3, is_system: true, created_at: '2026-01-01T00:00:00Z' },
+]
+
+const defaultProps = {
+  editingId: null,
+  formData: emptyForm,
+  onFormChange: vi.fn(),
+  categories: mockCategories,
+  submitting: false,
+  onSubmit: vi.fn((e: React.FormEvent) => e.preventDefault()),
+  onClose: vi.fn(),
+}
+
+describe('RecurringModal', () => {
+  it('추가 모드에서 제목을 표시한다', () => {
+    render(<RecurringModal {...defaultProps} />)
+    expect(screen.getByText('반복 거래 추가')).toBeInTheDocument()
+  })
+
+  it('수정 모드에서 제목을 표시한다', () => {
+    render(<RecurringModal {...defaultProps} editingId={1} />)
+    expect(screen.getByText('반복 거래 수정')).toBeInTheDocument()
+  })
+
+  it('추가 모드에서 유형 선택 버튼을 표시한다', () => {
+    render(<RecurringModal {...defaultProps} />)
+    expect(screen.getByText('지출')).toBeInTheDocument()
+    expect(screen.getByText('수입')).toBeInTheDocument()
+  })
+
+  it('수정 모드에서 유형 선택 버튼을 숨긴다', () => {
+    render(<RecurringModal {...defaultProps} editingId={1} />)
+    // 유형 선택 영역의 "지출/수입" 버튼이 없어야 함
+    // (카테고리 옵션에 식비 등이 있을 수 있으므로 정확한 컨텍스트로 확인)
+    expect(screen.queryByText('유형')).not.toBeInTheDocument()
+  })
+
+  it('추가 모드에서 빈도 필드를 표시한다', () => {
+    render(<RecurringModal {...defaultProps} />)
+    expect(screen.getByLabelText('반복 빈도')).toBeInTheDocument()
+    expect(screen.getByLabelText('반복일')).toBeInTheDocument()
+    expect(screen.getByLabelText('시작일')).toBeInTheDocument()
+  })
+
+  it('수정 모드에서 빈도 필드를 숨긴다', () => {
+    render(<RecurringModal {...defaultProps} editingId={1} />)
+    expect(screen.queryByLabelText('반복 빈도')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('시작일')).not.toBeInTheDocument()
+  })
+
+  it('종료일 필드를 항상 표시한다', () => {
+    render(<RecurringModal {...defaultProps} />)
+    expect(screen.getByLabelText('종료일 (선택)')).toBeInTheDocument()
+  })
+
+  it('expense 타입일 때 expense 카테고리와 both 카테고리를 표시한다', () => {
+    render(<RecurringModal {...defaultProps} />)
+    const categorySelect = screen.getByLabelText('카테고리')
+    // 식비(expense) + 기타(both) = 2개 + 선택 안 함
+    expect(categorySelect.querySelectorAll('option').length).toBe(3)
+  })
+
+  it('닫기 버튼 클릭 시 onClose를 호출한다', async () => {
+    const user = userEvent.setup()
+    render(<RecurringModal {...defaultProps} />)
+    await user.click(screen.getByLabelText('닫기'))
+    expect(defaultProps.onClose).toHaveBeenCalled()
+  })
+
+  it('제출 중이면 저장 버튼이 비활성화된다', () => {
+    render(<RecurringModal {...defaultProps} submitting={true} />)
+    const submitBtn = screen.getByText('저장 중...')
+    expect(submitBtn).toBeDisabled()
+  })
+
+  it('추가 모드에서 추가하기 버튼을 표시한다', () => {
+    render(<RecurringModal {...defaultProps} />)
+    expect(screen.getByText('추가하기')).toBeInTheDocument()
+  })
+
+  it('수정 모드에서 수정하기 버튼을 표시한다', () => {
+    render(<RecurringModal {...defaultProps} editingId={1} />)
+    expect(screen.getByText('수정하기')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/hooks/__tests__/useHouseholdRole.test.ts
+++ b/frontend/src/hooks/__tests__/useHouseholdRole.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @file useHouseholdRole.test.ts
+ * @description useHouseholdRole 훅 테스트
+ */
+
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useHouseholdRole } from '../useHouseholdRole'
+import type { HouseholdDetail, HouseholdMember } from '../../types'
+
+const makeMember = (overrides: Partial<HouseholdMember> = {}): HouseholdMember => ({
+  user_id: 2,
+  username: '김철수',
+  email: 'kim@example.com',
+  role: 'member',
+  joined_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+})
+
+const makeHousehold = (role: 'owner' | 'admin' | 'member'): HouseholdDetail => ({
+  id: 1,
+  name: '테스트 가구',
+  description: null,
+  currency: 'KRW',
+  my_role: role,
+  member_count: 2,
+  created_at: '2026-01-01T00:00:00Z',
+  members: [
+    makeMember({ user_id: 1, username: '홍길동', role: 'owner' }),
+    makeMember({ user_id: 2, username: '김철수', role: 'member' }),
+  ],
+})
+
+describe('useHouseholdRole', () => {
+  it('household가 null이면 모든 권한이 false이다', () => {
+    const { result } = renderHook(() => useHouseholdRole(null))
+    expect(result.current.isOwner).toBe(false)
+    expect(result.current.isAdmin).toBe(false)
+    expect(result.current.canManageMember(makeMember(), 1)).toBe(false)
+  })
+
+  it('owner는 isOwner=true, isAdmin=true', () => {
+    const { result } = renderHook(() => useHouseholdRole(makeHousehold('owner')))
+    expect(result.current.isOwner).toBe(true)
+    expect(result.current.isAdmin).toBe(true)
+  })
+
+  it('admin은 isOwner=false, isAdmin=true', () => {
+    const { result } = renderHook(() => useHouseholdRole(makeHousehold('admin')))
+    expect(result.current.isOwner).toBe(false)
+    expect(result.current.isAdmin).toBe(true)
+  })
+
+  it('member는 isOwner=false, isAdmin=false', () => {
+    const { result } = renderHook(() => useHouseholdRole(makeHousehold('member')))
+    expect(result.current.isOwner).toBe(false)
+    expect(result.current.isAdmin).toBe(false)
+  })
+
+  it('owner는 다른 멤버를 관리할 수 있다', () => {
+    const { result } = renderHook(() => useHouseholdRole(makeHousehold('owner')))
+    const member = makeMember({ user_id: 2, role: 'member' })
+    expect(result.current.canManageMember(member, 1)).toBe(true)
+  })
+
+  it('owner는 자기 자신을 관리할 수 없다', () => {
+    const { result } = renderHook(() => useHouseholdRole(makeHousehold('owner')))
+    const member = makeMember({ user_id: 1, role: 'owner' })
+    expect(result.current.canManageMember(member, 1)).toBe(false)
+  })
+
+  it('owner는 다른 owner를 관리할 수 없다', () => {
+    const { result } = renderHook(() => useHouseholdRole(makeHousehold('owner')))
+    const member = makeMember({ user_id: 3, role: 'owner' })
+    expect(result.current.canManageMember(member, 1)).toBe(false)
+  })
+
+  it('admin은 멤버를 관리할 수 없다 (owner만 가능)', () => {
+    const { result } = renderHook(() => useHouseholdRole(makeHousehold('admin')))
+    const member = makeMember({ user_id: 2, role: 'member' })
+    expect(result.current.canManageMember(member, 1)).toBe(false)
+  })
+})

--- a/frontend/src/hooks/useHouseholdRole.ts
+++ b/frontend/src/hooks/useHouseholdRole.ts
@@ -1,0 +1,34 @@
+/**
+ * @file useHouseholdRole.ts
+ * @description 가구 내 역할 기반 권한 판단 훅
+ * HouseholdDetail의 my_role을 기반으로 isOwner, isAdmin, canManageMember를 반환한다.
+ */
+
+import type { HouseholdDetail, HouseholdMember } from '../types'
+
+interface HouseholdRoleResult {
+  /** 소유자인지 여부 */
+  isOwner: boolean
+  /** 관리자(owner 포함)인지 여부 */
+  isAdmin: boolean
+  /** 해당 멤버를 관리(역할 변경, 추방)할 수 있는지 여부 */
+  canManageMember: (member: HouseholdMember, currentUserId: number) => boolean
+}
+
+/**
+ * 가구 역할 기반 권한 판단 훅
+ * @param household - 가구 상세 정보 (null이면 모든 권한 false)
+ */
+export function useHouseholdRole(household: HouseholdDetail | null): HouseholdRoleResult {
+  const isOwner = household?.my_role === 'owner'
+  const isAdmin = isOwner || household?.my_role === 'admin'
+
+  const canManageMember = (member: HouseholdMember, currentUserId: number): boolean => {
+    if (!isOwner) return false
+    if (member.user_id === currentUserId) return false
+    if (member.role === 'owner') return false
+    return true
+  }
+
+  return { isOwner, isAdmin, canManageMember }
+}

--- a/frontend/src/pages/HouseholdDetailPage.tsx
+++ b/frontend/src/pages/HouseholdDetailPage.tsx
@@ -1,22 +1,26 @@
 /**
  * @file HouseholdDetailPage.tsx
  * @description 공유 가계부 상세 페이지
- * 멤버 목록, 초대, 역할 변경, 가구 설정 등을 관리한다.
+ * 탭 라우터 역할만 수행하며, 각 탭은 별도 컴포넌트로 분리되어 있다.
  */
 
 import type { } from 'react'
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { ArrowLeft, Link2 } from 'lucide-react'
+import { ArrowLeft } from 'lucide-react'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
 import { useAuth } from '../contexts/AuthContext'
+import { useHouseholdRole } from '../hooks/useHouseholdRole'
 import InviteMemberModal from '../components/InviteMemberModal'
 import EmptyState from '../components/EmptyState'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorState from '../components/ErrorState'
-import type { InviteMemberDto, UpdateHouseholdDto, MemberRole } from '../types'
-import { formatDate, formatRole, getRoleBadgeColor } from '../utils/household'
+import MembersTab from '../components/household/MembersTab'
+import InvitationsTab from '../components/household/InvitationsTab'
+import SettingsTab from '../components/household/SettingsTab'
+import type { InviteMemberDto, MemberRole } from '../types'
+import { formatRole, getRoleBadgeColor } from '../utils/household'
 import { trackEvent } from '../utils/analytics'
 
 type TabType = 'members' | 'invitations' | 'settings'
@@ -46,17 +50,13 @@ export default function HouseholdDetailPage() {
     clearCurrentHousehold,
   } = useHouseholdStore()
 
+  // 역할 기반 권한
+  const { isOwner, isAdmin, canManageMember } = useHouseholdRole(currentHousehold)
+
   // 로컬 상태
   const [activeTab, setActiveTab] = useState<TabType>('members')
   const [showInviteModal, setShowInviteModal] = useState(false)
   const [isInviting, setIsInviting] = useState(false)
-
-  // 설정 탭 상태
-  const [editMode, setEditMode] = useState(false)
-  const [formData, setFormData] = useState<UpdateHouseholdDto>({
-    name: '',
-    description: '',
-  })
 
   /**
    * 컴포넌트 마운트 시 상세 정보 조회
@@ -83,18 +83,6 @@ export default function HouseholdDetailPage() {
       fetchHouseholdInvitations(Number(id)).catch(() => {})
     }
   }, [id, currentHousehold?.my_role, fetchHouseholdInvitations])
-
-  /**
-   * 가구 정보가 로드되면 폼 데이터 초기화
-   */
-  useEffect(() => {
-    if (currentHousehold) {
-      setFormData({
-        name: currentHousehold.name,
-        description: currentHousehold.description || '',
-      })
-    }
-  }, [currentHousehold])
 
   /**
    * 에러 발생 시 자동으로 토스트 표시
@@ -186,14 +174,12 @@ export default function HouseholdDetailPage() {
   /**
    * 가구 정보 수정 핸들러
    */
-  const handleUpdateHousehold = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleUpdateHousehold = async (formData: { name?: string; description?: string }) => {
     if (!id) return
 
     try {
       await updateHousehold(Number(id), formData)
       addToast('success', '가구 정보가 수정되었습니다')
-      setEditMode(false)
     } catch (err) {
       console.error('가구 수정 실패:', err)
       addToast('error', '가구 수정에 실패했습니다')
@@ -215,6 +201,31 @@ export default function HouseholdDetailPage() {
       console.error('가구 삭제 실패:', err)
       addToast('error', '가구 삭제에 실패했습니다')
     }
+  }
+
+  /**
+   * 초대 취소 핸들러
+   */
+  const handleCancelInvitation = async (invitationId: number) => {
+    if (!id) return
+    const inv = householdInvitations.find(i => i.id === invitationId)
+    if (inv && !confirm(`${inv.invitee_email}의 초대를 취소하시겠습니까?`)) return
+
+    try {
+      await cancelInvitation(Number(id), invitationId)
+      addToast('success', '초대를 취소했습니다')
+    } catch {
+      addToast('error', '초대 취소에 실패했습니다')
+    }
+  }
+
+  /**
+   * 초대 링크 복사 핸들러
+   */
+  const handleCopyInviteLink = async (token: string) => {
+    const link = `${window.location.origin}/invitations/accept?token=${token}`
+    await navigator.clipboard.writeText(link)
+    addToast('success', '초대 링크가 복사되었습니다')
   }
 
   /**
@@ -255,9 +266,6 @@ export default function HouseholdDetailPage() {
       />
     )
   }
-
-  const isOwner = currentHousehold.my_role === 'owner'
-  const isAdmin = currentHousehold.my_role === 'admin' || isOwner
 
   return (
     <div className="space-y-6">
@@ -332,298 +340,34 @@ export default function HouseholdDetailPage() {
         </div>
       </div>
 
-      {/* 멤버 탭 */}
+      {/* 탭 콘텐츠 */}
       {activeTab === 'members' && (
-        <div className="space-y-4">
-          {/* 멤버 목록 */}
-          <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] overflow-hidden">
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead className="bg-[var(--surface-elevated)] border-b border-[var(--border-default)]">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
-                      이름
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
-                      이메일
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
-                      역할
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
-                      가입일
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
-                      관리
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-[var(--border-default)]">
-                  {currentHousehold.members.map((member) => {
-                    const isMe = member.user_id === user?.id
-                    const canManage = isOwner && !isMe && member.role !== 'owner'
-
-                    return (
-                      <tr key={member.user_id} className="hover:bg-[var(--surface-hover)]">
-                        <td className="px-4 py-3 text-sm font-medium text-[var(--text-primary)]">
-                          {member.username}
-                          {isMe && (
-                            <span className="ml-2 text-xs text-[var(--text-tertiary)]">(나)</span>
-                          )}
-                        </td>
-                        <td className="px-4 py-3 text-sm text-[var(--text-secondary)]">
-                          {member.email || '-'}
-                        </td>
-                        <td className="px-4 py-3">
-                          {canManage ? (
-                            <select
-                              value={member.role}
-                              onChange={(e) =>
-                                handleRoleChange(
-                                  member.user_id,
-                                  e.target.value as MemberRole
-                                )
-                              }
-                              className="text-sm px-2 py-1 border border-[var(--input-border)] rounded bg-[var(--surface-card)] focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                            >
-                              <option value="member">멤버</option>
-                              <option value="admin">관리자</option>
-                            </select>
-                          ) : (
-                            <span
-                              className={`inline-block text-xs px-2 py-1 rounded-full ${getRoleBadgeColor(
-                                member.role
-                              )}`}
-                            >
-                              {formatRole(member.role)}
-                            </span>
-                          )}
-                        </td>
-                        <td className="px-4 py-3 text-sm text-[var(--text-secondary)]">
-                          {formatDate(member.joined_at)}
-                        </td>
-                        <td className="px-4 py-3 text-sm text-right">
-                          {canManage ? (
-                            <button
-                              onClick={() =>
-                                handleRemoveMember(member.user_id, member.username)
-                              }
-                              className="text-rose-600 hover:text-rose-700 font-medium"
-                            >
-                              추방
-                            </button>
-                          ) : isMe && (member.role !== 'owner' || currentHousehold.members.length > 1) ? (
-                            <button
-                              onClick={handleLeave}
-                              className="text-rose-600 hover:text-rose-700 font-medium"
-                            >
-                              탈퇴
-                            </button>
-                          ) : (
-                            <span className="text-[var(--text-muted)]">-</span>
-                          )}
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
+        <MembersTab
+          household={currentHousehold}
+          currentUserId={user?.id ?? 0}
+          canManageMember={canManageMember}
+          onRoleChange={handleRoleChange}
+          onRemoveMember={handleRemoveMember}
+          onLeave={handleLeave}
+        />
       )}
 
-      {/* 초대 탭 */}
       {activeTab === 'invitations' && isAdmin && (
-        <div className="space-y-4">
-          <div className="flex justify-end">
-            <button
-              onClick={() => setShowInviteModal(true)}
-              className="px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
-            >
-              + 멤버 초대
-            </button>
-          </div>
-
-          {householdInvitations.length === 0 ? (
-            <div className="text-center py-8 text-sm text-[var(--text-muted)]">
-              보낸 초대가 없습니다
-            </div>
-          ) : (
-            <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] overflow-hidden">
-              <div className="divide-y divide-[var(--border-default)]">
-                {householdInvitations.map((inv) => {
-                  const isPending = inv.status === 'pending'
-                  const statusText: Record<string, string> = {
-                    pending: '대기 중',
-                    accepted: '수락됨',
-                    rejected: '거절됨',
-                    expired: '만료됨',
-                  }
-                  const statusColor: Record<string, string> = {
-                    pending: 'bg-yellow-100 text-yellow-600',
-                    accepted: 'bg-green-100 text-green-600',
-                    rejected: 'bg-warm-100 text-warm-600',
-                    expired: 'bg-warm-100 text-[var(--text-muted)]',
-                  }
-
-                  return (
-                    <div key={inv.id} className="flex items-center justify-between p-4">
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm font-medium text-[var(--text-primary)] truncate">
-                          {inv.invitee_email}
-                        </p>
-                        <div className="flex items-center gap-2 mt-1">
-                          <span className={`text-xs px-2 py-0.5 rounded-full ${statusColor[inv.status] || ''}`}>
-                            {statusText[inv.status] || inv.status}
-                          </span>
-                          <span className="text-xs text-[var(--text-muted)]">
-                            {inv.role === 'admin' ? '관리자' : '멤버'}
-                          </span>
-                        </div>
-                      </div>
-                      {isPending && (
-                        <div className="flex items-center gap-2 ml-3">
-                          {inv.token && (
-                            <button
-                              onClick={async () => {
-                                const link = `${window.location.origin}/invitations/accept?token=${inv.token}`
-                                await navigator.clipboard.writeText(link)
-                                addToast('success', '초대 링크가 복사되었습니다')
-                              }}
-                              className="text-xs text-grape-600 hover:text-grape-700 font-medium flex items-center gap-1"
-                              title="초대 링크 복사"
-                            >
-                              <Link2 className="w-3.5 h-3.5" />
-                              링크 복사
-                            </button>
-                          )}
-                          <button
-                            onClick={async () => {
-                              if (!confirm(`${inv.invitee_email}의 초대를 취소하시겠습니까?`)) return
-                              try {
-                                await cancelInvitation(Number(id), inv.id)
-                                addToast('success', '초대를 취소했습니다')
-                              } catch {
-                                addToast('error', '초대 취소에 실패했습니다')
-                              }
-                            }}
-                            className="text-xs text-rose-600 hover:text-rose-700 font-medium"
-                          >
-                            취소
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  )
-                })}
-              </div>
-            </div>
-          )}
-        </div>
+        <InvitationsTab
+          invitations={householdInvitations}
+          onOpenInviteModal={() => setShowInviteModal(true)}
+          onCancelInvitation={handleCancelInvitation}
+          onCopyInviteLink={handleCopyInviteLink}
+        />
       )}
 
-      {/* 설정 탭 */}
       {activeTab === 'settings' && isAdmin && (
-        <div className="space-y-6">
-          {/* 가구 정보 수정 */}
-          <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-6">
-            <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-4">
-              가구 정보
-            </h2>
-
-            <form onSubmit={handleUpdateHousehold} className="space-y-4">
-              <div>
-                <label
-                  htmlFor="name"
-                  className="block text-sm font-medium text-[var(--text-secondary)] mb-1"
-                >
-                  가구 이름
-                </label>
-                <input
-                  id="name"
-                  type="text"
-                  value={formData.name}
-                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                  disabled={!editMode}
-                  required
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="description"
-                  className="block text-sm font-medium text-[var(--text-secondary)] mb-1"
-                >
-                  설명
-                </label>
-                <textarea
-                  id="description"
-                  value={formData.description}
-                  onChange={(e) =>
-                    setFormData({ ...formData, description: e.target.value })
-                  }
-                  className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500 resize-none"
-                  rows={3}
-                  disabled={!editMode}
-                />
-              </div>
-
-              <div className="flex gap-3">
-                {editMode ? (
-                  <>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setEditMode(false)
-                        setFormData({
-                          name: currentHousehold.name,
-                          description: currentHousehold.description || '',
-                        })
-                      }}
-                      className="px-4 py-2 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-card)] border border-[var(--input-border)] rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
-                    >
-                      취소
-                    </button>
-                    <button
-                      type="submit"
-                      className="px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
-                    >
-                      저장
-                    </button>
-                  </>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => setEditMode(true)}
-                    className="px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
-                  >
-                    수정
-                  </button>
-                )}
-              </div>
-            </form>
-          </div>
-
-          {/* 가구 삭제 (owner만) */}
-          {isOwner && (
-            <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-rose-200 p-6">
-              <h2 className="text-lg font-semibold text-rose-600 mb-2">
-                위험 영역
-              </h2>
-              <p className="text-sm text-[var(--text-secondary)] mb-4">
-                가구를 삭제하면 모든 데이터가 영구적으로 삭제됩니다. 이 작업은 되돌릴 수 없습니다.
-              </p>
-              <button
-                onClick={handleDelete}
-                className="px-4 py-2 text-sm font-medium text-white bg-rose-600 rounded-lg hover:bg-rose-700 transition-colors"
-              >
-                가구 삭제
-              </button>
-            </div>
-          )}
-        </div>
+        <SettingsTab
+          household={currentHousehold}
+          isOwner={isOwner}
+          onUpdate={handleUpdateHousehold}
+          onDelete={handleDelete}
+        />
       )}
 
       {/* 멤버 초대 모달 */}

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -1,20 +1,22 @@
 /**
  * @file RecurringList.tsx
  * @description 반복 거래 관리 페이지
- * 정기 지출/수입 목록 조회, 추가, 수정, 삭제, 일시정지/재개 기능을 제공한다.
+ * 목록 표시 + 필터만 담당하며, 모달은 RecurringModal로 분리되어 있다.
  */
 
 import { useState, useEffect } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
-import { ArrowLeft, Plus, Pencil, Trash2, Pause, Play, X, Zap } from 'lucide-react'
+import { ArrowLeft, Plus, Pencil, Trash2, Pause, Play, Zap } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { recurringApi } from '../api/recurring'
 import { categoryApi } from '../api/categories'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
+import RecurringModal from '../components/recurring/RecurringModal'
+import type { RecurringFormData } from '../components/recurring/RecurringModal'
 import type { RecurringTransaction, RecurringTransactionCreate, Category } from '../types'
-import { formatAmount , getLocalDateString } from '../utils/format'
+import { formatAmount, getLocalDateString } from '../utils/format'
 import { trackEvent } from '../utils/analytics'
 
 /* 빈도 한국어 표시 */
@@ -35,12 +37,12 @@ function formatFrequency(r: RecurringTransaction): string {
 }
 
 /* 빈 폼 데이터 */
-const emptyForm = {
-  type: 'expense' as 'expense' | 'income',
+const emptyForm: RecurringFormData = {
+  type: 'expense',
   amount: '',
   description: '',
   category_id: '',
-  frequency: 'monthly' as 'monthly' | 'weekly' | 'yearly' | 'custom',
+  frequency: 'monthly',
   day_of_month: '25',
   day_of_week: '0',
   month_of_year: '1',
@@ -65,7 +67,7 @@ export default function RecurringList() {
   /* 모달 */
   const [showModal, setShowModal] = useState(false)
   const [editingId, setEditingId] = useState<number | null>(null)
-  const [formData, setFormData] = useState(emptyForm)
+  const [formData, setFormData] = useState<RecurringFormData>(emptyForm)
   const [submitting, setSubmitting] = useState(false)
 
   /* 데이터 로드 */
@@ -214,11 +216,6 @@ export default function RecurringList() {
     }
   }
 
-  /* 카테고리 필터링 (타입에 맞는 카테고리만) */
-  const filteredCategories = categories.filter(
-    (c) => c.type === formData.type || c.type === 'both'
-  )
-
   if (error) {
     return (
       <div className="space-y-6">
@@ -280,7 +277,7 @@ export default function RecurringList() {
         </div>
       ) : (
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 overflow-hidden">
-          {/* 모바일: 카드 리스트, 데스크톱: 테이블 */}
+          {/* 데스크톱: 테이블 */}
           <div className="hidden md:block">
             <table className="w-full text-sm">
               <thead>
@@ -381,204 +378,15 @@ export default function RecurringList() {
 
       {/* 추가/수정 모달 */}
       {showModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true" aria-labelledby="recurring-modal-title">
-          <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto">
-            <div className="flex items-center justify-between p-5 border-b border-[var(--border-subtle)]">
-              <h2 id="recurring-modal-title" className="text-lg font-semibold text-[var(--text-primary)]">
-                {editingId ? '반복 거래 수정' : '반복 거래 추가'}
-              </h2>
-              <button onClick={() => setShowModal(false)} className="p-1 rounded-md hover:bg-[var(--surface-hover)]" aria-label="닫기">
-                <X className="w-5 h-5 text-[var(--text-tertiary)]" />
-              </button>
-            </div>
-            <form onSubmit={handleSubmit} className="p-5 space-y-4">
-              {/* 타입 선택 (추가 시에만) */}
-              {!editingId && (
-                <div>
-                  <span className="block text-sm font-medium text-[var(--text-secondary)] mb-2">유형</span>
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      onClick={() => setFormData({ ...formData, type: 'expense', category_id: '' })}
-                      className={`flex-1 py-2 rounded-xl text-sm font-medium transition-colors ${
-                        formData.type === 'expense' ? 'bg-grape-100 text-grape-600' : 'bg-[var(--surface-hover)] text-[var(--text-secondary)]'
-                      }`}
-                    >
-                      지출
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setFormData({ ...formData, type: 'income', category_id: '' })}
-                      className={`flex-1 py-2 rounded-xl text-sm font-medium transition-colors ${
-                        formData.type === 'income' ? 'bg-leaf-100 text-leaf-600' : 'bg-[var(--surface-hover)] text-[var(--text-secondary)]'
-                      }`}
-                    >
-                      수입
-                    </button>
-                  </div>
-                </div>
-              )}
-
-              {/* 설명 */}
-              <div>
-                <label htmlFor="reclist-description" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">설명</label>
-                <input
-                  id="reclist-description"
-                  type="text"
-                  value={formData.description}
-                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  placeholder="예: 넷플릭스, 월급"
-                  className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                />
-              </div>
-
-              {/* 금액 */}
-              <div>
-                <label htmlFor="reclist-amount" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">금액</label>
-                <input
-                  id="reclist-amount"
-                  type="number"
-                  value={formData.amount}
-                  onChange={(e) => setFormData({ ...formData, amount: e.target.value })}
-                  placeholder="0"
-                  min="1"
-                  className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                />
-              </div>
-
-              {/* 카테고리 */}
-              <div>
-                <label htmlFor="reclist-category" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">카테고리</label>
-                <select
-                  id="reclist-category"
-                  value={formData.category_id}
-                  onChange={(e) => setFormData({ ...formData, category_id: e.target.value })}
-                  className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                >
-                  <option value="">선택 안 함</option>
-                  {filteredCategories.map((c) => (
-                    <option key={c.id} value={c.id}>{c.name}</option>
-                  ))}
-                </select>
-              </div>
-
-              {/* 빈도 (추가 시에만) */}
-              {!editingId && (
-                <>
-                  <div>
-                    <label htmlFor="reclist-frequency" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 빈도</label>
-                    <select
-                      id="reclist-frequency"
-                      value={formData.frequency}
-                      onChange={(e) => setFormData({ ...formData, frequency: e.target.value as typeof formData.frequency })}
-                      className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                    >
-                      <option value="monthly">매월</option>
-                      <option value="weekly">매주</option>
-                      <option value="yearly">매년</option>
-                      <option value="custom">사용자 지정</option>
-                    </select>
-                  </div>
-
-                  {/* 빈도별 추가 필드 */}
-                  {(formData.frequency === 'monthly' || formData.frequency === 'yearly') && (
-                    <div>
-                      <label htmlFor="reclist-day-of-month" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복일</label>
-                      <input
-                        id="reclist-day-of-month"
-                        type="number"
-                        value={formData.day_of_month}
-                        onChange={(e) => setFormData({ ...formData, day_of_month: e.target.value })}
-                        min="1"
-                        max="31"
-                        className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                      />
-                    </div>
-                  )}
-
-                  {formData.frequency === 'weekly' && (
-                    <div>
-                      <label htmlFor="reclist-day-of-week" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">요일</label>
-                      <select
-                        id="reclist-day-of-week"
-                        value={formData.day_of_week}
-                        onChange={(e) => setFormData({ ...formData, day_of_week: e.target.value })}
-                        className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                      >
-                        {['월', '화', '수', '목', '금', '토', '일'].map((d, i) => (
-                          <option key={i} value={i}>{d}요일</option>
-                        ))}
-                      </select>
-                    </div>
-                  )}
-
-                  {formData.frequency === 'yearly' && (
-                    <div>
-                      <label htmlFor="reclist-month-of-year" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 월</label>
-                      <select
-                        id="reclist-month-of-year"
-                        value={formData.month_of_year}
-                        onChange={(e) => setFormData({ ...formData, month_of_year: e.target.value })}
-                        className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                      >
-                        {Array.from({ length: 12 }, (_, i) => (
-                          <option key={i + 1} value={i + 1}>{i + 1}월</option>
-                        ))}
-                      </select>
-                    </div>
-                  )}
-
-                  {formData.frequency === 'custom' && (
-                    <div>
-                      <label htmlFor="reclist-interval" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">반복 주기 (일)</label>
-                      <input
-                        id="reclist-interval"
-                        type="number"
-                        value={formData.interval}
-                        onChange={(e) => setFormData({ ...formData, interval: e.target.value })}
-                        min="1"
-                        className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                      />
-                    </div>
-                  )}
-
-                  {/* 시작일 */}
-                  <div>
-                    <label htmlFor="reclist-start-date" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">시작일</label>
-                    <input
-                      id="reclist-start-date"
-                      type="date"
-                      value={formData.start_date}
-                      onChange={(e) => setFormData({ ...formData, start_date: e.target.value })}
-                      className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                    />
-                  </div>
-                </>
-              )}
-
-              {/* 종료일 (항상 표시) */}
-              <div>
-                <label htmlFor="reclist-end-date" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">종료일 (선택)</label>
-                <input
-                  id="reclist-end-date"
-                  type="date"
-                  value={formData.end_date}
-                  onChange={(e) => setFormData({ ...formData, end_date: e.target.value })}
-                  className="w-full px-3 py-2 rounded-xl border border-[var(--input-border)] text-sm focus:outline-none focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                />
-              </div>
-
-              {/* 저장 버튼 */}
-              <button
-                type="submit"
-                disabled={submitting}
-                className="w-full py-3 bg-grape-600 text-white rounded-xl text-sm font-medium shadow-sm hover:bg-grape-700 transition-colors disabled:opacity-50"
-              >
-                {submitting ? '저장 중...' : editingId ? '수정하기' : '추가하기'}
-              </button>
-            </form>
-          </div>
-        </div>
+        <RecurringModal
+          editingId={editingId}
+          formData={formData}
+          onFormChange={setFormData}
+          categories={categories}
+          submitting={submitting}
+          onSubmit={handleSubmit}
+          onClose={() => setShowModal(false)}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

- **#386**: HouseholdDetailPage(638줄) → 탭별 분리 + useHouseholdRole 훅
- **#387**: RecurringList(585줄) → 모달/빈도필드 분리

## 줄수 변화

| 파일 | Before | After |
|------|--------|-------|
| HouseholdDetailPage | 638줄 | ~270줄 |
| RecurringList | 585줄 | ~280줄 |

## Test plan

- [x] 780 tests passed (기존 726 + 신규 54)
- [x] lint 0 에러, build 성공
- [ ] CI 통과

Closes #386
Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)