### PR TITLE
test: FE MyAccount/Recurring 커버리지 강화 (#399)

### DIFF
--- a/frontend/src/components/recurring/__tests__/RecurringModal.test.tsx
+++ b/frontend/src/components/recurring/__tests__/RecurringModal.test.tsx
@@ -41,6 +41,8 @@ const defaultProps = {
 }
 
 describe('RecurringModal', () => {
+  // ==================== 추가 vs 수정 모드 ====================
+
   it('추가 모드에서 제목을 표시한다', () => {
     render(<RecurringModal {...defaultProps} />)
     expect(screen.getByText('반복 거래 추가')).toBeInTheDocument()
@@ -59,8 +61,6 @@ describe('RecurringModal', () => {
 
   it('수정 모드에서 유형 선택 버튼을 숨긴다', () => {
     render(<RecurringModal {...defaultProps} editingId={1} />)
-    // 유형 선택 영역의 "지출/수입" 버튼이 없어야 함
-    // (카테고리 옵션에 식비 등이 있을 수 있으므로 정확한 컨텍스트로 확인)
     expect(screen.queryByText('유형')).not.toBeInTheDocument()
   })
 
@@ -77,31 +77,6 @@ describe('RecurringModal', () => {
     expect(screen.queryByLabelText('시작일')).not.toBeInTheDocument()
   })
 
-  it('종료일 필드를 항상 표시한다', () => {
-    render(<RecurringModal {...defaultProps} />)
-    expect(screen.getByLabelText('종료일 (선택)')).toBeInTheDocument()
-  })
-
-  it('expense 타입일 때 expense 카테고리와 both 카테고리를 표시한다', () => {
-    render(<RecurringModal {...defaultProps} />)
-    const categorySelect = screen.getByLabelText('카테고리')
-    // 식비(expense) + 기타(both) = 2개 + 선택 안 함
-    expect(categorySelect.querySelectorAll('option').length).toBe(3)
-  })
-
-  it('닫기 버튼 클릭 시 onClose를 호출한다', async () => {
-    const user = userEvent.setup()
-    render(<RecurringModal {...defaultProps} />)
-    await user.click(screen.getByLabelText('닫기'))
-    expect(defaultProps.onClose).toHaveBeenCalled()
-  })
-
-  it('제출 중이면 저장 버튼이 비활성화된다', () => {
-    render(<RecurringModal {...defaultProps} submitting={true} />)
-    const submitBtn = screen.getByText('저장 중...')
-    expect(submitBtn).toBeDisabled()
-  })
-
   it('추가 모드에서 추가하기 버튼을 표시한다', () => {
     render(<RecurringModal {...defaultProps} />)
     expect(screen.getByText('추가하기')).toBeInTheDocument()
@@ -110,5 +85,157 @@ describe('RecurringModal', () => {
   it('수정 모드에서 수정하기 버튼을 표시한다', () => {
     render(<RecurringModal {...defaultProps} editingId={1} />)
     expect(screen.getByText('수정하기')).toBeInTheDocument()
+  })
+
+  // ==================== 빈도별 필드 전환 ====================
+
+  it('monthly 빈도일 때 반복일 필드를 표시한다', () => {
+    render(<RecurringModal {...defaultProps} formData={{ ...emptyForm, frequency: 'monthly' }} />)
+    expect(screen.getByLabelText('반복일')).toBeInTheDocument()
+    expect(screen.queryByLabelText('요일')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('반복 주기 (일)')).not.toBeInTheDocument()
+  })
+
+  it('weekly 빈도일 때 요일 필드를 표시한다', () => {
+    render(<RecurringModal {...defaultProps} formData={{ ...emptyForm, frequency: 'weekly' }} />)
+    expect(screen.getByLabelText('요일')).toBeInTheDocument()
+    expect(screen.queryByLabelText('반복일')).not.toBeInTheDocument()
+  })
+
+  it('yearly 빈도일 때 반복일과 반복 월 필드를 표시한다', () => {
+    render(<RecurringModal {...defaultProps} formData={{ ...emptyForm, frequency: 'yearly' }} />)
+    expect(screen.getByLabelText('반복일')).toBeInTheDocument()
+    expect(screen.getByLabelText('반복 월')).toBeInTheDocument()
+    expect(screen.queryByLabelText('요일')).not.toBeInTheDocument()
+  })
+
+  it('custom 빈도일 때 반복 주기 필드를 표시한다', () => {
+    render(<RecurringModal {...defaultProps} formData={{ ...emptyForm, frequency: 'custom' }} />)
+    expect(screen.getByLabelText('반복 주기 (일)')).toBeInTheDocument()
+    expect(screen.queryByLabelText('반복일')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('요일')).not.toBeInTheDocument()
+  })
+
+  // ==================== 빈도 변경 시 onFormChange 호출 ====================
+
+  it('빈도 선택을 변경하면 onFormChange를 호출한다', async () => {
+    const onFormChange = vi.fn()
+    const user = userEvent.setup()
+    render(<RecurringModal {...defaultProps} onFormChange={onFormChange} />)
+
+    await user.selectOptions(screen.getByLabelText('반복 빈도'), 'weekly')
+    expect(onFormChange).toHaveBeenCalled()
+  })
+
+  // ==================== 카테고리 필터링 ====================
+
+  it('expense 타입일 때 expense 카테고리와 both 카테고리를 표시한다', () => {
+    render(<RecurringModal {...defaultProps} />)
+    const categorySelect = screen.getByLabelText('카테고리')
+    // 식비(expense) + 기타(both) = 2개 + 선택 안 함
+    expect(categorySelect.querySelectorAll('option').length).toBe(3)
+  })
+
+  it('income 타입일 때 income 카테고리와 both 카테고리를 표시한다', () => {
+    render(<RecurringModal {...defaultProps} formData={{ ...emptyForm, type: 'income' }} />)
+    const categorySelect = screen.getByLabelText('카테고리')
+    // 급여(income) + 기타(both) = 2개 + 선택 안 함
+    expect(categorySelect.querySelectorAll('option').length).toBe(3)
+  })
+
+  // ==================== 유형 전환 ====================
+
+  it('수입 버튼 클릭 시 onFormChange를 호출한다', async () => {
+    const onFormChange = vi.fn()
+    const user = userEvent.setup()
+    render(<RecurringModal {...defaultProps} onFormChange={onFormChange} />)
+
+    await user.click(screen.getByText('수입'))
+    expect(onFormChange).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'income', category_id: '' })
+    )
+  })
+
+  it('지출 버튼 클릭 시 onFormChange를 호출한다', async () => {
+    const onFormChange = vi.fn()
+    const user = userEvent.setup()
+    render(<RecurringModal {...defaultProps} formData={{ ...emptyForm, type: 'income' }} onFormChange={onFormChange} />)
+
+    await user.click(screen.getByText('지출'))
+    expect(onFormChange).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'expense', category_id: '' })
+    )
+  })
+
+  // ==================== 종료일 ====================
+
+  it('종료일 필드를 항상 표시한다', () => {
+    render(<RecurringModal {...defaultProps} />)
+    expect(screen.getByLabelText('종료일 (선택)')).toBeInTheDocument()
+  })
+
+  it('수정 모드에서도 종료일 필드를 표시한다', () => {
+    render(<RecurringModal {...defaultProps} editingId={1} />)
+    expect(screen.getByLabelText('종료일 (선택)')).toBeInTheDocument()
+  })
+
+  // ==================== 닫기/제출 ====================
+
+  it('닫기 버튼 클릭 시 onClose를 호출한다', async () => {
+    const user = userEvent.setup()
+    render(<RecurringModal {...defaultProps} />)
+    await user.click(screen.getByLabelText('닫기'))
+    expect(defaultProps.onClose).toHaveBeenCalled()
+  })
+
+  it('폼 제출 시 onSubmit을 호출한다', async () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault())
+    const user = userEvent.setup()
+    render(<RecurringModal {...defaultProps} onSubmit={onSubmit} />)
+    await user.click(screen.getByText('추가하기'))
+    expect(onSubmit).toHaveBeenCalled()
+  })
+
+  it('제출 중이면 저장 버튼이 비활성화된다', () => {
+    render(<RecurringModal {...defaultProps} submitting={true} />)
+    const submitBtn = screen.getByText('저장 중...')
+    expect(submitBtn).toBeDisabled()
+  })
+
+  // ==================== 필드 입력 ====================
+
+  it('설명 필드 입력 시 onFormChange를 호출한다', async () => {
+    const onFormChange = vi.fn()
+    const user = userEvent.setup()
+    render(<RecurringModal {...defaultProps} onFormChange={onFormChange} />)
+
+    await user.type(screen.getByLabelText('설명'), 'A')
+    expect(onFormChange).toHaveBeenCalled()
+  })
+
+  it('금액 필드 입력 시 onFormChange를 호출한다', async () => {
+    const onFormChange = vi.fn()
+    const user = userEvent.setup()
+    render(<RecurringModal {...defaultProps} onFormChange={onFormChange} />)
+
+    await user.type(screen.getByLabelText('금액'), '5')
+    expect(onFormChange).toHaveBeenCalled()
+  })
+
+  it('카테고리 선택 시 onFormChange를 호출한다', async () => {
+    const onFormChange = vi.fn()
+    const user = userEvent.setup()
+    render(<RecurringModal {...defaultProps} onFormChange={onFormChange} />)
+
+    await user.selectOptions(screen.getByLabelText('카테고리'), '1')
+    expect(onFormChange).toHaveBeenCalledWith(
+      expect.objectContaining({ category_id: '1' })
+    )
+  })
+
+  it('dialog role과 aria-modal 속성이 있다', () => {
+    render(<RecurringModal {...defaultProps} />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
   })
 })

--- a/frontend/src/components/settings/__tests__/MyAccountSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/MyAccountSection.test.tsx
@@ -12,19 +12,28 @@ import { server } from '../../../mocks/server'
 import { ThemeProvider } from '../../../contexts/ThemeContext'
 import SettingsPage from '../../../pages/SettingsPage'
 
+const mockUpdateUser = vi.fn().mockResolvedValue({ error: null })
+const mockSignOut = vi.fn().mockResolvedValue({ error: null })
+
 vi.mock('../../../utils/supabase', () => ({
   supabase: {
     auth: {
-      updateUser: vi.fn().mockResolvedValue({ error: null }),
-      signOut: vi.fn().mockResolvedValue({ error: null }),
+      updateUser: (...args: unknown[]) => mockUpdateUser(...args),
+      signOut: (...args: unknown[]) => mockSignOut(...args),
     },
   },
 }))
 
+const mockAddToast = vi.fn()
 vi.mock('../../../hooks/useToast', () => ({
-  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn() }),
+  useToast: () => ({ addToast: mockAddToast, removeToast: vi.fn() }),
 }))
 
+const mockLogout = vi.fn()
+const mockRefreshUser = vi.fn().mockResolvedValue(undefined)
+
+/** useAuth 반환값을 동적으로 교체하기 위한 설정 */
+let authOverrides: Record<string, unknown> = {}
 vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({
     user: {
@@ -34,11 +43,13 @@ vi.mock('../../../contexts/AuthContext', () => ({
       is_active: true,
       created_at: '2024-01-15T00:00:00Z',
       is_telegram_linked: false,
+      is_kakao_linked: false,
+      ...authOverrides,
     },
     isAuthenticated: true,
     loading: false,
-    refreshUser: vi.fn(),
-    logout: vi.fn(),
+    refreshUser: mockRefreshUser,
+    logout: mockLogout,
   }),
 }))
 
@@ -66,7 +77,10 @@ describe('MyAccountSection 컴포넌트', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(window, 'confirm').mockReturnValue(true)
+    authOverrides = {}
   })
+
+  // ==================== 기본 정보 ====================
 
   it('기본 정보 (사용자명, 이메일, 가입일)를 표시한다', () => {
     renderMyAccount()
@@ -79,6 +93,8 @@ describe('MyAccountSection 컴포넌트', () => {
     expect(screen.getByText('2024.01.15')).toBeInTheDocument()
   })
 
+  // ==================== 연동 서비스 ====================
+
   it('연동 서비스 섹션을 표시한다', () => {
     renderMyAccount()
     expect(screen.getByText('연동 서비스')).toBeInTheDocument()
@@ -89,21 +105,6 @@ describe('MyAccountSection 컴포넌트', () => {
     renderMyAccount()
     expect(screen.getByText('카카오톡 연동')).toBeInTheDocument()
     expect(screen.getByText('카카오톡')).toBeInTheDocument()
-  })
-
-  it('비밀번호 변경 버튼을 표시한다', () => {
-    renderMyAccount()
-    expect(screen.getByText('비밀번호 변경')).toBeInTheDocument()
-  })
-
-  it('로그아웃 버튼을 표시한다', () => {
-    renderMyAccount()
-    expect(screen.getByText('로그아웃')).toBeInTheDocument()
-  })
-
-  it('계정 삭제 버튼을 표시한다', () => {
-    renderMyAccount()
-    expect(screen.getByText('계정 삭제')).toBeInTheDocument()
   })
 
   it('미연동 상태에서는 연동 코드 발급 버튼이 표시된다', () => {
@@ -134,6 +135,79 @@ describe('MyAccountSection 컴포넌트', () => {
     })
   })
 
+  it('카카오 연동 코드 발급 시 코드가 표시된다', async () => {
+    server.use(
+      http.post('/api/auth/kakao-link-code', () =>
+        HttpResponse.json({
+          code: 'KK-TEST99',
+          expires_at: '2026-03-19T12:00:00Z',
+        })
+      )
+    )
+
+    const user = userEvent.setup()
+    renderMyAccount()
+
+    const codeBtns = await screen.findAllByRole('button', { name: '연동 코드 발급' })
+    // 카카오는 두 번째 발급 버튼
+    await user.click(codeBtns[1])
+
+    await waitFor(() => {
+      expect(screen.getByText('KK-TEST99')).toBeInTheDocument()
+    })
+  })
+
+  it('텔레그램 연동 상태에서 연동 해제 버튼을 표시한다', () => {
+    authOverrides = { is_telegram_linked: true }
+    renderMyAccount()
+    expect(screen.getByText('연동 해제')).toBeInTheDocument()
+  })
+
+  it('텔레그램 연동 해제를 실행한다', async () => {
+    authOverrides = { is_telegram_linked: true }
+    server.use(
+      http.delete('/api/auth/telegram/link', () => HttpResponse.json(null, { status: 204 }))
+    )
+
+    const user = userEvent.setup()
+    renderMyAccount()
+
+    await user.click(screen.getByText('연동 해제'))
+
+    await waitFor(() => {
+      expect(mockRefreshUser).toHaveBeenCalled()
+    })
+  })
+
+  it('카카오 연동 상태에서 연동 해제 버튼을 표시한다', () => {
+    authOverrides = { is_kakao_linked: true }
+    renderMyAccount()
+    expect(screen.getByText('연동 해제')).toBeInTheDocument()
+  })
+
+  it('카카오 연동 해제를 실행한다', async () => {
+    authOverrides = { is_kakao_linked: true }
+    server.use(
+      http.delete('/api/auth/kakao/link', () => HttpResponse.json(null, { status: 204 }))
+    )
+
+    const user = userEvent.setup()
+    renderMyAccount()
+
+    await user.click(screen.getByText('연동 해제'))
+
+    await waitFor(() => {
+      expect(mockRefreshUser).toHaveBeenCalled()
+    })
+  })
+
+  // ==================== 비밀번호 변경 ====================
+
+  it('비밀번호 변경 버튼을 표시한다', () => {
+    renderMyAccount()
+    expect(screen.getByText('비밀번호 변경')).toBeInTheDocument()
+  })
+
   it('비밀번호 변경 버튼 클릭 시 폼이 표시된다', async () => {
     const user = userEvent.setup()
     renderMyAccount()
@@ -142,11 +216,192 @@ describe('MyAccountSection 컴포넌트', () => {
     expect(screen.getByPlaceholderText('새 비밀번호 확인')).toBeInTheDocument()
   })
 
+  it('비밀번호 변경 폼에서 취소 클릭 시 폼이 닫힌다', async () => {
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('비밀번호 변경'))
+    expect(screen.getByPlaceholderText('새 비밀번호 (6자 이상)')).toBeInTheDocument()
+
+    await user.click(screen.getByText('취소'))
+    expect(screen.queryByPlaceholderText('새 비밀번호 (6자 이상)')).not.toBeInTheDocument()
+  })
+
+  it('비밀번호 불일치 시 에러를 표시한다', async () => {
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('비밀번호 변경'))
+
+    await user.type(screen.getByPlaceholderText('새 비밀번호 (6자 이상)'), 'password123')
+    await user.type(screen.getByPlaceholderText('새 비밀번호 확인'), 'differentpassword')
+    await user.click(screen.getByText('변경'))
+
+    await waitFor(() => {
+      expect(screen.getByText('새 비밀번호가 일치하지 않습니다')).toBeInTheDocument()
+    })
+  })
+
+  it('비밀번호 변경 성공 시 토스트를 표시하고 폼을 닫는다', async () => {
+    mockUpdateUser.mockResolvedValue({ error: null })
+
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('비밀번호 변경'))
+
+    await user.type(screen.getByPlaceholderText('새 비밀번호 (6자 이상)'), 'newpassword123')
+    await user.type(screen.getByPlaceholderText('새 비밀번호 확인'), 'newpassword123')
+    await user.click(screen.getByText('변경'))
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'newpassword123' })
+    })
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('success', '비밀번호가 변경되었습니다')
+    })
+    // 폼이 닫힌다
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('새 비밀번호 (6자 이상)')).not.toBeInTheDocument()
+    })
+  })
+
+  it('비밀번호 변경 API 에러 시 에러 메시지를 표시한다 (6자 미만)', async () => {
+    mockUpdateUser.mockResolvedValue({ error: new Error('Password should be at least 6 characters') })
+
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('비밀번호 변경'))
+
+    await user.type(screen.getByPlaceholderText('새 비밀번호 (6자 이상)'), 'abc123')
+    await user.type(screen.getByPlaceholderText('새 비밀번호 확인'), 'abc123')
+    await user.click(screen.getByText('변경'))
+
+    await waitFor(() => {
+      expect(screen.getByText('비밀번호는 6자 이상이어야 합니다')).toBeInTheDocument()
+    })
+  })
+
+  it('비밀번호 변경 API 에러 시 에러 메시지를 표시한다 (동일 비밀번호)', async () => {
+    mockUpdateUser.mockResolvedValue({ error: new Error('New password should be different from the old password. Please use a same password or choose a different one') })
+
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('비밀번호 변경'))
+
+    await user.type(screen.getByPlaceholderText('새 비밀번호 (6자 이상)'), 'samepassword')
+    await user.type(screen.getByPlaceholderText('새 비밀번호 확인'), 'samepassword')
+    await user.click(screen.getByText('변경'))
+
+    await waitFor(() => {
+      expect(screen.getByText('현재 비밀번호와 동일합니다')).toBeInTheDocument()
+    })
+  })
+
+  it('비밀번호 변경 API 에러 시 일반 에러 메시지를 표시한다', async () => {
+    mockUpdateUser.mockResolvedValue({ error: new Error('Unknown server error') })
+
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('비밀번호 변경'))
+
+    await user.type(screen.getByPlaceholderText('새 비밀번호 (6자 이상)'), 'newpass123')
+    await user.type(screen.getByPlaceholderText('새 비밀번호 확인'), 'newpass123')
+    await user.click(screen.getByText('변경'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Unknown server error')).toBeInTheDocument()
+    })
+  })
+
+  // ==================== 로그아웃 ====================
+
+  it('로그아웃 버튼을 표시한다', () => {
+    renderMyAccount()
+    expect(screen.getByText('로그아웃')).toBeInTheDocument()
+  })
+
+  it('로그아웃 버튼 클릭 시 logout을 호출한다', async () => {
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('로그아웃'))
+    expect(mockLogout).toHaveBeenCalled()
+  })
+
+  // ==================== 계정 삭제 ====================
+
+  it('계정 삭제 버튼을 표시한다', () => {
+    renderMyAccount()
+    expect(screen.getByText('계정 삭제')).toBeInTheDocument()
+  })
+
   it('계정 삭제 버튼 클릭 시 확인 폼이 표시된다', async () => {
     const user = userEvent.setup()
     renderMyAccount()
     await user.click(screen.getByText('계정 삭제'))
     expect(screen.getByText('계정을 정말 삭제하시겠습니까?')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('삭제')).toBeInTheDocument()
+  })
+
+  it('삭제 텍스트 미입력 시 삭제 버튼이 비활성화된다', async () => {
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('계정 삭제'))
+    const deleteBtn = screen.getByText('계정 영구 삭제')
+    expect(deleteBtn).toBeDisabled()
+  })
+
+  it('삭제 텍스트 입력 후 삭제 버튼이 활성화된다', async () => {
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('계정 삭제'))
+
+    await user.type(screen.getByPlaceholderText('삭제'), '삭제')
+    const deleteBtn = screen.getByText('계정 영구 삭제')
+    expect(deleteBtn).not.toBeDisabled()
+  })
+
+  it('계정 삭제 확인 폼에서 취소하면 원래 상태로 돌아간다', async () => {
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('계정 삭제'))
+    expect(screen.getByText('계정을 정말 삭제하시겠습니까?')).toBeInTheDocument()
+
+    await user.click(screen.getByText('취소'))
+    expect(screen.queryByText('계정을 정말 삭제하시겠습니까?')).not.toBeInTheDocument()
+    // 원래 계정 삭제 버튼이 다시 보인다
+    expect(screen.getByText('계정 삭제')).toBeInTheDocument()
+  })
+
+  it('계정 삭제를 실행하면 API 호출 후 로그아웃된다', async () => {
+    // 컴포넌트가 apiClient.delete('/api/auth/me')를 호출 → baseURL '/api' + '/api/auth/me'
+    server.use(
+      http.delete('*/api/auth/me', () => HttpResponse.json(null, { status: 200 }))
+    )
+
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('계정 삭제'))
+
+    await user.type(screen.getByPlaceholderText('삭제'), '삭제')
+    await user.click(screen.getByText('계정 영구 삭제'))
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled()
+    })
+  })
+
+  it('계정 삭제 API 실패 시 에러 토스트를 표시한다', async () => {
+    server.use(
+      http.delete('*/api/auth/me', () => HttpResponse.json({ detail: 'Error' }, { status: 500 }))
+    )
+
+    const user = userEvent.setup()
+    renderMyAccount()
+    await user.click(screen.getByText('계정 삭제'))
+
+    await user.type(screen.getByPlaceholderText('삭제'), '삭제')
+    await user.click(screen.getByText('계정 영구 삭제'))
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('error', '계정 삭제에 실패했습니다. 다시 시도해주세요.')
+    })
   })
 })

--- a/frontend/src/pages/__tests__/RecurringList.test.tsx
+++ b/frontend/src/pages/__tests__/RecurringList.test.tsx
@@ -1,19 +1,57 @@
-import { describe, it, expect, vi } from 'vitest'
+/**
+ * @file RecurringList.test.tsx
+ * @description 반복 거래 관리 페이지 테스트
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { server } from '../../mocks/server'
 import { http, HttpResponse } from 'msw'
 import RecurringList from '../RecurringList'
+import type { RecurringTransaction } from '../../types'
 
+const mockAddToast = vi.fn()
 vi.mock('../../hooks/useToast', () => ({
-  useToast: () => ({ addToast: vi.fn() }),
+  useToast: () => ({ addToast: mockAddToast }),
 }))
 
 vi.mock('../../stores/useHouseholdStore', () => ({
   useHouseholdStore: (selector: (s: { activeHouseholdId: number }) => unknown) =>
     selector({ activeHouseholdId: 1 }),
 }))
+
+/** 테스트용 반복 거래 데이터 */
+const mockItems: RecurringTransaction[] = [
+  {
+    id: 1, user_id: 1, household_id: 1,
+    type: 'expense', amount: 17000, description: '넷플릭스',
+    category_id: null, frequency: 'monthly', interval: null,
+    day_of_month: 25, day_of_week: null, month_of_year: null,
+    start_date: '2026-01-25', end_date: null,
+    next_due_date: '2026-02-25', is_active: true,
+    created_at: '2026-01-25T00:00:00Z', updated_at: '2026-01-25T00:00:00Z',
+  },
+  {
+    id: 2, user_id: 1, household_id: 1,
+    type: 'income', amount: 3500000, description: '급여',
+    category_id: null, frequency: 'monthly', interval: null,
+    day_of_month: 25, day_of_week: null, month_of_year: null,
+    start_date: '2026-01-25', end_date: null,
+    next_due_date: '2026-02-25', is_active: true,
+    created_at: '2026-01-25T00:00:00Z', updated_at: '2026-01-25T00:00:00Z',
+  },
+  {
+    id: 3, user_id: 1, household_id: 1,
+    type: 'expense', amount: 50000, description: '정지된 거래',
+    category_id: null, frequency: 'monthly', interval: null,
+    day_of_month: 1, day_of_week: null, month_of_year: null,
+    start_date: '2026-01-01', end_date: null,
+    next_due_date: '2026-02-01', is_active: false,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+  },
+]
 
 function renderRecurringList() {
   return render(
@@ -24,10 +62,24 @@ function renderRecurringList() {
 }
 
 describe('RecurringList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  // ==================== 기본 렌더링 ====================
+
   it('필터 탭을 표시한다', () => {
     renderRecurringList()
     expect(screen.getByText('전체')).toBeInTheDocument()
     expect(screen.getByText('추가')).toBeInTheDocument()
+  })
+
+  it('전체/지출/수입 필터 탭이 있다', () => {
+    renderRecurringList()
+    expect(screen.getByText('전체')).toBeInTheDocument()
+    expect(screen.getByText('지출')).toBeInTheDocument()
+    expect(screen.getByText('수입')).toBeInTheDocument()
   })
 
   it('반복 거래 목록을 표시한다', async () => {
@@ -45,12 +97,20 @@ describe('RecurringList', () => {
     })
   })
 
-  it('전체/지출/수입 필터 탭이 있다', () => {
+  it('활성/정지 상태 뱃지를 표시한다', async () => {
     renderRecurringList()
-    expect(screen.getByText('전체')).toBeInTheDocument()
-    expect(screen.getByText('지출')).toBeInTheDocument()
-    expect(screen.getByText('수입')).toBeInTheDocument()
+    await waitFor(() => {
+      const badges = screen.getAllByText('사용 중')
+      expect(badges.length).toBeGreaterThan(0)
+    })
   })
+
+  it('추가 버튼이 있다', () => {
+    renderRecurringList()
+    expect(screen.getByText('추가')).toBeInTheDocument()
+  })
+
+  // ==================== 필터 전환 ====================
 
   it('지출 탭 클릭 시 지출만 표시한다', async () => {
     const user = userEvent.setup()
@@ -59,18 +119,11 @@ describe('RecurringList', () => {
         const url = new URL(request.url)
         const type = url.searchParams.get('type')
         if (type === 'expense') {
-          return HttpResponse.json([{
-            id: 1, user_id: 1, household_id: null,
-            type: 'expense', amount: 17000, description: '넷플릭스',
-            category_id: null, frequency: 'monthly', interval: null,
-            day_of_month: 25, day_of_week: null, month_of_year: null,
-            start_date: '2026-01-25', end_date: null,
-            next_due_date: '2026-02-25', is_active: true,
-            created_at: '2026-01-25T00:00:00Z', updated_at: '2026-01-25T00:00:00Z',
-          }])
+          return HttpResponse.json([mockItems[0]])
         }
-        return HttpResponse.json([])
+        return HttpResponse.json(mockItems)
       }),
+      http.get('/api/categories', () => HttpResponse.json([])),
     )
     renderRecurringList()
     await user.click(screen.getByText('지출'))
@@ -78,6 +131,28 @@ describe('RecurringList', () => {
       expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
     })
   })
+
+  it('수입 탭 클릭 시 수입만 표시한다', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/recurring', ({ request }) => {
+        const url = new URL(request.url)
+        const type = url.searchParams.get('type')
+        if (type === 'income') {
+          return HttpResponse.json([mockItems[1]])
+        }
+        return HttpResponse.json(mockItems)
+      }),
+      http.get('/api/categories', () => HttpResponse.json([])),
+    )
+    renderRecurringList()
+    await user.click(screen.getByText('수입'))
+    await waitFor(() => {
+      expect(screen.getAllByText('급여').length).toBeGreaterThan(0)
+    })
+  })
+
+  // ==================== 빈/에러 상태 ====================
 
   it('빈 목록일 때 빈 상태를 표시한다', async () => {
     server.use(http.get('/api/recurring', () => HttpResponse.json([])))
@@ -95,10 +170,7 @@ describe('RecurringList', () => {
     })
   })
 
-  it('추가 버튼이 있다', () => {
-    renderRecurringList()
-    expect(screen.getByText('추가')).toBeInTheDocument()
-  })
+  // ==================== 모달 ====================
 
   it('추가 버튼 클릭 시 모달이 열린다', async () => {
     const user = userEvent.setup()
@@ -107,11 +179,262 @@ describe('RecurringList', () => {
     expect(screen.getByText('반복 거래 추가')).toBeInTheDocument()
   })
 
-  it('활성/정지 상태 뱃지를 표시한다', async () => {
+  it('모달에서 닫기 클릭 시 모달이 닫힌다', async () => {
+    const user = userEvent.setup()
     renderRecurringList()
+    await user.click(screen.getByText('추가'))
+    expect(screen.getByText('반복 거래 추가')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('닫기'))
+    expect(screen.queryByText('반복 거래 추가')).not.toBeInTheDocument()
+  })
+
+  // ==================== 바로 등록 (execute) ====================
+
+  it('활성 항목에서 바로 등록 버튼을 클릭하면 실행된다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+      http.post('/api/recurring/1/execute', () =>
+        HttpResponse.json({
+          message: '넷플릭스 17,000원이 지출로 등록되었습니다',
+          created_id: 100,
+          type: 'expense',
+          next_due_date: '2026-03-25',
+        }, { status: 201 })
+      ),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
     await waitFor(() => {
-      const badges = screen.getAllByText('사용 중')
-      expect(badges.length).toBeGreaterThan(0)
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    const executeBtns = screen.getAllByTitle('바로 등록')
+    await user.click(executeBtns[0])
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('success', '넷플릭스 등록되었습니다')
+    })
+  })
+
+  // ==================== 활성화/비활성화 토글 ====================
+
+  it('활성 항목에서 중지 버튼을 클릭하면 비활성화된다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+      http.put('/api/recurring/1', () =>
+        HttpResponse.json({ ...mockItems[0], is_active: false })
+      ),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    const pauseBtns = screen.getAllByTitle('중지')
+    await user.click(pauseBtns[0])
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('success', '중지되었습니다')
+    })
+  })
+
+  it('비활성 항목에서 다시 시작 버튼을 클릭하면 활성화된다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[2]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+      http.put('/api/recurring/3', () =>
+        HttpResponse.json({ ...mockItems[2], is_active: true })
+      ),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('정지된 거래').length).toBeGreaterThan(0)
+    })
+
+    const playBtns = screen.getAllByTitle('다시 시작')
+    await user.click(playBtns[0])
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('success', '다시 시작되었습니다')
+    })
+  })
+
+  // ==================== 삭제 ====================
+
+  it('삭제 버튼 클릭 시 항목이 삭제된다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+      http.delete('/api/recurring/1', () => HttpResponse.json(null, { status: 204 })),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    const deleteBtns = screen.getAllByTitle('삭제')
+    await user.click(deleteBtns[0])
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('success', '반복 거래가 삭제되었습니다')
+    })
+  })
+
+  it('삭제 확인을 취소하면 삭제되지 않는다', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    const deleteBtns = screen.getAllByTitle('삭제')
+    await user.click(deleteBtns[0])
+
+    // 삭제 토스트가 호출되지 않아야 함
+    expect(mockAddToast).not.toHaveBeenCalledWith('success', '반복 거래가 삭제되었습니다')
+  })
+
+  // ==================== 수정 ====================
+
+  it('수정 버튼 클릭 시 수정 모달이 열린다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    const editBtns = screen.getAllByTitle('수정')
+    await user.click(editBtns[0])
+
+    expect(screen.getByText('반복 거래 수정')).toBeInTheDocument()
+  })
+
+  // ==================== 폼 제출 검증 ====================
+
+  it('설명 없이 제출하면 에러 토스트를 표시한다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getByText(/등록된 반복 거래가 없습니다/)).toBeInTheDocument()
+    })
+
+    // 빈 상태 화면의 추가 버튼으로 모달 열기
+    await user.click(screen.getByText('반복 거래 추가'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    // 금액만 입력하고 설명은 비워둠
+    await user.type(screen.getByLabelText('금액'), '10000')
+    await user.click(screen.getByText('추가하기'))
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('error', '설명을 입력해주세요')
+    })
+  })
+
+  it('금액 0으로 제출하면 에러 토스트를 표시한다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getByText(/등록된 반복 거래가 없습니다/)).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('반복 거래 추가'))
+
+    await user.type(screen.getByLabelText('설명'), '테스트')
+    // 금액을 입력하지 않음 (기본 빈 문자열)
+    await user.click(screen.getByText('추가하기'))
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('error', '올바른 금액을 입력해주세요')
+    })
+  })
+
+  // ==================== API 에러 ====================
+
+  it('바로 등록 실패 시 에러 토스트를 표시한다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+      http.post('/api/recurring/1/execute', () =>
+        HttpResponse.json({ detail: 'Error' }, { status: 500 })
+      ),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    const executeBtns = screen.getAllByTitle('바로 등록')
+    await user.click(executeBtns[0])
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('error', '등록에 실패했습니다')
+    })
+  })
+
+  it('토글 실패 시 에러 토스트를 표시한다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+      http.put('/api/recurring/1', () =>
+        HttpResponse.json({ detail: 'Error' }, { status: 500 })
+      ),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    const pauseBtns = screen.getAllByTitle('중지')
+    await user.click(pauseBtns[0])
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('error', '변경에 실패했습니다')
     })
   })
 })


### PR DESCRIPTION
## Summary

41개 FE 테스트 추가 (MyAccountSection +15, RecurringModal +14, RecurringList +12)

## Test plan

- [x] 970 tests passed
- [x] lint 0 에러, build 성공
- [ ] CI 통과

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)