### PR TITLE
test: E2E Tier 2 — 검색/예산/정기거래/CRUD (#450)

### DIFF
--- a/e2e/tests/tier2-budget.spec.ts
+++ b/e2e/tests/tier2-budget.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Tier 2 예산 E2E 테스트
+ *
+ * API로 카테고리를 생성한 뒤 예산 설정 페이지에서 카테고리별 예산을 입력하고,
+ * 지출 등록 후 예산 달성률 표시를 검증한다.
+ */
+
+import { test, expect, API_URL } from '../fixtures/auth'
+import { getAuthToken } from '../fixtures/auth'
+import type { Page } from '@playwright/test'
+
+/** API로 카테고리 생성 헬퍼 */
+async function createCategory(
+  page: Page,
+  data: { name: string; type?: string },
+) {
+  const token = await getAuthToken(page)
+  const res = await page.request.post(`${API_URL}/api/categories`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { name: data.name, type: data.type ?? 'expense' },
+  })
+  if (!res.ok()) {
+    throw new Error(`카테고리 생성 실패 (${res.status()}): ${await res.text()}`)
+  }
+  return res.json()
+}
+
+/** API로 예산 생성 헬퍼 */
+async function createBudget(
+  page: Page,
+  data: { category_id: number; amount: number },
+) {
+  const token = await getAuthToken(page)
+  const res = await page.request.post(`${API_URL}/api/budgets`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      category_id: data.category_id,
+      amount: data.amount,
+      period: 'monthly',
+      start_date: new Date().toISOString(),
+    },
+  })
+  if (!res.ok()) {
+    throw new Error(`예산 생성 실패 (${res.status()}): ${await res.text()}`)
+  }
+  return res.json()
+}
+
+/** API로 지출 생성 헬퍼 */
+async function createExpense(
+  page: Page,
+  data: { amount: number; description: string; category_id?: number },
+) {
+  const token = await getAuthToken(page)
+  const res = await page.request.post(`${API_URL}/api/expenses`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      amount: data.amount,
+      description: data.description,
+      category_id: data.category_id,
+      date: new Date().toISOString().replace('Z', ''),
+    },
+  })
+  if (!res.ok()) {
+    throw new Error(`지출 생성 실패 (${res.status()}): ${await res.text()}`)
+  }
+  return res.json()
+}
+
+test.describe('예산 관리', () => {
+  test('카테고리별 예산 입력 → 저장 → 표시 확인', async ({ authedPage: page }) => {
+    // 카테고리 생성
+    const category = await createCategory(page, { name: 'E2E식비' })
+
+    // 예산 관리 페이지로 이동
+    await page.goto('/budgets')
+    await page.waitForLoadState('networkidle')
+
+    // 카테고리별 예산 섹션에서 'E2E식비' 카테고리 확인
+    await expect(page.getByText('E2E식비')).toBeVisible({ timeout: 15000 })
+
+    // 해당 카테고리의 예산 입력 필드에 금액 입력
+    const budgetInput = page.getByLabel('E2E식비 예산')
+    await budgetInput.fill('300000')
+
+    // 저장 버튼 클릭 (입력값이 변경되면 '저장' 버튼이 나타남)
+    await page.getByRole('button', { name: '저장' }).first().click()
+
+    // 저장 성공 대기 — 저장 후 버튼이 사라짐 (dirty 상태 해제)
+    await expect(page.getByRole('button', { name: '저장' })).not.toBeVisible({ timeout: 10000 })
+
+    // 페이지 새로고침 후에도 금액이 유지됨
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByLabel('E2E식비 예산')).toHaveValue('300000', { timeout: 15000 })
+  })
+
+  test('지출 등록 후 예산 달성률 표시', async ({ authedPage: page }) => {
+    // 카테고리 + 예산 + 지출 생성 (API)
+    const category = await createCategory(page, { name: 'E2E교통비' })
+    await createBudget(page, { category_id: category.id, amount: 100000 })
+    await createExpense(page, {
+      amount: 45000,
+      description: 'E2E 택시비',
+      category_id: category.id,
+    })
+
+    // 예산 관리 페이지로 이동
+    await page.goto('/budgets')
+    await page.waitForLoadState('networkidle')
+
+    // '예산 상황' 섹션에 카테고리 표시
+    await expect(page.getByText('예산 상황')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText('E2E교통비')).toBeVisible()
+
+    // 달성률 퍼센트 표시 확인 (45,000 / 100,000 = 45.0%)
+    await expect(page.getByText('45.0%')).toBeVisible()
+
+    // 사용 금액 표시 확인
+    await expect(page.getByText(/45,000/).first()).toBeVisible()
+  })
+
+  test('월 총 예산 설정 → 저장', async ({ authedPage: page }) => {
+    await page.goto('/budgets')
+    await page.waitForLoadState('networkidle')
+
+    // 월 총 예산 섹션 확인
+    await expect(page.getByText('월 총 예산')).toBeVisible({ timeout: 15000 })
+
+    // 총 예산 입력
+    const totalInput = page.getByLabel('월 총 예산')
+    await totalInput.fill('2000000')
+
+    // 저장 버튼 클릭
+    await page.getByRole('button', { name: '저장' }).first().click()
+
+    // 저장 성공 — 버튼 사라짐
+    await expect(page.getByRole('button', { name: '저장' })).not.toBeVisible({ timeout: 10000 })
+
+    // 새로고침 후 값 유지 확인
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByLabel('월 총 예산')).toHaveValue('2000000', { timeout: 15000 })
+  })
+})

--- a/e2e/tests/tier2-crud.spec.ts
+++ b/e2e/tests/tier2-crud.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Tier 2 CRUD E2E 테스트 — 지출/수입 수정·삭제
+ *
+ * API로 데이터를 생성한 뒤 상세 페이지에서 수정·삭제 UI 동작을 검증한다.
+ * 기존 expenses.spec.ts 패턴을 따르되, 수입(Income) 시나리오를 추가한다.
+ */
+
+import { test, expect, API_URL } from '../fixtures/auth'
+import { getAuthToken } from '../fixtures/auth'
+import type { Page } from '@playwright/test'
+
+/** API로 지출 생성 헬퍼 */
+async function createExpense(
+  page: Page,
+  data: { amount: number; description: string },
+) {
+  const token = await getAuthToken(page)
+  const res = await page.request.post(`${API_URL}/api/expenses`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      ...data,
+      date: new Date().toISOString().replace('Z', ''),
+    },
+  })
+  if (!res.ok()) {
+    throw new Error(`지출 생성 실패 (${res.status()}): ${await res.text()}`)
+  }
+  return res.json()
+}
+
+/** API로 수입 생성 헬퍼 */
+async function createIncome(
+  page: Page,
+  data: { amount: number; description: string },
+) {
+  const token = await getAuthToken(page)
+  const res = await page.request.post(`${API_URL}/api/income`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      ...data,
+      date: new Date().toISOString().replace('Z', ''),
+    },
+  })
+  if (!res.ok()) {
+    throw new Error(`수입 생성 실패 (${res.status()}): ${await res.text()}`)
+  }
+  return res.json()
+}
+
+test.describe('지출 수정/삭제', () => {
+  test('지출 수정 → 금액 변경 → 저장 → 변경 확인', async ({ authedPage: page }) => {
+    const expense = await createExpense(page, {
+      amount: 12000,
+      description: 'E2E 수정 테스트 지출',
+    })
+
+    // 상세 페이지로 이동
+    await page.goto(`/expenses/${expense.id}`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('E2E 수정 테스트 지출')).toBeVisible({ timeout: 15000 })
+
+    // 수정 모드 진입
+    await page.getByRole('button', { name: '수정' }).click()
+
+    // 금액 필드 수정 (placeholder: "10000")
+    const amountInput = page.getByPlaceholder('10000')
+    await expect(amountInput).toBeVisible()
+    await amountInput.fill('25000')
+
+    // 저장 후 PUT 응답 대기
+    await Promise.all([
+      page.waitForResponse(
+        (res) => res.url().includes('/api/expenses/') && res.request().method() === 'PUT',
+      ),
+      page.getByRole('button', { name: '저장' }).click(),
+    ])
+
+    // 변경된 금액 확인
+    await expect(page.getByText(/25,000/).first()).toBeVisible({ timeout: 15000 })
+  })
+
+  test('지출 삭제 → 확인 → 목록에서 사라짐', async ({ authedPage: page }) => {
+    const expense = await createExpense(page, {
+      amount: 7000,
+      description: 'E2E 삭제 대상 지출',
+    })
+
+    await page.goto(`/expenses/${expense.id}`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('E2E 삭제 대상 지출')).toBeVisible({ timeout: 15000 })
+
+    // 삭제 버튼 클릭 → 확인 모달
+    await page.getByRole('button', { name: '삭제' }).first().click()
+    // 모달에서 삭제 확인
+    await page.getByRole('button', { name: '삭제' }).last().click()
+
+    // 홈으로 리디렉션 확인
+    await expect(page).toHaveURL(/\//, { timeout: 15000 })
+  })
+})
+
+test.describe('수입 수정/삭제', () => {
+  test('수입 수정 → 금액 변경 → 저장 → 변경 확인', async ({ authedPage: page }) => {
+    const income = await createIncome(page, {
+      amount: 500000,
+      description: 'E2E 수정 테스트 수입',
+    })
+
+    // 수입 상세 페이지로 이동
+    await page.goto(`/income/${income.id}`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('E2E 수정 테스트 수입')).toBeVisible({ timeout: 15000 })
+
+    // 수정 모드 진입
+    await page.getByRole('button', { name: '수정' }).click()
+
+    // 금액 필드 수정 (id: "income-edit-amount")
+    const amountInput = page.locator('#income-edit-amount')
+    await expect(amountInput).toBeVisible()
+    await amountInput.fill('750000')
+
+    // 저장 후 PUT 응답 대기
+    await Promise.all([
+      page.waitForResponse(
+        (res) => res.url().includes('/api/income/') && res.request().method() === 'PUT',
+      ),
+      page.getByRole('button', { name: '저장' }).click(),
+    ])
+
+    // 변경된 금액 확인
+    await expect(page.getByText(/750,000/).first()).toBeVisible({ timeout: 15000 })
+  })
+
+  test('수입 삭제 → 확인 → 리디렉션', async ({ authedPage: page }) => {
+    const income = await createIncome(page, {
+      amount: 100000,
+      description: 'E2E 삭제 대상 수입',
+    })
+
+    await page.goto(`/income/${income.id}`)
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('E2E 삭제 대상 수입')).toBeVisible({ timeout: 15000 })
+
+    // 삭제 버튼 클릭 → 확인 모달
+    await page.getByRole('button', { name: '삭제' }).first().click()
+    // 모달에서 삭제 확인
+    await page.getByRole('button', { name: '삭제' }).last().click()
+
+    // /income → /?filter=income 리디렉션
+    await expect(page).toHaveURL(/\//, { timeout: 15000 })
+  })
+})

--- a/e2e/tests/tier2-recurring.spec.ts
+++ b/e2e/tests/tier2-recurring.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Tier 2 정기 거래 E2E 테스트
+ *
+ * 정기 거래 페이지에서 추가·목록표시·실행(execute) 플로우를 검증한다.
+ * API로 직접 정기 거래를 생성하고 UI에서 확인하는 패턴도 함께 사용한다.
+ */
+
+import { test, expect, API_URL } from '../fixtures/auth'
+import { getAuthToken } from '../fixtures/auth'
+import type { Page } from '@playwright/test'
+
+/** API로 정기 거래 생성 헬퍼 */
+async function createRecurring(
+  page: Page,
+  data: {
+    type: 'expense' | 'income'
+    amount: number
+    description: string
+    frequency?: string
+    day_of_month?: number
+  },
+) {
+  const token = await getAuthToken(page)
+  const today = new Date().toISOString().slice(0, 10)
+  const res = await page.request.post(`${API_URL}/api/recurring`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      type: data.type,
+      amount: data.amount,
+      description: data.description,
+      frequency: data.frequency ?? 'monthly',
+      day_of_month: data.day_of_month ?? 25,
+      start_date: today,
+    },
+  })
+  if (!res.ok()) {
+    throw new Error(`정기 거래 생성 실패 (${res.status()}): ${await res.text()}`)
+  }
+  return res.json()
+}
+
+test.describe('정기 거래 관리', () => {
+  test('정기 거래 페이지 이동 → 빈 상태 확인', async ({ authedPage: page }) => {
+    await page.goto('/recurring')
+    await page.waitForLoadState('networkidle')
+
+    // 빈 상태 메시지
+    await expect(
+      page.getByText('등록된 반복 거래가 없습니다'),
+    ).toBeVisible({ timeout: 15000 })
+  })
+
+  test('정기 거래 추가 → 폼 작성 → 저장 → 목록에 표시', async ({ authedPage: page }) => {
+    await page.goto('/recurring')
+    await page.waitForLoadState('networkidle')
+
+    // 추가 버튼 클릭
+    await page.getByRole('button', { name: '추가' }).click()
+
+    // 모달에서 폼 작성
+    // 설명 입력 (placeholder: "예: 넷플릭스, 월급")
+    await page.getByPlaceholder('예: 넷플릭스, 월급').fill('E2E 월세')
+    // 금액 입력 (placeholder: "0")
+    await page.getByPlaceholder('0').fill('500000')
+
+    // 추가하기 버튼 클릭
+    await page.getByRole('button', { name: '추가하기' }).click()
+
+    // 목록에 추가된 항목 표시
+    await expect(page.getByText('E2E 월세')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText(/500,000/).first()).toBeVisible()
+  })
+
+  test('API로 정기 거래 생성 → 목록에 표시', async ({ authedPage: page }) => {
+    await createRecurring(page, {
+      type: 'expense',
+      amount: 89000,
+      description: 'E2E 넷플릭스',
+    })
+
+    await page.goto('/recurring')
+    await page.waitForLoadState('networkidle')
+
+    // 목록에 표시 확인
+    await expect(page.getByText('E2E 넷플릭스')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText(/89,000/).first()).toBeVisible()
+  })
+
+  test('정기 거래 실행(execute) → 거래 목록에 반영', async ({ authedPage: page }) => {
+    const recurring = await createRecurring(page, {
+      type: 'expense',
+      amount: 15000,
+      description: 'E2E 실행테스트',
+    })
+
+    await page.goto('/recurring')
+    await page.waitForLoadState('networkidle')
+
+    // 항목 표시 확인
+    await expect(page.getByText('E2E 실행테스트')).toBeVisible({ timeout: 15000 })
+
+    // 바로 등록(execute) 버튼 클릭 (title="바로 등록")
+    await page.getByTitle('바로 등록').click()
+
+    // 등록 성공 토스트 확인
+    await expect(page.getByText(/등록되었습니다/)).toBeVisible({ timeout: 10000 })
+
+    // 가계부 홈으로 이동하여 거래가 생성되었는지 확인
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByText('E2E 실행테스트')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText(/15,000/).first()).toBeVisible()
+  })
+
+  test('지출/수입 필터 탭 동작', async ({ authedPage: page }) => {
+    // 지출형 + 수입형 정기 거래 각각 생성
+    await Promise.all([
+      createRecurring(page, { type: 'expense', amount: 30000, description: 'E2E 지출정기' }),
+      createRecurring(page, { type: 'income', amount: 200000, description: 'E2E 수입정기' }),
+    ])
+
+    await page.goto('/recurring')
+    await page.waitForLoadState('networkidle')
+
+    // 전체 탭 — 둘 다 표시
+    await expect(page.getByText('E2E 지출정기')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText('E2E 수입정기')).toBeVisible()
+
+    // 지출 탭 클릭
+    await page.getByRole('button', { name: '지출' }).click()
+    await expect(page.getByText('E2E 지출정기')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText('E2E 수입정기')).not.toBeVisible()
+
+    // 수입 탭 클릭
+    await page.getByRole('button', { name: '수입' }).click()
+    await expect(page.getByText('E2E 수입정기')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText('E2E 지출정기')).not.toBeVisible()
+  })
+})

--- a/e2e/tests/tier2-search.spec.ts
+++ b/e2e/tests/tier2-search.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Tier 2 검색 E2E 테스트
+ *
+ * API로 다양한 지출/수입을 생성한 뒤 검색 모드 진입, 검색어 입력,
+ * 결과 확인, 필터 전환, 검색 모드 해제를 검증한다.
+ */
+
+import { test, expect, API_URL } from '../fixtures/auth'
+import { getAuthToken } from '../fixtures/auth'
+import type { Page } from '@playwright/test'
+
+/** API로 지출 생성 헬퍼 */
+async function createExpense(
+  page: Page,
+  data: { amount: number; description: string },
+) {
+  const token = await getAuthToken(page)
+  const res = await page.request.post(`${API_URL}/api/expenses`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      ...data,
+      date: new Date().toISOString().replace('Z', ''),
+    },
+  })
+  if (!res.ok()) {
+    throw new Error(`지출 생성 실패 (${res.status()}): ${await res.text()}`)
+  }
+  return res.json()
+}
+
+/** API로 수입 생성 헬퍼 */
+async function createIncome(
+  page: Page,
+  data: { amount: number; description: string },
+) {
+  const token = await getAuthToken(page)
+  const res = await page.request.post(`${API_URL}/api/income`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      ...data,
+      date: new Date().toISOString().replace('Z', ''),
+    },
+  })
+  if (!res.ok()) {
+    throw new Error(`수입 생성 실패 (${res.status()}): ${await res.text()}`)
+  }
+  return res.json()
+}
+
+test.describe('검색 기능', () => {
+  test.beforeEach(async ({ authedPage: page }) => {
+    // 다양한 지출/수입 5건 + 1건 생성
+    await Promise.all([
+      createExpense(page, { amount: 8000, description: 'E2E검색 김치찌개' }),
+      createExpense(page, { amount: 15000, description: 'E2E검색 삼겹살' }),
+      createExpense(page, { amount: 3000, description: 'E2E검색 커피' }),
+      createExpense(page, { amount: 50000, description: 'E2E검색 마트장보기' }),
+      createExpense(page, { amount: 12000, description: 'E2E검색 택시비' }),
+      createIncome(page, { amount: 3000000, description: 'E2E검색 월급' }),
+    ])
+  })
+
+  test('검색 아이콘 클릭 → 검색 모드 진입', async ({ authedPage: page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // 월뷰에서 검색 버튼 클릭 (aria-label="검색")
+    await page.getByRole('button', { name: '검색' }).click()
+
+    // 검색 입력 필드가 나타남
+    const searchInput = page.getByPlaceholder('거래 내역 검색')
+    await expect(searchInput).toBeVisible({ timeout: 10000 })
+  })
+
+  test('검색어 입력 → 결과 확인', async ({ authedPage: page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // 검색 모드 진입
+    await page.getByRole('button', { name: '검색' }).click()
+
+    // 검색어 입력 후 Enter
+    const searchInput = page.getByPlaceholder('거래 내역 검색')
+    await searchInput.fill('김치찌개')
+    await searchInput.press('Enter')
+
+    // 검색 결과에 '김치찌개'가 표시됨
+    await expect(page.getByText('E2E검색 김치찌개')).toBeVisible({ timeout: 15000 })
+    // 다른 항목은 표시되지 않음
+    await expect(page.getByText('E2E검색 삼겹살')).not.toBeVisible()
+  })
+
+  test('지출/수입 필터 전환 → 결과 변화', async ({ authedPage: page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // 검색 모드 진입
+    await page.getByRole('button', { name: '검색' }).click()
+
+    // 'E2E검색' 검색 → 지출 5건 + 수입 1건 모두 표시
+    const searchInput = page.getByPlaceholder('거래 내역 검색')
+    await searchInput.fill('E2E검색')
+    await searchInput.press('Enter')
+
+    // 지출과 수입 모두 표시됨
+    await expect(page.getByText('E2E검색 김치찌개')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText('E2E검색 월급')).toBeVisible()
+
+    // '지출/수입' 필터 칩 클릭하여 드롭다운 열기
+    await page.getByText('지출/수입').click()
+    // '수입만' 선택
+    await page.getByText('수입만').click()
+
+    // 수입만 표시됨 — 지출은 사라짐
+    await expect(page.getByText('E2E검색 월급')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText('E2E검색 김치찌개')).not.toBeVisible()
+  })
+
+  test('검색 모드 해제 → 월뷰 복귀', async ({ authedPage: page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // 검색 모드 진입
+    await page.getByRole('button', { name: '검색' }).click()
+    await expect(page.getByPlaceholder('거래 내역 검색')).toBeVisible({ timeout: 10000 })
+
+    // 검색 닫기 버튼 클릭 (aria-label="검색 닫기")
+    await page.getByRole('button', { name: '검색 닫기' }).click()
+
+    // 검색 입력이 사라지고 월 네비게이션이 다시 보임
+    await expect(page.getByPlaceholder('거래 내역 검색')).not.toBeVisible()
+    // 검색 버튼(아이콘)이 다시 나타남
+    await expect(page.getByRole('button', { name: '검색' })).toBeVisible({ timeout: 10000 })
+  })
+})


### PR DESCRIPTION
## Summary

E2E Tier 2 테스트 16개 추가 (4개 파일).

| 파일 | 테스트 | 시나리오 |
|------|--------|---------|
| tier2-crud | 4 | 지출/수입 수정·삭제 |
| tier2-search | 4 | 검색 모드·필터·복귀 |
| tier2-budget | 3 | 예산 설정·달성률 |
| tier2-recurring | 5 | 추가·실행·필터 |

## Test plan

- [x] BE 1594 passed
- [x] Playwright --list 28개 테스트 확인
- [ ] CI 통과

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)