### PR TITLE
test: E2E Tier 3 — 설정/가구/모바일 (#451)

### DIFF
--- a/e2e/tests/tier3-household.spec.ts
+++ b/e2e/tests/tier3-household.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * 가구 관리 E2E 테스트 (Tier 3)
+ *
+ * HouseholdListPage, HouseholdDetailPage의 목록, 생성,
+ * 멤버 확인, 설정 탭 이름 수정을 검증한다.
+ */
+
+import { test, expect, API_URL } from '../fixtures/auth'
+import { getAuthToken } from '../fixtures/auth'
+import type { Page } from '@playwright/test'
+
+/** API로 가구 생성하는 헬퍼 */
+async function createHousehold(
+  page: Page,
+  data: { name: string; description?: string },
+): Promise<{ id: number; name: string }> {
+  const token = await getAuthToken(page)
+
+  const res = await page.request.post(`${API_URL}/api/households`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data,
+  })
+
+  if (!res.ok()) {
+    const body = await res.text()
+    throw new Error(`가구 생성 API 실패 (${res.status()}): ${body}`)
+  }
+  return res.json()
+}
+
+test.describe('가구 관리', () => {
+  test('가구 목록 페이지 이동', async ({ authedPage: page }) => {
+    await page.goto('/households')
+    await page.waitForLoadState('networkidle')
+
+    // 가구 목록 페이지가 로드됨 — "가구 만들기" 버튼 또는 기존 가구 카드
+    // E2E setup이 자동으로 기본 가구를 생성하므로 목록에 1개 이상 표시
+    await expect(
+      page.getByText('가구 만들기').or(page.locator('[role="button"]').first()),
+    ).toBeVisible({ timeout: 15000 })
+  })
+
+  test('새 가구 생성 → 목록에 표시', async ({ authedPage: page }) => {
+    // API로 가구 생성
+    const household = await createHousehold(page, {
+      name: 'E2E 테스트 가구',
+      description: 'E2E 테스트용 가구입니다',
+    })
+
+    // 가구 목록 페이지로 이동
+    await page.goto('/households')
+    await page.waitForLoadState('networkidle')
+
+    // 생성한 가구가 목록에 보여야 함
+    await expect(page.getByText('E2E 테스트 가구')).toBeVisible({ timeout: 15000 })
+  })
+
+  test('가구 상세 이동 → 멤버 목록 확인', async ({ authedPage: page }) => {
+    // API로 가구 생성
+    const household = await createHousehold(page, {
+      name: 'E2E 멤버 확인 가구',
+    })
+
+    // 가구 상세 페이지로 이동
+    await page.goto(`/households/${household.id}`)
+    await page.waitForLoadState('networkidle')
+
+    // 멤버 탭이 기본 활성이고, 멤버 목록이 보여야 함
+    // owner(현재 유저)가 멤버로 표시됨
+    await expect(page.getByText('멤버').first()).toBeVisible({ timeout: 15000 })
+
+    // 소유자 역할 배지가 보여야 함
+    await expect(page.getByText('소유자').first()).toBeVisible()
+  })
+
+  test('가구 설정 탭 → 이름 수정', async ({ authedPage: page }) => {
+    // API로 가구 생성
+    const household = await createHousehold(page, {
+      name: 'E2E 수정 전 가구',
+    })
+
+    // 가구 상세 페이지로 이동
+    await page.goto(`/households/${household.id}`)
+    await page.waitForLoadState('networkidle')
+
+    // 설정 탭 클릭 (owner/admin만 보임 — E2E 유저는 owner)
+    await page.getByText('설정', { exact: true }).click()
+
+    // 가구 이름 입력 필드가 보여야 함
+    const nameInput = page.locator('input').first()
+    await expect(nameInput).toBeVisible({ timeout: 15000 })
+
+    // 이름 수정
+    await nameInput.fill('E2E 수정 후 가구')
+
+    // 저장 버튼 클릭 + PUT 응답 대기
+    await Promise.all([
+      page.waitForResponse(
+        (res) => res.url().includes('/api/households/') && res.request().method() === 'PUT',
+      ),
+      page.getByRole('button', { name: /저장/ }).click(),
+    ])
+
+    // 수정된 이름이 반영되었는지 확인 — 페이지 새로고침 후 확인
+    await page.goto(`/households/${household.id}`)
+    await page.waitForLoadState('networkidle')
+
+    // 설정 탭에서 수정된 이름이 보여야 함
+    await page.getByText('설정', { exact: true }).click()
+    const updatedInput = page.locator('input').first()
+    await expect(updatedInput).toHaveValue('E2E 수정 후 가구', { timeout: 15000 })
+  })
+})

--- a/e2e/tests/tier3-mobile.spec.ts
+++ b/e2e/tests/tier3-mobile.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * 모바일 뷰포트 E2E 테스트 (Tier 3)
+ *
+ * 375x812(iPhone X 기준) 뷰포트에서 하단 탭 네비게이션,
+ * 탭 이동, FAB(지출/수입 입력 버튼)를 검증한다.
+ */
+
+import { test, expect } from '../fixtures/auth'
+
+test.describe('모바일 뷰포트', () => {
+  test.beforeEach(async ({ authedPage: page }) => {
+    // 모바일 뷰포트 설정
+    await page.setViewportSize({ width: 375, height: 812 })
+  })
+
+  test('하단 탭 네비게이션 표시 확인', async ({ authedPage: page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // 모바일에서는 하단 탭 바(aria-label="하단 탭 메뉴")가 표시됨
+    const bottomNav = page.locator('nav[aria-label="하단 탭 메뉴"]')
+    await expect(bottomNav).toBeVisible({ timeout: 15000 })
+
+    // 하단 탭 바에 4개 탭이 모두 존재하는지 확인
+    for (const label of ['가계부', '자산', '돌아보기', '더보기']) {
+      await expect(bottomNav.getByText(label)).toBeVisible()
+    }
+  })
+
+  test('홈 → 돌아보기 → 자산 → 더보기 탭 이동', async ({ authedPage: page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const bottomNav = page.locator('nav[aria-label="하단 탭 메뉴"]')
+    await expect(bottomNav).toBeVisible({ timeout: 15000 })
+
+    // 돌아보기 탭
+    await bottomNav.getByText('돌아보기').click()
+    await expect(page).toHaveURL('/insights')
+
+    // 자산 탭
+    await bottomNav.getByText('자산').click()
+    await expect(page).toHaveURL('/assets')
+
+    // 더보기(설정) 탭
+    await bottomNav.getByText('더보기').click()
+    await expect(page).toHaveURL('/settings')
+
+    // 가계부(홈) 탭으로 복귀
+    await bottomNav.getByText('가계부').click()
+    await expect(page).toHaveURL('/')
+  })
+
+  test('FAB 클릭 → 지출 입력 페이지 이동', async ({ authedPage: page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    // FAB 메인 버튼 클릭 (aria-label="지출/수입 입력")
+    const fab = page.getByRole('button', { name: '지출/수입 입력' })
+    await expect(fab).toBeVisible({ timeout: 15000 })
+    await fab.click()
+
+    // 팝오버에서 "지출 입력" 선택
+    const expenseButton = page.getByText('지출 입력')
+    await expect(expenseButton).toBeVisible({ timeout: 5000 })
+    await expenseButton.click()
+
+    // 지출 입력 페이지로 이동
+    await expect(page).toHaveURL('/expenses/new', { timeout: 15000 })
+  })
+})

--- a/e2e/tests/tier3-settings.spec.ts
+++ b/e2e/tests/tier3-settings.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * 설정 페이지 E2E 테스트 (Tier 3)
+ *
+ * SettingsPage의 메뉴 항목 표시, 화면 모드 변경, 새소식,
+ * 내 계정 정보, 로그아웃 플로우를 검증한다.
+ */
+
+import { test, expect } from '../fixtures/auth'
+
+test.describe('설정 페이지', () => {
+  test('설정 페이지 이동 → 메뉴 항목 표시 확인', async ({ authedPage: page }) => {
+    await page.goto('/settings')
+    await page.waitForLoadState('networkidle')
+
+    // 주요 메뉴 항목이 모두 보여야 함
+    const menuLabels = [
+      '카테고리',
+      '예산 관리',
+      '반복 거래',
+      '공유 가계부',
+      '화면 모드',
+      '내 계정',
+      '새소식',
+      '사용 가이드',
+      '피드백',
+    ]
+
+    for (const label of menuLabels) {
+      await expect(page.getByText(label, { exact: true }).first()).toBeVisible({ timeout: 15000 })
+    }
+  })
+
+  test('화면 모드 섹션 → 테마 변경', async ({ authedPage: page }) => {
+    await page.goto('/settings/appearance')
+    await page.waitForLoadState('networkidle')
+
+    // 화면 모드 헤딩이 보여야 함
+    await expect(page.getByText('화면 모드')).toBeVisible({ timeout: 15000 })
+
+    // 3가지 테마 옵션이 보여야 함
+    await expect(page.getByText('시스템 설정')).toBeVisible()
+    await expect(page.getByText('라이트 모드')).toBeVisible()
+    await expect(page.getByText('다크 모드')).toBeVisible()
+
+    // 다크 모드 클릭
+    await page.getByText('다크 모드').click()
+    // 다크 모드 옵션의 설명이 보여야 함
+    await expect(page.getByText('어두운 화면')).toBeVisible()
+
+    // 라이트 모드 클릭
+    await page.getByText('라이트 모드').click()
+    await expect(page.getByText('밝은 화면')).toBeVisible()
+
+    // 시스템 설정 클릭
+    await page.getByText('시스템 설정').click()
+    await expect(page.getByText('기기 설정에 따라 자동 전환')).toBeVisible()
+    // 시스템 모드에서는 현재 적용 모드 안내 텍스트가 보임
+    await expect(page.getByText(/현재 적용:/)).toBeVisible()
+  })
+
+  test('새소식 섹션 → 버전 히스토리 표시', async ({ authedPage: page }) => {
+    await page.goto('/settings/changelog')
+    await page.waitForLoadState('networkidle')
+
+    // 버전 번호 형식(vX.X.X)이 하나 이상 보여야 함
+    await expect(page.locator('text=/v\\d+\\.\\d+/').first()).toBeVisible({ timeout: 15000 })
+  })
+
+  test('내 계정 섹션 → 이메일, 봇 연동 코드 발급 버튼 확인', async ({ authedPage: page }) => {
+    await page.goto('/settings/my-account')
+    await page.waitForLoadState('networkidle')
+
+    // 기본 정보 영역
+    await expect(page.getByText('기본 정보')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText('이메일')).toBeVisible()
+
+    // 텔레그램 연동 코드 발급 버튼 (미연동 상태에서 표시)
+    // E2E 유저는 봇 미연동이므로 "연동 코드 발급" 버튼이 보임
+    await expect(page.getByRole('button', { name: '연동 코드 발급' }).first()).toBeVisible()
+  })
+
+  test('로그아웃 버튼 클릭 → 로그인 페이지 이동', async ({ authedPage: page }) => {
+    await page.goto('/settings/my-account')
+    await page.waitForLoadState('networkidle')
+
+    // 로그아웃 버튼이 보여야 함
+    const logoutButton = page.getByRole('button', { name: '로그아웃' })
+    await expect(logoutButton).toBeVisible({ timeout: 15000 })
+
+    // 로그아웃 클릭
+    await logoutButton.click()
+
+    // SSO 로그인 페이지(auth.podonest.com) 또는 로컬 로그인 페이지로 이동
+    await expect(page).toHaveURL(/auth\.podonest\.com|\/login/, { timeout: 15000 })
+  })
+})


### PR DESCRIPTION
## Summary

E2E Tier 3 테스트 12개 (3개 파일).

| 파일 | 테스트 | 시나리오 |
|------|--------|---------|
| tier3-settings | 5 | 메뉴/테마/새소식/계정/로그아웃 |
| tier3-household | 4 | 목록/생성/상세/수정 |
| tier3-mobile | 3 | 모바일 탭/FAB |

## Test plan

- [x] BE 1594 passed
- [x] Playwright --list 확인
- [ ] CI 통과

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)