### PR TITLE
test: FE analytics/sentry/HouseholdDetail 커버리지 마무리 (#401)

### DIFF
--- a/frontend/src/pages/__tests__/HouseholdDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/HouseholdDetailPage.test.tsx
@@ -1,18 +1,24 @@
 /**
  * @file HouseholdDetailPage.test.tsx
  * @description 공유 가계부 상세 페이지 테스트
+ * 탭 전환, 로딩/에러 상태, 권한별 UI를 검증한다.
  */
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import HouseholdDetailPage from '../HouseholdDetailPage'
 
-const mockHousehold = {
+/* ------------------------------------------------------------------ */
+/*  모킹 데이터 — 테스트마다 storeState를 변경하여 다양한 시나리오 검증  */
+/* ------------------------------------------------------------------ */
+
+const baseMockHousehold = {
   id: 1,
   name: '우리집',
   description: '가족 가계부',
-  my_role: 'owner',
+  my_role: 'owner' as string,
   members: [
     {
       user_id: 1,
@@ -31,18 +37,25 @@ const mockHousehold = {
   ],
 }
 
-const fetchHouseholdDetail = vi.fn().mockResolvedValue(mockHousehold)
+const fetchHouseholdDetail = vi.fn().mockResolvedValue(baseMockHousehold)
+const fetchHouseholdInvitations = vi.fn().mockResolvedValue(undefined)
 const clearCurrentHousehold = vi.fn()
 const clearError = vi.fn()
+const addToast = vi.fn()
+
+/** 테스트마다 변경할 수 있는 스토어 상태 */
+let storeState: {
+  currentHousehold: typeof baseMockHousehold | null
+  isLoading: boolean
+  error: string | null
+  householdInvitations: Array<{ id: number; invitee_email: string; status: string; token: string }>
+}
 
 vi.mock('../../stores/useHouseholdStore', () => ({
   useHouseholdStore: () => ({
-    currentHousehold: mockHousehold,
-    isLoading: false,
-    error: null,
-    householdInvitations: [],
+    ...storeState,
     fetchHouseholdDetail,
-    fetchHouseholdInvitations: vi.fn().mockResolvedValue(undefined),
+    fetchHouseholdInvitations,
     updateHousehold: vi.fn(),
     deleteHousehold: vi.fn(),
     inviteMember: vi.fn(),
@@ -56,7 +69,7 @@ vi.mock('../../stores/useHouseholdStore', () => ({
 }))
 
 vi.mock('../../hooks/useToast', () => ({
-  useToast: () => ({ addToast: vi.fn() }),
+  useToast: () => ({ addToast }),
 }))
 
 vi.mock('../../contexts/AuthContext', () => ({
@@ -73,10 +86,26 @@ function renderPage() {
   )
 }
 
+/* ------------------------------------------------------------------ */
+/*  테스트                                                              */
+/* ------------------------------------------------------------------ */
+
 describe('HouseholdDetailPage', () => {
-  it('가구 역할 뱃지를 표시한다', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // 기본 상태: owner, 로딩 완료, 에러 없음
+    storeState = {
+      currentHousehold: { ...baseMockHousehold, my_role: 'owner' },
+      isLoading: false,
+      error: null,
+      householdInvitations: [],
+    }
+  })
+
+  /* ---------- 기본 렌더링 ---------- */
+
+  it('가구 역할 뱃지를 표시한다', () => {
     renderPage()
-    // 헤더의 역할 뱃지 + 테이블의 역할 뱃지 모두 표시됨
     expect(screen.getAllByText('소유자').length).toBeGreaterThan(0)
   })
 
@@ -87,7 +116,6 @@ describe('HouseholdDetailPage', () => {
 
   it('멤버 탭이 기본 선택되어 있다', () => {
     renderPage()
-    // "멤버" 텍스트는 탭 + 테이블 역할 드롭다운에 모두 존재
     expect(screen.getAllByText('멤버').length).toBeGreaterThan(0)
   })
 
@@ -103,7 +131,73 @@ describe('HouseholdDetailPage', () => {
     expect(screen.getByText('kim@example.com')).toBeInTheDocument()
   })
 
-  it('소유자에게 초대 탭과 설정 탭을 표시한다', () => {
+  it('가구 정보 로드를 요청한다', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(fetchHouseholdDetail).toHaveBeenCalledWith(1)
+    })
+  })
+
+  it('자기 자신은 (나) 표시가 된다', () => {
+    renderPage()
+    expect(screen.getByText('(나)')).toBeInTheDocument()
+  })
+
+  it('설명이 없으면 설명 영역을 표시하지 않는다', () => {
+    storeState.currentHousehold = { ...baseMockHousehold, description: '', my_role: 'owner' }
+    renderPage()
+    expect(screen.queryByText('가족 가계부')).not.toBeInTheDocument()
+  })
+
+  /* ---------- 로딩 상태 ---------- */
+
+  it('로딩 중이고 데이터가 없으면 로딩 스피너를 표시한다', () => {
+    storeState.isLoading = true
+    storeState.currentHousehold = null
+    renderPage()
+    // LoadingSpinner 컴포넌트의 animate-spin 요소가 렌더링된다
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('로딩 중이지만 데이터가 있으면 콘텐츠를 표시한다', () => {
+    storeState.isLoading = true
+    // currentHousehold는 기본값(있음)
+    renderPage()
+    expect(screen.getByText('홍길동')).toBeInTheDocument()
+  })
+
+  /* ---------- 에러 상태 ---------- */
+
+  it('에러가 있고 데이터가 없으면 ErrorState를 표시한다', () => {
+    storeState.error = '서버 에러'
+    storeState.currentHousehold = null
+    renderPage()
+    // ErrorState의 재시도 버튼
+    expect(screen.getByText('다시 시도')).toBeInTheDocument()
+  })
+
+  it('에러가 있지만 데이터가 있으면 콘텐츠를 표시하고 토스트를 호출한다', () => {
+    storeState.error = '서버 에러'
+    renderPage()
+    // 콘텐츠는 표시됨
+    expect(screen.getByText('홍길동')).toBeInTheDocument()
+    // error useEffect가 토스트를 호출
+    expect(addToast).toHaveBeenCalledWith('error', '처리에 실패했습니다')
+    expect(clearError).toHaveBeenCalled()
+  })
+
+  /* ---------- 가구 정보 없음 ---------- */
+
+  it('가구 데이터가 null이면 EmptyState를 표시한다', () => {
+    storeState.currentHousehold = null
+    renderPage()
+    expect(screen.getByText('가구를 찾을 수 없습니다')).toBeInTheDocument()
+    expect(screen.getByText('가구 목록으로')).toBeInTheDocument()
+  })
+
+  /* ---------- 소유자 권한 ---------- */
+
+  it('소유자에게 초대/설정 탭을 표시한다', () => {
     renderPage()
     expect(screen.getByRole('button', { name: /초대/ })).toBeInTheDocument()
     expect(screen.getByText('설정')).toBeInTheDocument()
@@ -114,15 +208,97 @@ describe('HouseholdDetailPage', () => {
     expect(screen.getByText('추방')).toBeInTheDocument()
   })
 
-  it('자기 자신은 (나) 표시가 된다', () => {
+  /* ---------- 관리자 권한 ---------- */
+
+  it('관리자에게 초대/설정 탭을 표시한다', () => {
+    storeState.currentHousehold = { ...baseMockHousehold, my_role: 'admin' }
     renderPage()
-    expect(screen.getByText('(나)')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /초대/ })).toBeInTheDocument()
+    expect(screen.getByText('설정')).toBeInTheDocument()
   })
 
-  it('가구 정보 로드를 요청한다', async () => {
+  /* ---------- 일반 멤버 권한 ---------- */
+
+  it('일반 멤버에게는 초대/설정 탭을 표시하지 않는다', () => {
+    storeState.currentHousehold = { ...baseMockHousehold, my_role: 'member' }
+    renderPage()
+    // 탭 버튼으로서의 "초대"가 없어야 한다 (멤버 탭의 텍스트와 구분)
+    const tabs = screen.getAllByRole('button')
+    const invitationTab = tabs.find(
+      (btn) => btn.textContent?.includes('초대') && !btn.textContent?.includes('멤버'),
+    )
+    expect(invitationTab).toBeUndefined()
+    expect(screen.queryByText('설정')).not.toBeInTheDocument()
+  })
+
+  it('일반 멤버는 추방 버튼을 볼 수 없다', () => {
+    storeState.currentHousehold = { ...baseMockHousehold, my_role: 'member' }
+    renderPage()
+    expect(screen.queryByText('추방')).not.toBeInTheDocument()
+  })
+
+  /* ---------- 탭 전환 ---------- */
+
+  it('초대 탭을 클릭하면 초대 탭 콘텐츠가 표시된다', async () => {
+    storeState.householdInvitations = [
+      { id: 10, invitee_email: 'new@test.com', status: 'pending', token: 'abc' },
+    ]
+    renderPage()
+
+    const invitationTab = screen.getByRole('button', { name: /초대/ })
+    await userEvent.click(invitationTab)
+
+    // InvitationsTab이 렌더링된다 — "+ 멤버 초대" 버튼이 표시됨
+    expect(screen.getByText('+ 멤버 초대')).toBeInTheDocument()
+  })
+
+  it('설정 탭을 클릭하면 설정 탭 콘텐츠가 표시된다', async () => {
+    renderPage()
+
+    const settingsTab = screen.getByText('설정')
+    await userEvent.click(settingsTab)
+
+    // SettingsTab이 렌더링된다 — "가구 정보" 섹션 제목이 표시됨
+    expect(screen.getByText('가구 정보')).toBeInTheDocument()
+  })
+
+  it('초대 탭에서 pending 초대 수를 뱃지로 표시한다', () => {
+    storeState.householdInvitations = [
+      { id: 10, invitee_email: 'a@test.com', status: 'pending', token: 'abc' },
+      { id: 11, invitee_email: 'b@test.com', status: 'pending', token: 'def' },
+      { id: 12, invitee_email: 'c@test.com', status: 'accepted', token: 'ghi' },
+    ]
+    renderPage()
+
+    // pending 2건 뱃지
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  /* ---------- 언마운트 시 정리 ---------- */
+
+  it('언마운트 시 clearCurrentHousehold를 호출한다', () => {
+    const { unmount } = renderPage()
+    unmount()
+    expect(clearCurrentHousehold).toHaveBeenCalled()
+  })
+
+  /* ---------- admin인 경우 초대 목록 조회 ---------- */
+
+  it('admin인 경우 초대 목록을 조회한다', async () => {
+    storeState.currentHousehold = { ...baseMockHousehold, my_role: 'admin' }
     renderPage()
     await waitFor(() => {
-      expect(fetchHouseholdDetail).toHaveBeenCalledWith(1)
+      expect(fetchHouseholdInvitations).toHaveBeenCalledWith(1)
     })
+  })
+
+  it('일반 멤버인 경우 초대 목록을 조회하지 않는다', async () => {
+    storeState.currentHousehold = { ...baseMockHousehold, my_role: 'member' }
+    renderPage()
+    // fetchHouseholdDetail은 호출되지만 fetchHouseholdInvitations는 호출되지 않아야 한다
+    await waitFor(() => {
+      expect(fetchHouseholdDetail).toHaveBeenCalled()
+    })
+    expect(fetchHouseholdInvitations).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/utils/__tests__/analytics.test.ts
+++ b/frontend/src/utils/__tests__/analytics.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @file analytics.test.ts
+ * @description Google Analytics 4 래퍼 테스트
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { initAnalytics, trackEvent, trackPageView, identifyUser } from '../analytics'
+
+describe('analytics', () => {
+  beforeEach(() => {
+    // _initialized를 리셋하기 위해 모듈을 격리해서 테스트해야 하지만,
+    // 모듈 상태 공유 문제를 피하기 위해 순서를 고려하여 테스트한다.
+    vi.restoreAllMocks()
+    // document.head의 script 태그 정리
+    document.head.querySelectorAll('script').forEach((s) => s.remove())
+    // window 전역 정리
+    delete (window as unknown as Record<string, unknown>).dataLayer
+    delete (window as unknown as Record<string, unknown>).gtag
+  })
+
+  describe('initAnalytics', () => {
+    it('VITE_GA_MEASUREMENT_ID 미설정 시 아무것도 하지 않는다', async () => {
+      vi.stubEnv('VITE_GA_MEASUREMENT_ID', '')
+
+      await initAnalytics()
+
+      // script 태그가 삽입되지 않아야 한다
+      const scripts = document.head.querySelectorAll('script')
+      expect(scripts).toHaveLength(0)
+      expect(window.dataLayer).toBeUndefined()
+    })
+
+    it('Measurement ID 설정 시 gtag.js 스크립트를 삽입하고 초기화한다', async () => {
+      vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-TEST123')
+
+      await initAnalytics()
+
+      // script 태그가 삽입되어야 한다
+      const scripts = document.head.querySelectorAll('script')
+      expect(scripts.length).toBeGreaterThanOrEqual(1)
+      const gtagScript = Array.from(scripts).find((s) =>
+        s.src.includes('googletagmanager.com/gtag/js?id=G-TEST123'),
+      )
+      expect(gtagScript).toBeDefined()
+      expect(gtagScript!.async).toBe(true)
+
+      // dataLayer가 초기화되어야 한다
+      expect(window.dataLayer).toBeDefined()
+      expect(Array.isArray(window.dataLayer)).toBe(true)
+
+      // gtag 함수가 설정되어야 한다
+      expect(typeof window.gtag).toBe('function')
+
+      // gtag('js', ...) + gtag('config', ...) 호출로 dataLayer에 2개 항목이 있어야 한다
+      expect(window.dataLayer!.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('trackEvent / trackPageView / identifyUser — 초기화 전', () => {
+    it('초기화 전에는 trackEvent가 아무것도 하지 않는다', async () => {
+      // 모듈 캐시를 리셋하여 _initialized = false인 새 인스턴스를 얻는다
+      vi.resetModules()
+      const mod = await import('../analytics')
+
+      // 초기화하지 않은 상태에서 호출 — _initialized가 false이므로 early return
+      expect(() => mod.trackEvent('test_event')).not.toThrow()
+      expect(() => mod.trackPageView('/test')).not.toThrow()
+      expect(() => mod.identifyUser('user123')).not.toThrow()
+    })
+  })
+
+  describe('trackEvent / trackPageView / identifyUser — 초기화 후', () => {
+    beforeEach(async () => {
+      vi.stubEnv('VITE_GA_MEASUREMENT_ID', 'G-TEST123')
+      await initAnalytics()
+      // 실제 gtag를 spy로 교체 (dataLayer.push를 추적)
+      vi.spyOn(window, 'gtag')
+    })
+
+    it('trackEvent가 gtag("event", ...)를 호출한다', () => {
+      trackEvent('purchase', { value: 100 })
+
+      expect(window.gtag).toHaveBeenCalledWith('event', 'purchase', { value: 100 })
+    })
+
+    it('trackEvent를 파라미터 없이 호출할 수 있다', () => {
+      trackEvent('click')
+
+      expect(window.gtag).toHaveBeenCalledWith('event', 'click', undefined)
+    })
+
+    it('trackPageView가 gtag("event", "page_view", ...)를 호출한다', () => {
+      trackPageView('/dashboard')
+
+      expect(window.gtag).toHaveBeenCalledWith('event', 'page_view', {
+        page_path: '/dashboard',
+      })
+    })
+
+    it('identifyUser가 gtag("set", { user_id })를 호출한다', () => {
+      identifyUser('user-42')
+
+      expect(window.gtag).toHaveBeenCalledWith('set', { user_id: 'user-42' })
+    })
+  })
+})

--- a/frontend/src/utils/__tests__/sentry.test.ts
+++ b/frontend/src/utils/__tests__/sentry.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @file sentry.test.ts
+ * @description Sentry 지연 로딩 래퍼 테스트
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// @sentry/react 모킹
+const mockInit = vi.fn()
+const mockCaptureException = vi.fn()
+const mockBrowserTracingIntegration = vi.fn().mockReturnValue('browserTracing')
+const mockReplayIntegration = vi.fn().mockReturnValue('replay')
+const MockErrorBoundary = () => null
+MockErrorBoundary.displayName = 'SentryErrorBoundary'
+
+vi.mock('@sentry/react', () => ({
+  init: mockInit,
+  captureException: mockCaptureException,
+  browserTracingIntegration: mockBrowserTracingIntegration,
+  replayIntegration: mockReplayIntegration,
+  ErrorBoundary: MockErrorBoundary,
+}))
+
+describe('sentry', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+    mockInit.mockClear()
+    mockCaptureException.mockClear()
+  })
+
+  describe('initSentry', () => {
+    it('VITE_SENTRY_DSN 미설정 시 초기화하지 않는다', async () => {
+      vi.stubEnv('VITE_SENTRY_DSN', '')
+
+      const { initSentry } = await import('../sentry')
+      await initSentry()
+
+      expect(mockInit).not.toHaveBeenCalled()
+    })
+
+    it('DSN 설정 시 Sentry.init을 호출한다', async () => {
+      vi.stubEnv('VITE_SENTRY_DSN', 'https://test@sentry.io/123')
+      vi.stubEnv('VITE_SENTRY_ENVIRONMENT', 'test')
+
+      const { initSentry } = await import('../sentry')
+      await initSentry()
+
+      expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dsn: 'https://test@sentry.io/123',
+          environment: 'test',
+          integrations: ['browserTracing', 'replay'],
+          replaysOnErrorSampleRate: 1.0,
+        }),
+      )
+    })
+
+    it('환경 미설정 시 development로 기본값을 사용한다', async () => {
+      vi.stubEnv('VITE_SENTRY_DSN', 'https://test@sentry.io/123')
+      vi.stubEnv('VITE_SENTRY_ENVIRONMENT', '')
+
+      const { initSentry } = await import('../sentry')
+      await initSentry()
+
+      expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environment: 'development',
+        }),
+      )
+    })
+  })
+
+  describe('captureException', () => {
+    it('Sentry 미로드 시 에러 없이 무시한다', async () => {
+      vi.stubEnv('VITE_SENTRY_DSN', '')
+
+      const { initSentry, captureException } = await import('../sentry')
+      await initSentry()
+
+      // captureException 호출 — 에러 없이 no-op
+      expect(() => captureException(new Error('test'))).not.toThrow()
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    it('Sentry 로드 후 captureException을 호출한다', async () => {
+      vi.stubEnv('VITE_SENTRY_DSN', 'https://test@sentry.io/123')
+
+      const { initSentry, captureException } = await import('../sentry')
+      await initSentry()
+
+      const error = new Error('테스트 에러')
+      captureException(error)
+
+      expect(mockCaptureException).toHaveBeenCalledWith(error)
+    })
+  })
+
+  describe('getErrorBoundary', () => {
+    it('Sentry 미로드 시 null을 반환한다', async () => {
+      vi.stubEnv('VITE_SENTRY_DSN', '')
+
+      const { initSentry, getErrorBoundary } = await import('../sentry')
+      await initSentry()
+
+      expect(getErrorBoundary()).toBeNull()
+    })
+
+    it('Sentry 로드 후 ErrorBoundary 컴포넌트를 반환한다', async () => {
+      vi.stubEnv('VITE_SENTRY_DSN', 'https://test@sentry.io/123')
+
+      const { initSentry, getErrorBoundary } = await import('../sentry')
+      await initSentry()
+
+      const EB = getErrorBoundary()
+      expect(EB).toBe(MockErrorBoundary)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

29개 FE 테스트 추가 (analytics 7 + sentry 7 + HouseholdDetailPage 15)

## Test plan

- [x] 956 tests passed
- [x] lint 0 에러, build 성공
- [ ] CI 통과

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)