### PR TITLE
test: BE 커버리지 86→93% (#427)

### DIFF
--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    */api/e2e.py
+concurrency = greenlet

--- a/backend/tests/integration/test_api_accounts_coverage.py
+++ b/backend/tests/integration/test_api_accounts_coverage.py
@@ -1,0 +1,120 @@
+"""계좌 CRUD 커버리지 테스트
+
+api/accounts.py 미커버 라인: 27-28, 40-41, 52-60, 76-79, 94-97
+"""
+
+import pytest
+
+from app.models.account import Account
+
+
+@pytest.mark.asyncio
+async def test_create_account(authenticated_client, test_user, test_household, db_session):
+    """계좌 등록"""
+    resp = await authenticated_client.post(
+        "/api/accounts",
+        json={
+            "name": "KB국민은행",
+            "type": "bank",
+            "institution": "KB",
+            "memo": "주거래",
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "KB국민은행"
+    assert data["type"] == "bank"
+
+
+@pytest.mark.asyncio
+async def test_get_accounts(authenticated_client, test_user, test_household, db_session):
+    """계좌 목록 조회"""
+    acc = Account(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="키움증권",
+        type="brokerage",
+    )
+    db_session.add(acc)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/accounts")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_account_detail(authenticated_client, test_user, test_household, db_session):
+    """계좌 상세 조회"""
+    acc = Account(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="업비트",
+        type="crypto_exchange",
+    )
+    db_session.add(acc)
+    await db_session.commit()
+    await db_session.refresh(acc)
+
+    resp = await authenticated_client.get(f"/api/accounts/{acc.id}")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "업비트"
+
+
+@pytest.mark.asyncio
+async def test_get_account_not_found(authenticated_client):
+    """존재하지 않는 계좌 조회 → 404"""
+    resp = await authenticated_client.get("/api/accounts/99999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_account(authenticated_client, test_user, test_household, db_session):
+    """계좌 수정"""
+    acc = Account(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="원본",
+        type="bank",
+    )
+    db_session.add(acc)
+    await db_session.commit()
+    await db_session.refresh(acc)
+
+    resp = await authenticated_client.put(
+        f"/api/accounts/{acc.id}",
+        json={"name": "수정됨", "memo": "메모 추가"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "수정됨"
+
+
+@pytest.mark.asyncio
+async def test_update_account_not_found(authenticated_client):
+    """존재하지 않는 계좌 수정 → 404"""
+    resp = await authenticated_client.put("/api/accounts/99999", json={"name": "테스트"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_account(authenticated_client, test_user, test_household, db_session):
+    """계좌 삭제"""
+    acc = Account(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="삭제할 계좌",
+        type="other",
+    )
+    db_session.add(acc)
+    await db_session.commit()
+    await db_session.refresh(acc)
+
+    resp = await authenticated_client.delete(f"/api/accounts/{acc.id}")
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_account_not_found(authenticated_client):
+    """존재하지 않는 계좌 삭제 → 404"""
+    resp = await authenticated_client.delete("/api/accounts/99999")
+    assert resp.status_code == 404

--- a/backend/tests/integration/test_api_categories_crud.py
+++ b/backend/tests/integration/test_api_categories_crud.py
@@ -1,0 +1,130 @@
+"""카테고리 CRUD 커버리지 테스트
+
+api/categories.py 미커버 라인: 61-68, 82-96, 112-134, 151-172, 188-204
+"""
+
+import pytest
+
+from app.models.category import Category
+
+
+@pytest.mark.asyncio
+async def test_create_category(authenticated_client, test_user, test_household, db_session):
+    """카테고리 생성"""
+    resp = await authenticated_client.post(
+        "/api/categories",
+        json={"name": "테스트카테고리", "type": "expense"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "테스트카테고리"
+    assert data["is_system"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_category(authenticated_client, test_user, test_household, db_session):
+    """중복 카테고리 생성 → 400"""
+    cat = Category(name="식비", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.commit()
+
+    resp = await authenticated_client.post(
+        "/api/categories",
+        json={"name": "식비", "type": "expense"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reorder_categories(authenticated_client, test_user, test_household, db_session):
+    """카테고리 순서 변경"""
+    cats = []
+    for name in ("A카테고리", "B카테고리", "C카테고리"):
+        cat = Category(name=name, type="expense", household_id=test_household.id)
+        db_session.add(cat)
+        cats.append(cat)
+    await db_session.commit()
+    for c in cats:
+        await db_session.refresh(c)
+
+    resp = await authenticated_client.put(
+        "/api/categories/reorder",
+        json={"category_ids": [cats[2].id, cats[0].id, cats[1].id]},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_reorder_inaccessible_category(authenticated_client, test_user, test_household, db_session):
+    """접근 불가 카테고리 순서 변경 → 400"""
+    resp = await authenticated_client.put(
+        "/api/categories/reorder",
+        json={"category_ids": [99999]},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_category(authenticated_client, test_user, test_household, db_session):
+    """카테고리 수정"""
+    cat = Category(name="원본", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    resp = await authenticated_client.put(
+        f"/api/categories/{cat.id}",
+        json={"name": "수정됨"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "수정됨"
+
+
+@pytest.mark.asyncio
+async def test_update_category_not_found(authenticated_client, test_user, test_household, db_session):
+    """존재하지 않는 카테고리 수정 → 404"""
+    resp = await authenticated_client.put("/api/categories/99999", json={"name": "테스트"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_system_category(authenticated_client, test_user, test_household, db_session):
+    """시스템 카테고리 수정 → 403"""
+    cat = Category(name="시스템카테고리", type="expense", user_id=None, household_id=None)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    resp = await authenticated_client.put(f"/api/categories/{cat.id}", json={"name": "변경"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_category(authenticated_client, test_user, test_household, db_session):
+    """카테고리 삭제"""
+    cat = Category(name="삭제용", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    resp = await authenticated_client.delete(f"/api/categories/{cat.id}")
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_category_not_found(authenticated_client, test_user, test_household, db_session):
+    """존재하지 않는 카테고리 삭제 → 404"""
+    resp = await authenticated_client.delete("/api/categories/99999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_system_category(authenticated_client, test_user, test_household, db_session):
+    """시스템 카테고리 삭제 → 403"""
+    cat = Category(name="시스템", type="expense", user_id=None, household_id=None)
+    db_session.add(cat)
+    await db_session.commit()
+    await db_session.refresh(cat)
+
+    resp = await authenticated_client.delete(f"/api/categories/{cat.id}")
+    assert resp.status_code == 403

--- a/backend/tests/integration/test_api_chat_coverage.py
+++ b/backend/tests/integration/test_api_chat_coverage.py
@@ -1,0 +1,151 @@
+"""채팅 API 커버리지 테스트
+
+api/chat.py 미커버 라인: 54-58, 98-100, 130-170, 200, 225-230
+"""
+
+import pytest
+
+from app.models.category import Category
+
+
+@pytest.mark.asyncio
+async def test_chat_parse_error(authenticated_client, test_user, test_household, db_session, mock_llm_parse_expense):
+    """LLM 파싱 에러 응답"""
+    mock_llm_parse_expense.return_value = {"error": "금액을 찾을 수 없습니다"}
+
+    resp = await authenticated_client.post(
+        "/api/chat",
+        json={"message": "뭔가 이상한 입력"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "금액을 찾을 수 없습니다" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_chat_invalid_response(authenticated_client, test_user, test_household, db_session, mock_llm_parse_expense):
+    """LLM 유효하지 않은 응답 형식"""
+    mock_llm_parse_expense.return_value = "invalid_string"
+
+    resp = await authenticated_client.post(
+        "/api/chat",
+        json={"message": "테스트"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "알 수 없는 응답 형식" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_chat_preview_mode(authenticated_client, test_user, test_household, db_session, mock_llm_parse_expense):
+    """프리뷰 모드: DB 저장 안 함"""
+    mock_llm_parse_expense.return_value = {
+        "amount": 8000,
+        "category": "식비",
+        "description": "김치찌개",
+        "date": "2026-03-25",
+        "memo": "",
+    }
+
+    resp = await authenticated_client.post(
+        "/api/chat",
+        json={"message": "오늘 점심 김치찌개 8000원", "preview": True},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "인식했습니다" in data["message"]
+    assert data["parsed_items"] is not None
+    assert data["expenses_created"] is None
+
+
+@pytest.mark.asyncio
+async def test_chat_preview_with_income(authenticated_client, test_user, test_household, db_session, mock_llm_parse_expense):
+    """프리뷰 모드: 수입 + 지출 혼합"""
+    mock_llm_parse_expense.return_value = [
+        {"amount": 8000, "category": "식비", "description": "점심", "date": "2026-03-25", "type": "expense"},
+        {"amount": 3000000, "category": "급여", "description": "월급", "date": "2026-03-25", "type": "income"},
+    ]
+
+    resp = await authenticated_client.post(
+        "/api/chat",
+        json={"message": "점심 8000원, 월급 300만원", "preview": True},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "지출" in data["message"]
+    assert "수입" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_chat_save_mode(authenticated_client, test_user, test_household, db_session, mock_llm_parse_expense):
+    """저장 모드: DB에 저장"""
+    # 카테고리 생성
+    cat = Category(name="식비", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.commit()
+
+    mock_llm_parse_expense.return_value = {
+        "amount": 8000,
+        "category": "식비",
+        "description": "김치찌개",
+        "date": "2026-03-25",
+        "memo": "",
+    }
+
+    resp = await authenticated_client.post(
+        "/api/chat",
+        json={"message": "오늘 점심 김치찌개 8000원", "preview": False},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "기록되었습니다" in data["message"]
+    assert data["expenses_created"] is not None
+
+
+@pytest.mark.asyncio
+async def test_chat_save_multiple(authenticated_client, test_user, test_household, db_session, mock_llm_parse_expense):
+    """저장 모드: 여러 건 동시 저장"""
+    cat = Category(name="식비", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.commit()
+
+    mock_llm_parse_expense.return_value = [
+        {"amount": 8000, "category": "식비", "description": "점심", "date": "2026-03-25", "type": "expense"},
+        {"amount": 5000, "category": "식비", "description": "간식", "date": "2026-03-25", "type": "expense"},
+    ]
+
+    resp = await authenticated_client.post(
+        "/api/chat",
+        json={"message": "점심 8000원 간식 5000원"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "기록되었습니다" in data["message"]
+    assert data["expenses_created"] is not None
+    assert len(data["expenses_created"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_chat_save_income(authenticated_client, test_user, test_household, db_session, mock_llm_parse_expense):
+    """저장 모드: 수입 저장"""
+    cat = Category(name="급여", type="income", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.commit()
+
+    mock_llm_parse_expense.return_value = {
+        "amount": 3000000,
+        "category": "급여",
+        "description": "월급",
+        "date": "2026-03-25",
+        "type": "income",
+        "memo": "",
+    }
+
+    resp = await authenticated_client.post(
+        "/api/chat",
+        json={"message": "월급 300만원"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "수입" in data["message"]
+    assert data["incomes_created"] is not None

--- a/backend/tests/integration/test_api_expenses_crud.py
+++ b/backend/tests/integration/test_api_expenses_crud.py
@@ -1,0 +1,456 @@
+"""지출 CRUD + 통계 + 검색 + OCR 커버리지 테스트
+
+api/expenses.py 미커버 라인 커버:
+- 101-107 (create_expense)
+- 134-146 (get_expenses with filters)
+- 190-256 (stats)
+- 291-296, 304-306, 317-417 (stats comparison)
+- 446-477 (monthly stats)
+- 534-574 (OCR)
+- 577, 601-615 (search summary)
+- 630-646 (get_expense detail)
+- 662-690 (update_expense)
+- 705-729 (delete_expense)
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.category import Category
+from app.models.expense import Expense
+
+
+@pytest.mark.asyncio
+async def test_create_expense(authenticated_client, test_user, test_household, db_session):
+    """지출 생성"""
+    resp = await authenticated_client.post(
+        "/api/expenses",
+        json={
+            "amount": 8000,
+            "description": "김치찌개",
+            "date": "2026-03-25T12:00:00",
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["amount"] == 8000
+
+
+@pytest.mark.asyncio
+async def test_get_expenses_with_filters(authenticated_client, test_user, test_household, db_session):
+    """지출 목록 조회 + 필터"""
+    cat = Category(name="식비", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    for i in range(3):
+        exp = Expense(
+            user_id=test_user.id,
+            household_id=test_household.id,
+            amount=10000 * (i + 1),
+            description=f"지출 {i}",
+            category_id=cat.id,
+            date=datetime(2026, 3, 10 + i),
+        )
+        db_session.add(exp)
+    await db_session.commit()
+
+    # 날짜 필터 (날짜만, 시간 없는 end_date)
+    resp = await authenticated_client.get("/api/expenses?start_date=2026-03-10&end_date=2026-03-11")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+    # 카테고리 필터
+    resp = await authenticated_client.get(f"/api/expenses?category_id={cat.id}")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+
+    # 텍스트 검색
+    resp = await authenticated_client.get("/api/expenses?query=지출 1")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # 멤버별 필터
+    resp = await authenticated_client.get(f"/api/expenses?member_user_id={test_user.id}")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_expense_stats_weekly(authenticated_client, test_user, test_household, db_session):
+    """지출 주간 통계"""
+    cat = Category(name="식비", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=50000,
+        description="식비",
+        category_id=cat.id,
+        date=datetime(2026, 3, 23),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/expenses/stats?period=weekly&date=2026-03-23")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 50000
+    assert data["count"] == 1
+    assert len(data["by_category"]) == 1
+    assert len(data["trend"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_expense_stats_monthly(authenticated_client, test_user, test_household, db_session):
+    """지출 월간 통계"""
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=80000,
+        description="테스트",
+        date=datetime(2026, 3, 15),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/expenses/stats?period=monthly&date=2026-03-15")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 80000
+
+
+@pytest.mark.asyncio
+async def test_expense_stats_yearly(authenticated_client, test_user, test_household, db_session):
+    """지출 연간 통계 (월별 트렌드 포함)"""
+    for m in (1, 2, 3):
+        exp = Expense(
+            user_id=test_user.id,
+            household_id=test_household.id,
+            amount=100000 * m,
+            description=f"{m}월 지출",
+            date=datetime(2026, m, 15),
+        )
+        db_session.add(exp)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/expenses/stats?period=yearly&date=2026-03-15")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 600000
+    assert len(data["trend"]) == 12
+
+
+@pytest.mark.asyncio
+async def test_expense_stats_comparison_monthly(authenticated_client, test_user, test_household, db_session):
+    """지출 월간 비교"""
+    cat = Category(name="식비", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    # 2월 지출
+    exp_prev = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=200000,
+        description="2월 식비",
+        category_id=cat.id,
+        date=datetime(2026, 2, 15),
+    )
+    db_session.add(exp_prev)
+
+    # 3월 지출
+    exp_cur = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=300000,
+        description="3월 식비",
+        category_id=cat.id,
+        date=datetime(2026, 3, 15),
+    )
+    db_session.add(exp_cur)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/expenses/stats/comparison?period=monthly&date=2026-03-15&months=3")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["current"]["total"] == 300000
+    assert data["previous"]["total"] == 200000
+    assert data["change"]["amount"] == 100000
+    assert len(data["trend"]) == 3
+    assert len(data["by_category_comparison"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_expense_stats_comparison_yearly(authenticated_client, test_user, test_household, db_session):
+    """지출 연간 비교"""
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=5000000,
+        description="올해 지출",
+        date=datetime(2026, 3, 15),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/expenses/stats/comparison?period=yearly&date=2026-03-15&months=3")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["current"]["total"] == 5000000
+    assert len(data["trend"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_expense_monthly_stats(authenticated_client, test_user, test_household, db_session):
+    """월별 지출 통계 (/stats/monthly)"""
+    cat = Category(name="교통", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=50000,
+        description="교통비",
+        category_id=cat.id,
+        date=datetime(2026, 3, 20),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/expenses/stats/monthly?month=2026-03")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 50000
+    assert data["month"] == "2026-03"
+    assert len(data["by_category"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_expense_search_summary(authenticated_client, test_user, test_household, db_session):
+    """지출 검색 요약"""
+    for i in range(3):
+        exp = Expense(
+            user_id=test_user.id,
+            household_id=test_household.id,
+            amount=10000 * (i + 1),
+            description=f"항목{i}",
+            date=datetime(2026, 3, 10 + i),
+        )
+        db_session.add(exp)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/expenses/search/summary")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_count"] == 3
+    assert data["total_amount"] == 60000
+
+
+@pytest.mark.asyncio
+async def test_get_expense_detail(authenticated_client, test_user, test_household, db_session):
+    """지출 상세 조회"""
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=15000,
+        description="점심",
+        date=datetime(2026, 3, 25),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+    await db_session.refresh(exp)
+
+    resp = await authenticated_client.get(f"/api/expenses/{exp.id}")
+    assert resp.status_code == 200
+    assert resp.json()["amount"] == 15000
+
+
+@pytest.mark.asyncio
+async def test_get_expense_not_found(authenticated_client):
+    """존재하지 않는 지출 조회 → 404"""
+    resp = await authenticated_client.get("/api/expenses/99999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_expense(authenticated_client, test_user, test_household, db_session):
+    """지출 수정"""
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=8000,
+        description="김치찌개",
+        date=datetime(2026, 3, 25),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+    await db_session.refresh(exp)
+
+    resp = await authenticated_client.put(
+        f"/api/expenses/{exp.id}",
+        json={"amount": 9000, "description": "된장찌개"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["amount"] == 9000
+    assert data["description"] == "된장찌개"
+
+
+@pytest.mark.asyncio
+async def test_update_expense_not_found(authenticated_client):
+    """존재하지 않는 지출 수정 → 404"""
+    resp = await authenticated_client.put("/api/expenses/99999", json={"amount": 1000})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_expense_other_user_member_role(authenticated_client2, test_user, test_user2, test_household, db_session):
+    """타인 지출 수정 시 member 역할이면 403"""
+    from app.models.household_member import HouseholdMember
+
+    m = HouseholdMember(household_id=test_household.id, user_id=test_user2.id, role="member")
+    db_session.add(m)
+    await db_session.flush()
+
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=8000,
+        description="테스트",
+        date=datetime(2026, 3, 25),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+    await db_session.refresh(exp)
+
+    resp = await authenticated_client2.put(f"/api/expenses/{exp.id}", json={"amount": 1})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_expense(authenticated_client, test_user, test_household, db_session):
+    """지출 삭제"""
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=8000,
+        description="삭제할 지출",
+        date=datetime(2026, 3, 25),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+    await db_session.refresh(exp)
+
+    resp = await authenticated_client.delete(f"/api/expenses/{exp.id}")
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_expense_not_found(authenticated_client):
+    """존재하지 않는 지출 삭제 → 404"""
+    resp = await authenticated_client.delete("/api/expenses/99999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_expense_other_user_member_role(authenticated_client2, test_user, test_user2, test_household, db_session):
+    """타인 지출 삭제 시 member 역할이면 403"""
+    from app.models.household_member import HouseholdMember
+
+    m = HouseholdMember(household_id=test_household.id, user_id=test_user2.id, role="member")
+    db_session.add(m)
+    await db_session.flush()
+
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=8000,
+        description="테스트",
+        date=datetime(2026, 3, 25),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+    await db_session.refresh(exp)
+
+    resp = await authenticated_client2.delete(f"/api/expenses/{exp.id}")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_ocr_parse_expense_image(authenticated_client, test_user, test_household, db_session):
+    """OCR 이미지 파싱 — 정상 케이스"""
+    # 유효한 PNG 매직 바이트가 있는 더미 이미지
+    png_magic = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+    mock_parsed = {
+        "amount": 15000,
+        "description": "스타벅스",
+        "category": "카페",
+        "date": "2026-03-25",
+        "memo": "",
+    }
+
+    with patch("app.api.expenses.get_llm_provider") as mock_provider:
+        mock_llm = AsyncMock()
+        mock_llm.parse_image.return_value = mock_parsed
+        mock_provider.return_value = mock_llm
+
+        resp = await authenticated_client.post(
+            "/api/expenses/ocr",
+            files={"file": ("receipt.png", png_magic, "image/png")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "인식했습니다" in data["message"]
+        assert data["parsed_items"] is not None
+        assert len(data["parsed_items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_ocr_invalid_content_type(authenticated_client, test_user, test_household, db_session):
+    """OCR 잘못된 Content-Type → 400"""
+    resp = await authenticated_client.post(
+        "/api/expenses/ocr",
+        files={"file": ("doc.pdf", b"%PDF-1.4", "application/pdf")},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_ocr_error_response(authenticated_client, test_user, test_household, db_session):
+    """OCR 에러 응답 처리"""
+    png_magic = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+    with patch("app.api.expenses.get_llm_provider") as mock_provider:
+        mock_llm = AsyncMock()
+        mock_llm.parse_image.return_value = {"error": "이미지를 인식할 수 없습니다"}
+        mock_provider.return_value = mock_llm
+
+        resp = await authenticated_client.post(
+            "/api/expenses/ocr",
+            files={"file": ("receipt.png", png_magic, "image/png")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "인식할 수 없습니다" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_ocr_not_implemented(authenticated_client, test_user, test_household, db_session):
+    """OCR NotImplementedError → 501"""
+    png_magic = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+    with patch("app.api.expenses.get_llm_provider") as mock_provider:
+        mock_llm = AsyncMock()
+        mock_llm.parse_image.side_effect = NotImplementedError("Not supported")
+        mock_provider.return_value = mock_llm
+
+        resp = await authenticated_client.post(
+            "/api/expenses/ocr",
+            files={"file": ("receipt.png", png_magic, "image/png")},
+        )
+        assert resp.status_code == 501

--- a/backend/tests/integration/test_api_feedback_coverage.py
+++ b/backend/tests/integration/test_api_feedback_coverage.py
@@ -1,0 +1,127 @@
+"""피드백 CRUD 커버리지 테스트
+
+api/feedback.py 미커버 라인: 62-77, 87-88, 107-108, 125-138
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.config import settings
+from app.models.feedback import Feedback
+
+
+@pytest.mark.asyncio
+async def test_create_feedback(authenticated_client, test_user, test_household, db_session):
+    """피드백 제출"""
+    with patch("app.api.feedback.notify_admin_feedback", new_callable=AsyncMock):
+        resp = await authenticated_client.post(
+            "/api/feedback",
+            json={
+                "type": "feature",
+                "title": "새 기능 요청",
+                "content": "다크모드 추가해주세요",
+            },
+        )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["title"] == "새 기능 요청"
+    assert data["status"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_get_my_feedbacks(authenticated_client, test_user, test_household, db_session):
+    """내 피드백 목록 조회"""
+    fb = Feedback(
+        user_id=test_user.id,
+        type="bug",
+        title="버그",
+        content="테스트 버그",
+    )
+    db_session.add(fb)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/feedback/mine")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["title"] == "버그"
+
+
+@pytest.mark.asyncio
+async def test_get_all_feedbacks_admin(authenticated_client, test_user, test_household, db_session):
+    """관리자 전체 피드백 조회"""
+    fb = Feedback(user_id=test_user.id, type="feature", title="요청", content="내용")
+    db_session.add(fb)
+    await db_session.commit()
+
+    original = settings.ADMIN_USER_ID
+    settings.ADMIN_USER_ID = test_user.id
+    try:
+        resp = await authenticated_client.get("/api/feedback")
+        assert resp.status_code == 200
+        assert len(resp.json()) >= 1
+    finally:
+        settings.ADMIN_USER_ID = original
+
+
+@pytest.mark.asyncio
+async def test_get_all_feedbacks_non_admin(authenticated_client, test_user, test_household, db_session):
+    """비관리자 전체 피드백 조회 → 403"""
+    original = settings.ADMIN_USER_ID
+    settings.ADMIN_USER_ID = 99999
+    try:
+        resp = await authenticated_client.get("/api/feedback")
+        assert resp.status_code == 403
+    finally:
+        settings.ADMIN_USER_ID = original
+
+
+@pytest.mark.asyncio
+async def test_update_feedback_status(authenticated_client, test_user, test_household, db_session):
+    """피드백 상태 변경 (관리자)"""
+    fb = Feedback(user_id=test_user.id, type="bug", title="버그", content="버그 내용")
+    db_session.add(fb)
+    await db_session.commit()
+    await db_session.refresh(fb)
+
+    original = settings.ADMIN_USER_ID
+    settings.ADMIN_USER_ID = test_user.id
+    try:
+        resp = await authenticated_client.patch(
+            f"/api/feedback/{fb.id}",
+            json={"status": "done"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "done"
+    finally:
+        settings.ADMIN_USER_ID = original
+
+
+@pytest.mark.asyncio
+async def test_update_feedback_status_non_admin(authenticated_client, test_user, test_household, db_session):
+    """비관리자 피드백 상태 변경 → 403"""
+    fb = Feedback(user_id=test_user.id, type="bug", title="버그", content="내용")
+    db_session.add(fb)
+    await db_session.commit()
+    await db_session.refresh(fb)
+
+    original = settings.ADMIN_USER_ID
+    settings.ADMIN_USER_ID = 99999
+    try:
+        resp = await authenticated_client.patch(f"/api/feedback/{fb.id}", json={"status": "done"})
+        assert resp.status_code == 403
+    finally:
+        settings.ADMIN_USER_ID = original
+
+
+@pytest.mark.asyncio
+async def test_update_feedback_not_found(authenticated_client, test_user, test_household, db_session):
+    """존재하지 않는 피드백 상태 변경 → 404"""
+    original = settings.ADMIN_USER_ID
+    settings.ADMIN_USER_ID = test_user.id
+    try:
+        resp = await authenticated_client.patch("/api/feedback/99999", json={"status": "done"})
+        assert resp.status_code == 404
+    finally:
+        settings.ADMIN_USER_ID = original

--- a/backend/tests/integration/test_api_income_crud.py
+++ b/backend/tests/integration/test_api_income_crud.py
@@ -1,0 +1,301 @@
+"""수입 CRUD + 통계 + 검색 커버리지 테스트
+
+api/income.py 미커버 라인 커버: 77-85, 106-119, 156-206, 232-246, 257-272, 284-312, 323-347
+"""
+
+from datetime import datetime
+
+import pytest
+
+from app.models.category import Category
+from app.models.income import Income
+
+
+@pytest.mark.asyncio
+async def test_create_income(authenticated_client, test_user, test_household, db_session):
+    """수입 생성"""
+    response = await authenticated_client.post(
+        "/api/income",
+        json={
+            "amount": 3000000,
+            "description": "3월 급여",
+            "date": "2026-03-01T09:00:00",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["amount"] == 3000000
+    assert data["description"] == "3월 급여"
+
+
+@pytest.mark.asyncio
+async def test_get_incomes_with_filters(authenticated_client, test_user, test_household, db_session):
+    """수입 목록 조회 + 필터링"""
+    # 데이터 준비
+    cat = Category(name="급여", type="income", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    for i in range(3):
+        inc = Income(
+            user_id=test_user.id,
+            household_id=test_household.id,
+            amount=1000000 * (i + 1),
+            description=f"수입 {i}",
+            category_id=cat.id,
+            date=datetime(2026, 3, 10 + i),
+        )
+        db_session.add(inc)
+    await db_session.commit()
+
+    # 기본 조회
+    resp = await authenticated_client.get("/api/income")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+
+    # 날짜 필터
+    resp = await authenticated_client.get("/api/income?start_date=2026-03-11&end_date=2026-03-12")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+    # 카테고리 필터
+    resp = await authenticated_client.get(f"/api/income?category_id={cat.id}")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+
+    # 텍스트 검색
+    resp = await authenticated_client.get("/api/income?query=수입 1")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # 멤버별 필터
+    resp = await authenticated_client.get(f"/api/income?member_user_id={test_user.id}")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+
+
+@pytest.mark.asyncio
+async def test_income_stats_weekly(authenticated_client, test_user, test_household, db_session):
+    """수입 주간 통계"""
+    cat = Category(name="급여", type="income", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    inc = Income(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=3000000,
+        description="급여",
+        category_id=cat.id,
+        date=datetime(2026, 3, 23),
+    )
+    db_session.add(inc)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/income/stats?period=weekly&date=2026-03-23")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 3000000
+    assert data["count"] == 1
+    assert len(data["by_category"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_income_stats_monthly(authenticated_client, test_user, test_household, db_session):
+    """수입 월간 통계"""
+    inc = Income(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=2000000,
+        description="부수입",
+        date=datetime(2026, 3, 15),
+    )
+    db_session.add(inc)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/income/stats?period=monthly&date=2026-03-15")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2000000
+
+
+@pytest.mark.asyncio
+async def test_income_stats_yearly(authenticated_client, test_user, test_household, db_session):
+    """수입 연간 통계 (월별 트렌드 포함)"""
+    for m in (1, 2, 3):
+        inc = Income(
+            user_id=test_user.id,
+            household_id=test_household.id,
+            amount=1000000 * m,
+            description=f"{m}월 급여",
+            date=datetime(2026, m, 15),
+        )
+        db_session.add(inc)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/income/stats?period=yearly&date=2026-03-15")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 6000000
+    assert len(data["trend"]) == 12  # 12개월 포인트
+
+
+@pytest.mark.asyncio
+async def test_income_search_summary(authenticated_client, test_user, test_household, db_session):
+    """수입 검색 요약"""
+    for i in range(5):
+        inc = Income(
+            user_id=test_user.id,
+            household_id=test_household.id,
+            amount=100000 * (i + 1),
+            description=f"수입항목{i}",
+            date=datetime(2026, 3, 10 + i),
+        )
+        db_session.add(inc)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/income/search/summary")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_count"] == 5
+    assert data["total_amount"] == 1500000
+
+    # 필터 적용 검색
+    resp = await authenticated_client.get("/api/income/search/summary?query=수입항목2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_income_detail(authenticated_client, test_user, test_household, db_session):
+    """수입 상세 조회"""
+    inc = Income(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=5000000,
+        description="보너스",
+        date=datetime(2026, 3, 25),
+    )
+    db_session.add(inc)
+    await db_session.commit()
+    await db_session.refresh(inc)
+
+    resp = await authenticated_client.get(f"/api/income/{inc.id}")
+    assert resp.status_code == 200
+    assert resp.json()["amount"] == 5000000
+
+
+@pytest.mark.asyncio
+async def test_get_income_not_found(authenticated_client):
+    """존재하지 않는 수입 조회 → 404"""
+    resp = await authenticated_client.get("/api/income/99999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_income(authenticated_client, test_user, test_household, db_session):
+    """수입 수정"""
+    inc = Income(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=3000000,
+        description="급여",
+        date=datetime(2026, 3, 1),
+    )
+    db_session.add(inc)
+    await db_session.commit()
+    await db_session.refresh(inc)
+
+    resp = await authenticated_client.put(
+        f"/api/income/{inc.id}",
+        json={"amount": 3500000, "description": "급여+수당"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["amount"] == 3500000
+    assert data["description"] == "급여+수당"
+
+
+@pytest.mark.asyncio
+async def test_update_income_not_found(authenticated_client):
+    """존재하지 않는 수입 수정 → 404"""
+    resp = await authenticated_client.put("/api/income/99999", json={"amount": 1000})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_income_other_user_member_role(authenticated_client, authenticated_client2, test_user, test_user2, test_household, db_session):
+    """타인 수입 수정 시 member 역할이면 403"""
+    from app.models.household_member import HouseholdMember
+
+    # user2를 test_household에 member로 추가
+    m = HouseholdMember(household_id=test_household.id, user_id=test_user2.id, role="member")
+    db_session.add(m)
+    await db_session.flush()
+
+    inc = Income(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=3000000,
+        description="급여",
+        date=datetime(2026, 3, 1),
+    )
+    db_session.add(inc)
+    await db_session.commit()
+    await db_session.refresh(inc)
+
+    resp = await authenticated_client2.put(
+        f"/api/income/{inc.id}",
+        json={"amount": 1},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_income(authenticated_client, test_user, test_household, db_session):
+    """수입 삭제"""
+    inc = Income(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=500000,
+        description="부수입",
+        date=datetime(2026, 3, 20),
+    )
+    db_session.add(inc)
+    await db_session.commit()
+    await db_session.refresh(inc)
+
+    resp = await authenticated_client.delete(f"/api/income/{inc.id}")
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_delete_income_not_found(authenticated_client):
+    """존재하지 않는 수입 삭제 → 404"""
+    resp = await authenticated_client.delete("/api/income/99999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_income_other_user_member_role(authenticated_client, authenticated_client2, test_user, test_user2, test_household, db_session):
+    """타인 수입 삭제 시 member 역할이면 403"""
+    from app.models.household_member import HouseholdMember
+
+    m = HouseholdMember(household_id=test_household.id, user_id=test_user2.id, role="member")
+    db_session.add(m)
+    await db_session.flush()
+
+    inc = Income(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=3000000,
+        description="급여",
+        date=datetime(2026, 3, 1),
+    )
+    db_session.add(inc)
+    await db_session.commit()
+    await db_session.refresh(inc)
+
+    resp = await authenticated_client2.delete(f"/api/income/{inc.id}")
+    assert resp.status_code == 403

--- a/backend/tests/integration/test_api_insights_coverage.py
+++ b/backend/tests/integration/test_api_insights_coverage.py
@@ -1,0 +1,84 @@
+"""인사이트 API 커버리지 테스트
+
+api/insights.py 미커버 라인: 62-118
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.category import Category
+from app.models.expense import Expense
+
+
+@pytest.mark.asyncio
+async def test_generate_insights_no_data(authenticated_client, test_user, test_household, db_session):
+    """지출 데이터 없을 때 인사이트"""
+    resp = await authenticated_client.post(
+        "/api/insights/generate?month=2026-03",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "기록된 지출이 없습니다" in data["insights"]
+
+
+@pytest.mark.asyncio
+async def test_generate_insights_with_data(authenticated_client, test_user, test_household, db_session, mock_llm_generate_insights):
+    """지출 데이터 있을 때 인사이트 생성"""
+    cat = Category(name="식비", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=500000,
+        description="식비",
+        category_id=cat.id,
+        date=datetime(2026, 3, 15),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+
+    resp = await authenticated_client.post(
+        "/api/insights/generate?month=2026-03",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["month"] == "2026-03"
+    assert data["insights"] is not None
+
+
+@pytest.mark.asyncio
+async def test_generate_comprehensive_insights(authenticated_client, test_user, test_household, db_session):
+    """종합 재무 인사이트 생성"""
+    mock_result = {
+        "findings": [{"what": "식비가 줄었습니다", "so_what": "절약 효과", "now_what": "유지하세요"}],
+        "action_items": [{"title": "저축 늘리기", "description": "매달 10만원씩"}],
+        "encouragement": "잘 하고 있습니다!",
+    }
+
+    # LLM 프로바이더 캐시 클리어 후 모킹
+    from app.services.llm_service import _provider_cache
+
+    _provider_cache.clear()
+
+    with patch("app.services.llm_service._create_provider") as mock_create:
+        mock_llm = AsyncMock()
+        mock_llm.generate_comprehensive_insights.return_value = mock_result
+        mock_create.return_value = mock_llm
+
+        resp = await authenticated_client.post(
+            "/api/insights/generate-comprehensive",
+            json={
+                "month": "2026-03",
+                "expense_total": 500000,
+                "income_total": 3000000,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["month"] == "2026-03"
+
+    _provider_cache.clear()

--- a/backend/tests/integration/test_api_invitations_extra.py
+++ b/backend/tests/integration/test_api_invitations_extra.py
@@ -1,0 +1,210 @@
+"""초대 수락/거절 + 내 초대 목록 커버리지 테스트
+
+api/invitations.py 미커버 라인: 68-95, 126-206, 246-276
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.models.household import Household
+from app.models.household_invitation import HouseholdInvitation
+from app.models.household_member import HouseholdMember
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_list_my_invitations(authenticated_client, test_user, test_household, db_session):
+    """내가 받은 초대 목록 조회"""
+    # 다른 가구 생성
+    household2 = Household(name="초대 대상 가구")
+    db_session.add(household2)
+    await db_session.flush()
+
+    inviter = User(
+        auth_user_id="inviter-001",
+        username="초대자",
+        email="inviter@test.com",
+    )
+    db_session.add(inviter)
+    await db_session.flush()
+
+    # 멤버십 추가
+    m = HouseholdMember(household_id=household2.id, user_id=inviter.id, role="owner")
+    db_session.add(m)
+    await db_session.flush()
+
+    inv = HouseholdInvitation(
+        household_id=household2.id,
+        inviter_id=inviter.id,
+        invitee_email=test_user.email,
+        invitee_user_id=test_user.id,
+        token=str(uuid.uuid4()),
+        role="member",
+        status="pending",
+        expires_at=datetime.now(UTC).replace(tzinfo=None) + timedelta(days=7),
+    )
+    db_session.add(inv)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/invitations/my")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["household_name"] == "초대 대상 가구"
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation(authenticated_client, test_user, test_household, db_session):
+    """초대 수락"""
+    household2 = Household(name="새 가구")
+    db_session.add(household2)
+    await db_session.flush()
+
+    inviter = User(
+        auth_user_id="inviter-002",
+        username="초대자2",
+        email="inviter2@test.com",
+    )
+    db_session.add(inviter)
+    await db_session.flush()
+
+    m = HouseholdMember(household_id=household2.id, user_id=inviter.id, role="owner")
+    db_session.add(m)
+    await db_session.flush()
+
+    token = str(uuid.uuid4())
+    inv = HouseholdInvitation(
+        household_id=household2.id,
+        inviter_id=inviter.id,
+        invitee_email=test_user.email,
+        invitee_user_id=test_user.id,
+        token=token,
+        role="member",
+        status="pending",
+        expires_at=datetime.now(UTC).replace(tzinfo=None) + timedelta(days=7),
+    )
+    db_session.add(inv)
+    await db_session.commit()
+
+    resp = await authenticated_client.post(f"/api/invitations/{token}/accept")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_accept_invitation_not_found(authenticated_client):
+    """존재하지 않는 초대 수락 → 404"""
+    resp = await authenticated_client.post("/api/invitations/nonexistent-token/accept")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_accept_expired_invitation(authenticated_client, test_user, test_household, db_session):
+    """만료된 초대 수락 → 400"""
+    household2 = Household(name="새 가구")
+    db_session.add(household2)
+    await db_session.flush()
+
+    inviter = User(auth_user_id="inviter-003", username="초대자3", email="inviter3@test.com")
+    db_session.add(inviter)
+    await db_session.flush()
+
+    m = HouseholdMember(household_id=household2.id, user_id=inviter.id, role="owner")
+    db_session.add(m)
+    await db_session.flush()
+
+    token = str(uuid.uuid4())
+    inv = HouseholdInvitation(
+        household_id=household2.id,
+        inviter_id=inviter.id,
+        invitee_email=test_user.email,
+        invitee_user_id=test_user.id,
+        token=token,
+        role="member",
+        status="pending",
+        expires_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1),  # 만료
+    )
+    db_session.add(inv)
+    await db_session.commit()
+
+    resp = await authenticated_client.post(f"/api/invitations/{token}/accept")
+    assert resp.status_code == 400
+    assert "만료" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_accept_already_processed(authenticated_client, test_user, test_household, db_session):
+    """이미 처리된 초대 수락 → 400"""
+    household2 = Household(name="새 가구")
+    db_session.add(household2)
+    await db_session.flush()
+
+    inviter = User(auth_user_id="inviter-004", username="초대자4", email="inviter4@test.com")
+    db_session.add(inviter)
+    await db_session.flush()
+
+    m = HouseholdMember(household_id=household2.id, user_id=inviter.id, role="owner")
+    db_session.add(m)
+    await db_session.flush()
+
+    token = str(uuid.uuid4())
+    inv = HouseholdInvitation(
+        household_id=household2.id,
+        inviter_id=inviter.id,
+        invitee_email=test_user.email,
+        invitee_user_id=test_user.id,
+        token=token,
+        role="member",
+        status="accepted",
+        expires_at=datetime.now(UTC).replace(tzinfo=None) + timedelta(days=7),
+    )
+    db_session.add(inv)
+    await db_session.commit()
+
+    resp = await authenticated_client.post(f"/api/invitations/{token}/accept")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reject_invitation(authenticated_client, test_user, test_household, db_session):
+    """초대 거절"""
+    household2 = Household(name="거절 대상 가구")
+    db_session.add(household2)
+    await db_session.flush()
+
+    inviter = User(auth_user_id="inviter-005", username="초대자5", email="inviter5@test.com")
+    db_session.add(inviter)
+    await db_session.flush()
+
+    m = HouseholdMember(household_id=household2.id, user_id=inviter.id, role="owner")
+    db_session.add(m)
+    await db_session.flush()
+
+    token = str(uuid.uuid4())
+    inv = HouseholdInvitation(
+        household_id=household2.id,
+        inviter_id=inviter.id,
+        invitee_email=test_user.email,
+        invitee_user_id=test_user.id,
+        token=token,
+        role="member",
+        status="pending",
+        expires_at=datetime.now(UTC).replace(tzinfo=None) + timedelta(days=7),
+    )
+    db_session.add(inv)
+    await db_session.commit()
+
+    resp = await authenticated_client.post(f"/api/invitations/{token}/reject")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_reject_invitation_not_found(authenticated_client):
+    """존재하지 않는 초대 거절 → 404"""
+    resp = await authenticated_client.post("/api/invitations/nonexistent-token/reject")
+    assert resp.status_code == 404

--- a/backend/tests/integration/test_api_onboarding_coverage.py
+++ b/backend/tests/integration/test_api_onboarding_coverage.py
@@ -1,0 +1,94 @@
+"""온보딩 API 커버리지 테스트
+
+api/onboarding.py 미커버 라인: 37, 50, 66-88
+"""
+
+import pytest
+
+from app.models.user import User
+from tests.conftest import create_test_token
+
+
+@pytest.mark.asyncio
+async def test_onboarding_status_has_household(authenticated_client, test_user, test_household, db_session):
+    """온보딩 상태: 가구 소속"""
+    resp = await authenticated_client.get("/api/onboarding/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["has_household"] is True
+    assert data["household_count"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_onboarding_status_no_household(client, db_session):
+    """온보딩 상태: 가구 미소속"""
+    # 가구 없는 유저 생성
+    user = User(
+        auth_user_id="no-household-user",
+        username="homeless",
+        email="homeless@test.com",
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    token = create_test_token(auth_user_id="no-household-user", email="homeless@test.com")
+    resp = await client.get(
+        "/api/onboarding/status",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["has_household"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_default_household(client, db_session):
+    """기본 가구 생성"""
+    user = User(
+        auth_user_id="fresh-user",
+        username="신규유저",
+        email="fresh@test.com",
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    token = create_test_token(auth_user_id="fresh-user", email="fresh@test.com")
+    resp = await client.post(
+        "/api/onboarding/create-household",
+        json={"name": "내 가계부"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "내 가계부"
+
+
+@pytest.mark.asyncio
+async def test_create_default_household_duplicate(authenticated_client, test_user, test_household, db_session):
+    """이미 가구 소속인 유저가 다시 생성 → 409"""
+    resp = await authenticated_client.post(
+        "/api/onboarding/create-household",
+        json={"name": "중복 가구"},
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_create_default_household_auto_name(client, db_session):
+    """이름 미지정 시 자동 이름"""
+    user = User(
+        auth_user_id="auto-name-user",
+        username="자동이름유저",
+        email="auto@test.com",
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    token = create_test_token(auth_user_id="auto-name-user", email="auto@test.com")
+    resp = await client.post(
+        "/api/onboarding/create-household",
+        json={},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 201
+    assert "자동이름유저님의 가계부" in resp.json()["name"]

--- a/backend/tests/integration/test_api_recurring_coverage.py
+++ b/backend/tests/integration/test_api_recurring_coverage.py
@@ -1,0 +1,287 @@
+"""정기 거래 CRUD + execute/skip 커버리지 테스트
+
+api/recurring.py 미커버 라인: 51-57, 73-124, 137-145, 159-168, 179, 192-198, 209-210, 224-235, 252-260, 270-295
+"""
+
+from datetime import datetime
+
+import pytest
+
+from app.models.category import Category
+from app.models.expense import Expense
+from app.models.recurring_transaction import RecurringTransaction
+
+
+@pytest.mark.asyncio
+async def test_create_recurring(authenticated_client, test_user, test_household, db_session):
+    """정기 거래 생성"""
+    resp = await authenticated_client.post(
+        "/api/recurring",
+        json={
+            "type": "expense",
+            "amount": 50000,
+            "description": "넷플릭스",
+            "frequency": "monthly",
+            "start_date": "2026-03-01",
+            "day_of_month": 1,
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["amount"] == 50000
+    assert data["description"] == "넷플릭스"
+
+
+@pytest.mark.asyncio
+async def test_create_recurring_with_source(authenticated_client, test_user, test_household, db_session):
+    """원본 거래 연결된 정기 거래 생성"""
+    exp = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        amount=50000,
+        description="넷플릭스",
+        date=datetime(2026, 3, 1),
+    )
+    db_session.add(exp)
+    await db_session.commit()
+    await db_session.refresh(exp)
+
+    resp = await authenticated_client.post(
+        "/api/recurring",
+        json={
+            "type": "expense",
+            "amount": 50000,
+            "description": "넷플릭스",
+            "frequency": "monthly",
+            "start_date": "2026-03-01",
+            "day_of_month": 1,
+            "source_id": exp.id,
+        },
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_get_recurring_list(authenticated_client, test_user, test_household, db_session):
+    """정기 거래 목록 조회"""
+    rec = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=50000,
+        description="넷플릭스",
+        frequency="monthly",
+        day_of_month=1,
+        next_due_date=datetime(2026, 4, 1).date(),
+        start_date=datetime(2026, 3, 1).date(),
+    )
+    db_session.add(rec)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/recurring")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # 타입 필터
+    resp = await authenticated_client.get("/api/recurring?type=expense")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    resp = await authenticated_client.get("/api/recurring?type=income")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_pending_recurring(authenticated_client, test_user, test_household, db_session):
+    """대기 중인 정기 거래 조회"""
+    rec = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=50000,
+        description="넷플릭스",
+        frequency="monthly",
+        day_of_month=1,
+        next_due_date=datetime(2025, 1, 1).date(),  # 과거 날짜 = pending
+        start_date=datetime(2025, 1, 1).date(),
+    )
+    db_session.add(rec)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/recurring/pending")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_recurring_detail(authenticated_client, test_user, test_household, db_session):
+    """정기 거래 상세 조회"""
+    rec = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=50000,
+        description="넷플릭스",
+        frequency="monthly",
+        day_of_month=1,
+        next_due_date=datetime(2026, 4, 1).date(),
+        start_date=datetime(2026, 3, 1).date(),
+    )
+    db_session.add(rec)
+    await db_session.commit()
+    await db_session.refresh(rec)
+
+    resp = await authenticated_client.get(f"/api/recurring/{rec.id}")
+    assert resp.status_code == 200
+    assert resp.json()["amount"] == 50000
+
+
+@pytest.mark.asyncio
+async def test_get_recurring_not_found(authenticated_client):
+    """존재하지 않는 정기 거래 조회 → 404"""
+    resp = await authenticated_client.get("/api/recurring/99999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_recurring(authenticated_client, test_user, test_household, db_session):
+    """정기 거래 수정"""
+    rec = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=50000,
+        description="넷플릭스",
+        frequency="monthly",
+        day_of_month=1,
+        next_due_date=datetime(2026, 4, 1).date(),
+        start_date=datetime(2026, 3, 1).date(),
+    )
+    db_session.add(rec)
+    await db_session.commit()
+    await db_session.refresh(rec)
+
+    resp = await authenticated_client.put(
+        f"/api/recurring/{rec.id}",
+        json={"amount": 60000, "description": "넷플릭스 프리미엄"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["amount"] == 60000
+
+
+@pytest.mark.asyncio
+async def test_delete_recurring(authenticated_client, test_user, test_household, db_session):
+    """정기 거래 삭제"""
+    rec = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=50000,
+        description="넷플릭스",
+        frequency="monthly",
+        day_of_month=1,
+        next_due_date=datetime(2026, 4, 1).date(),
+        start_date=datetime(2026, 3, 1).date(),
+    )
+    db_session.add(rec)
+    await db_session.commit()
+    await db_session.refresh(rec)
+
+    resp = await authenticated_client.delete(f"/api/recurring/{rec.id}")
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_execute_recurring(authenticated_client, test_user, test_household, db_session):
+    """정기 거래 실행"""
+    cat = Category(name="구독", type="expense", household_id=test_household.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    rec = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=50000,
+        description="넷플릭스",
+        category_id=cat.id,
+        frequency="monthly",
+        next_due_date=datetime(2026, 3, 1).date(),
+        start_date=datetime(2026, 3, 1).date(),
+    )
+    db_session.add(rec)
+    await db_session.commit()
+    await db_session.refresh(rec)
+
+    resp = await authenticated_client.post(f"/api/recurring/{rec.id}/execute")
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "등록되었습니다" in data["message"]
+    assert data["created_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_execute_inactive_recurring(authenticated_client, test_user, test_household, db_session):
+    """비활성 정기 거래 실행 → 400"""
+    rec = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=50000,
+        description="넷플릭스",
+        frequency="monthly",
+        next_due_date=datetime(2026, 3, 1).date(),
+        start_date=datetime(2026, 3, 1).date(),
+        is_active=False,
+    )
+    db_session.add(rec)
+    await db_session.commit()
+    await db_session.refresh(rec)
+
+    resp = await authenticated_client.post(f"/api/recurring/{rec.id}/execute")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_skip_recurring(authenticated_client, test_user, test_household, db_session):
+    """정기 거래 건너뛰기"""
+    rec = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=50000,
+        description="넷플릭스",
+        frequency="monthly",
+        next_due_date=datetime(2026, 3, 1).date(),
+        start_date=datetime(2026, 3, 1).date(),
+    )
+    db_session.add(rec)
+    await db_session.commit()
+    await db_session.refresh(rec)
+
+    resp = await authenticated_client.post(f"/api/recurring/{rec.id}/skip")
+    assert resp.status_code == 200
+    assert "next_due_date" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_skip_inactive_recurring(authenticated_client, test_user, test_household, db_session):
+    """비활성 정기 거래 건너뛰기 → 400"""
+    rec = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=50000,
+        description="넷플릭스",
+        frequency="monthly",
+        next_due_date=datetime(2026, 3, 1).date(),
+        start_date=datetime(2026, 3, 1).date(),
+        is_active=False,
+    )
+    db_session.add(rec)
+    await db_session.commit()
+    await db_session.refresh(rec)
+
+    resp = await authenticated_client.post(f"/api/recurring/{rec.id}/skip")
+    assert resp.status_code == 400

--- a/backend/tests/unit/test_llm_service_openai.py
+++ b/backend/tests/unit/test_llm_service_openai.py
@@ -1,0 +1,211 @@
+"""OpenAI LLM 프로바이더 커버리지 테스트
+
+services/llm_service.py 미커버 라인:
+- 317-320 (OpenAI __init__)
+- 335-397 (OpenAI parse_expense)
+- 400 (OpenAI parse_image NotImplementedError)
+- 404-426 (OpenAI generate_insights)
+- 430-440 (OpenAI generate)
+- 444-469 (OpenAI generate_comprehensive_insights)
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+openai = pytest.importorskip("openai")
+
+
+def _make_provider(mock_client):
+    """OpenAI 프로바이더 인스턴스를 직접 생성 (import 없이)"""
+    from app.services.llm_service import OpenAIProvider
+
+    provider = object.__new__(OpenAIProvider)
+    provider.client = mock_client
+    provider.model = "gpt-4o-mini"
+    return provider
+
+
+def _make_response(content, finish_reason="stop"):
+    """OpenAI 형태의 mock response 생성"""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].finish_reason = finish_reason
+    mock_response.choices[0].message.content = content
+    return mock_response
+
+
+@pytest.mark.asyncio
+async def test_openai_parse_expense_single():
+    """OpenAI 단일 지출 파싱"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(
+        return_value=_make_response(json.dumps({"amount": 8000, "category": "식비", "description": "김치찌개", "date": "2026-03-25"}))
+    )
+    provider = _make_provider(client)
+    result = await provider.parse_expense("점심 김치찌개 8000원")
+    assert result["amount"] == 8000
+
+
+@pytest.mark.asyncio
+async def test_openai_parse_expense_multiple():
+    """OpenAI 여러 지출 파싱"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(
+        return_value=_make_response(
+            json.dumps(
+                [
+                    {"amount": 8000, "category": "식비", "description": "점심", "date": "2026-03-25"},
+                    {"amount": 5000, "category": "카페", "description": "커피", "date": "2026-03-25"},
+                ]
+            )
+        )
+    )
+    provider = _make_provider(client)
+    result = await provider.parse_expense("점심 8000원 커피 5000원")
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_openai_parse_expense_error_response():
+    """OpenAI 에러 응답"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=_make_response(json.dumps({"error": "이해할 수 없습니다"})))
+    provider = _make_provider(client)
+    result = await provider.parse_expense("asdfghjkl")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_openai_parse_expense_max_tokens():
+    """OpenAI max_tokens 초과"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=_make_response('{"amount": 8000', "length"))
+    provider = _make_provider(client)
+    result = await provider.parse_expense("매우 긴 입력" * 100)
+    assert "error" in result
+    assert "너무 길어" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_openai_parse_expense_json_error():
+    """OpenAI JSON 파싱 실패"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=_make_response("이것은 JSON이 아닙니다"))
+    provider = _make_provider(client)
+    result = await provider.parse_expense("테스트")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_openai_parse_expense_api_error():
+    """OpenAI API 호출 실패"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(side_effect=Exception("API Error"))
+    provider = _make_provider(client)
+    result = await provider.parse_expense("테스트")
+    assert "error" in result
+    assert "LLM 서비스 오류" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_openai_parse_expense_no_amount():
+    """OpenAI 금액 없는 응답"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=_make_response(json.dumps({"category": "식비", "description": "뭔가"})))
+    provider = _make_provider(client)
+    result = await provider.parse_expense("금액 없는 입력")
+    assert "error" in result
+    assert "금액" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_openai_parse_image_not_implemented():
+    """OpenAI parse_image NotImplementedError"""
+    client = AsyncMock()
+    provider = _make_provider(client)
+    with pytest.raises(NotImplementedError):
+        await provider.parse_image(b"fake", "image/png")
+
+
+@pytest.mark.asyncio
+async def test_openai_generate_insights():
+    """OpenAI 인사이트 생성"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=_make_response("# 3월 지출 분석\n이번 달 총 지출: 50만원"))
+    provider = _make_provider(client)
+    result = await provider.generate_insights({"month": "2026-03", "total": 500000})
+    assert "지출 분석" in result
+
+
+@pytest.mark.asyncio
+async def test_openai_generate_insights_error():
+    """OpenAI 인사이트 생성 실패"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(side_effect=Exception("API Error"))
+    provider = _make_provider(client)
+    result = await provider.generate_insights({"month": "2026-03", "total": 500000})
+    assert "오류" in result
+
+
+@pytest.mark.asyncio
+async def test_openai_generate():
+    """OpenAI 범용 텍스트 생성"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=_make_response("생성된 텍스트"))
+    provider = _make_provider(client)
+    result = await provider.generate("프롬프트")
+    assert result == "생성된 텍스트"
+
+
+@pytest.mark.asyncio
+async def test_openai_generate_error():
+    """OpenAI generate 실패 → 빈 문자열"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(side_effect=Exception("fail"))
+    provider = _make_provider(client)
+    result = await provider.generate("프롬프트")
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_openai_generate_comprehensive_insights():
+    """OpenAI 종합 인사이트 생성"""
+    insights_data = {"summary": "잘 하고 있습니다", "highlights": [], "suggestions": []}
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=_make_response(json.dumps(insights_data)))
+    provider = _make_provider(client)
+    result = await provider.generate_comprehensive_insights({"month": "2026-03"})
+    assert result["summary"] == "잘 하고 있습니다"
+
+
+@pytest.mark.asyncio
+async def test_openai_parse_expense_invalid_format():
+    """OpenAI 잘못된 형식 (int 반환 등)"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=_make_response("42"))
+    provider = _make_provider(client)
+    result = await provider.parse_expense("테스트")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_openai_parse_expense_list_no_amount():
+    """OpenAI 리스트 중 금액 없는 항목"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=_make_response(json.dumps([{"amount": 8000, "category": "식비"}, {"category": "교통"}])))
+    provider = _make_provider(client)
+    result = await provider.parse_expense("여러 건")
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_openai_insights_max_tokens_warning():
+    """OpenAI 인사이트 max_tokens 경고"""
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=_make_response("잘린 인사이트...", "length"))
+    provider = _make_provider(client)
+    result = await provider.generate_insights({"month": "2026-03", "total": 500000})
+    assert result == "잘린 인사이트..."


### PR DESCRIPTION
## Summary

BE 커버리지 86% → **93%**. 핵심: `.coveragerc`에 `concurrency = greenlet` 추가.

- 94개 테스트 추가 (11개 신규 파일)
- `api/e2e.py` 커버리지 제외
- 전체 1343 passed

## Test plan

- [x] 1343 passed, 20 skipped
- [x] ruff lint/format 통과
- [ ] CI 통과

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)