### PR TITLE
chore: FE↔BE 스키마 동기화 자동 검증

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,6 +16,9 @@ on:
       frontend_result:
         description: "프론트엔드 테스트 결과"
         value: ${{ jobs.test-frontend.result }}
+      schema_sync_result:
+        description: "스키마 동기화 검증 결과"
+        value: ${{ jobs.schema-sync.result }}
 
 jobs:
   test-backend:
@@ -176,3 +179,43 @@ jobs:
         if: inputs.frontend_build_check
         continue-on-error: true
         run: cd frontend && node scripts/bundle-size.mjs
+
+  schema-sync:
+    name: 스키마 동기화
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: uv 설치
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.20"
+          enable-cache: true
+
+      - name: Python 설정
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: BE 의존성 설치
+        run: uv sync --all-extras
+
+      - name: Node.js 설정
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: FE 의존성 설치
+        run: cd frontend && npm ci
+
+      - name: FE↔BE 스키마 동기화 검증
+        env:
+          DATABASE_URL: sqlite+aiosqlite:///./test.db
+          SECRET_KEY: test-secret-key  # pragma: allowlist secret
+          LLM_PROVIDER: anthropic
+          ANTHROPIC_API_KEY: test-key  # pragma: allowlist secret
+        run: ./scripts/check-schema-sync.sh

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -23,3 +23,7 @@ dist-ssr
 *.sln
 *.sw?
 coverage/
+
+# 스키마 동기화 검증용 생성 파일 (CI에서 매번 재생성)
+openapi.json
+src/types/generated-api.ts

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "globals": "^16.5.0",
         "jsdom": "^28.0.0",
         "msw": "^2.12.10",
+        "openapi-typescript": "^7.13.0",
         "tailwindcss": "^4.1.18",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
@@ -2708,6 +2709,82 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.11",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.11.tgz",
+      "integrity": "sha512-V09ayfnb5GyysmvARbt+voFZAjGcf7hSYxOYxSkCc4fbH/DTfq5YWoec8cflvmHHqyIFbqvmGKmYFzqhr9zxDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.1.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -4471,6 +4548,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4958,6 +5045,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -5027,6 +5121,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -6828,6 +6929,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -7393,6 +7507,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/js-tokens": {
@@ -8256,6 +8380,40 @@
       ],
       "license": "MIT"
     },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8349,6 +8507,37 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
@@ -8497,6 +8686,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -10195,6 +10394,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -11030,6 +11236,13 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
-    "analyze": "vite build && node scripts/bundle-size.mjs"
+    "analyze": "vite build && node scripts/bundle-size.mjs",
+    "check:schema": "npx openapi-typescript openapi.json -o src/types/generated-api.ts && npx tsc --noEmit --strict --moduleResolution bundler --module esnext --target esnext --skipLibCheck scripts/schema-sync-check.ts"
   },
   "dependencies": {
     "@sentry/react": "^9.0.0",
@@ -46,6 +47,7 @@
     "globals": "^16.5.0",
     "jsdom": "^28.0.0",
     "msw": "^2.12.10",
+    "openapi-typescript": "^7.13.0",
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",

--- a/frontend/scripts/schema-sync-check.ts
+++ b/frontend/scripts/schema-sync-check.ts
@@ -1,0 +1,168 @@
+/**
+ * @file schema-sync-check.ts
+ * @description BE OpenAPI 스키마와 FE 수동 타입 정의의 구조적 호환성을 검증한다.
+ *
+ * 원리: BE 생성 타입의 필수(non-optional) 필드가 FE 수동 타입에도 존재하는지
+ * TypeScript 컴파일러가 검사한다. 필드 누락 시 tsc 에러 발생.
+ *
+ * 허용하는 차이:
+ * - BE `string` ↔ FE 리터럴 유니온 (`'expense' | 'income'`) → FE가 더 구체적이므로 OK
+ * - BE `field?: T | null` ↔ FE `field: T | null` → optional vs nullable → OK
+ * - FE에만 있는 추가 필드 → FE 전용 타입이므로 OK
+ *
+ * 감지하는 문제:
+ * - BE에 새 필수 필드가 추가됐는데 FE 타입에 없음
+ * - BE 스키마 이름 변경으로 매핑 깨짐
+ *
+ * 사용법: npx tsc --noEmit scripts/schema-sync-check.ts
+ */
+
+import type { components } from '../src/types/generated-api'
+
+// ── BE 스키마 단축 참조 ──
+type S = components['schemas']
+
+// ── 헬퍼 타입 ──
+
+// BE 타입에서 필수(non-optional) 키만 추출
+type RequiredKeys<T> = {
+  [K in keyof T]-?: undefined extends T[K] ? never : K
+}[keyof T]
+
+// BE 필수 필드가 FE 타입에 모두 존재하는지 검증
+// 통과하면 true, 실패하면 에러 메시지 타입 반환
+type VerifyRequiredFields<
+  BEType,
+  FEType,
+  Label extends string
+> = RequiredKeys<BEType> extends keyof FEType
+  ? true
+  : `❌ ${Label}: FE 타입에 BE 필수 필드 누락`
+
+// ─────────────────────────────────────────────────
+// FE 타입 임포트
+// ─────────────────────────────────────────────────
+import type {
+  Account,
+  Asset,
+  AssetSummary,
+  AssetSnapshot,
+  AssetGoal,
+  Expense,
+  Category,
+  Income,
+  ParsedExpenseItem,
+  ChatResponse,
+  User,
+  Budget,
+  BudgetAlert,
+  MonthlySpending,
+  CategoryBudgetOverview,
+  TotalBudgetResponse,
+  BudgetMonthlyCategoryStats,
+  BudgetMonthlyStatsResponse,
+  CategoryStats,
+  TrendPoint,
+  StatsResponse,
+  PeriodTotal,
+  CategoryChange,
+  RecurringTransaction,
+  ExecuteResponse,
+  Feedback,
+  HealthScore,
+  Finding,
+  AssetAnalysisResult,
+  ActionItem,
+  RecentActivityItem,
+  InactiveUserItem,
+  AdminUserItem,
+  AdminUserListResponse,
+  AdminUserDetail,
+} from '../src/types/index'
+import type {
+  Household,
+  HouseholdMember,
+  HouseholdInvitation,
+} from '../src/types/household'
+
+// ─────────────────────────────────────────────────
+// BE 응답 → FE 타입 필수 필드 존재 검증
+// 각 줄에서 tsc 에러가 나면 해당 타입의 동기화가 깨진 것.
+// 에러 메시지에 어떤 타입이 문제인지 표시된다.
+// ─────────────────────────────────────────────────
+
+// 계좌/카드
+const _Account: VerifyRequiredFields<S['AccountResponse'], Account, 'Account'> = true
+
+// 자산
+const _Asset: VerifyRequiredFields<S['AssetWithPrice'], Asset, 'Asset'> = true
+const _AssetSummary: VerifyRequiredFields<S['AssetSummary'], AssetSummary, 'AssetSummary'> = true
+const _AssetSnapshot: VerifyRequiredFields<S['AssetSnapshotResponse'], AssetSnapshot, 'AssetSnapshot'> = true
+const _AssetGoal: VerifyRequiredFields<S['AssetGoalWithInsight'], AssetGoal, 'AssetGoal'> = true
+
+// 지출/수입
+const _Expense: VerifyRequiredFields<S['ExpenseResponse'], Expense, 'Expense'> = true
+const _Category: VerifyRequiredFields<S['CategoryResponse'], Category, 'Category'> = true
+const _Income: VerifyRequiredFields<S['IncomeResponse'], Income, 'Income'> = true
+
+// 채팅/파싱
+const _ParsedItem: VerifyRequiredFields<S['ParsedExpenseItem'], ParsedExpenseItem, 'ParsedExpenseItem'> = true
+const _ChatResp: VerifyRequiredFields<S['ChatResponse'], ChatResponse, 'ChatResponse'> = true
+
+// 사용자
+const _User: VerifyRequiredFields<S['UserResponse'], User, 'User'> = true
+
+// 예산
+const _Budget: VerifyRequiredFields<S['BudgetResponse'], Budget, 'Budget'> = true
+const _BudgetAlert: VerifyRequiredFields<S['BudgetAlert'], BudgetAlert, 'BudgetAlert'> = true
+const _MonthlySpending: VerifyRequiredFields<S['MonthlySpending'], MonthlySpending, 'MonthlySpending'> = true
+const _CatBudget: VerifyRequiredFields<S['CategoryBudgetOverview'], CategoryBudgetOverview, 'CategoryBudgetOverview'> = true
+const _TotalBudget: VerifyRequiredFields<S['TotalBudgetResponse'], TotalBudgetResponse, 'TotalBudgetResponse'> = true
+const _BudgetMonthlyCat: VerifyRequiredFields<S['BudgetMonthlyCategoryStats'], BudgetMonthlyCategoryStats, 'BudgetMonthlyCategoryStats'> = true
+const _BudgetMonthlyStats: VerifyRequiredFields<S['BudgetMonthlyStatsResponse'], BudgetMonthlyStatsResponse, 'BudgetMonthlyStatsResponse'> = true
+
+// 통계
+const _CategoryStats: VerifyRequiredFields<S['CategoryStats'], CategoryStats, 'CategoryStats'> = true
+const _TrendPoint: VerifyRequiredFields<S['TrendPoint'], TrendPoint, 'TrendPoint'> = true
+const _StatsResp: VerifyRequiredFields<S['StatsResponse'], StatsResponse, 'StatsResponse'> = true
+const _PeriodTotal: VerifyRequiredFields<S['PeriodTotal'], PeriodTotal, 'PeriodTotal'> = true
+const _CategoryChange: VerifyRequiredFields<S['CategoryChange'], CategoryChange, 'CategoryChange'> = true
+
+// 정기 거래
+const _Recurring: VerifyRequiredFields<S['RecurringTransactionResponse'], RecurringTransaction, 'RecurringTransaction'> = true
+const _ExecuteResp: VerifyRequiredFields<S['ExecuteResponse'], ExecuteResponse, 'ExecuteResponse'> = true
+
+// 피드백
+const _Feedback: VerifyRequiredFields<S['FeedbackResponse'], Feedback, 'Feedback'> = true
+
+// 인사이트
+const _HealthScore: VerifyRequiredFields<S['HealthScoreBreakdown'], HealthScore, 'HealthScore'> = true
+const _Finding: VerifyRequiredFields<S['Finding'], Finding, 'Finding'> = true
+const _AssetAnalysis: VerifyRequiredFields<S['AssetAnalysis'], AssetAnalysisResult, 'AssetAnalysis'> = true
+const _ActionItem: VerifyRequiredFields<S['ActionItem'], ActionItem, 'ActionItem'> = true
+
+// Admin
+const _RecentActivity: VerifyRequiredFields<S['RecentActivityItem'], RecentActivityItem, 'RecentActivity'> = true
+const _InactiveUser: VerifyRequiredFields<S['InactiveUserItem'], InactiveUserItem, 'InactiveUser'> = true
+const _AdminUserItem: VerifyRequiredFields<S['AdminUserItem'], AdminUserItem, 'AdminUserItem'> = true
+const _AdminUserList: VerifyRequiredFields<S['AdminUserListResponse'], AdminUserListResponse, 'AdminUserList'> = true
+const _AdminUserDetail: VerifyRequiredFields<S['AdminUserDetailResponse'], AdminUserDetail, 'AdminUserDetail'> = true
+
+// Household
+const _Household: VerifyRequiredFields<S['HouseholdResponse'], Household, 'Household'> = true
+const _HouseholdMember: VerifyRequiredFields<S['MemberResponse'], HouseholdMember, 'HouseholdMember'> = true
+const _HouseholdInvitation: VerifyRequiredFields<S['InvitationResponse'], HouseholdInvitation, 'HouseholdInvitation'> = true
+
+// 사용하지 않는 변수 경고 방지
+export {
+  _Account, _Asset, _AssetSummary, _AssetSnapshot, _AssetGoal,
+  _Expense, _Category, _Income,
+  _ParsedItem, _ChatResp, _User,
+  _Budget, _BudgetAlert, _MonthlySpending, _CatBudget, _TotalBudget,
+  _BudgetMonthlyCat, _BudgetMonthlyStats,
+  _CategoryStats, _TrendPoint, _StatsResp, _PeriodTotal, _CategoryChange,
+  _Recurring, _ExecuteResp, _Feedback,
+  _HealthScore, _Finding, _AssetAnalysis, _ActionItem,
+  _RecentActivity, _InactiveUser, _AdminUserItem, _AdminUserList, _AdminUserDetail,
+  _Household, _HouseholdMember, _HouseholdInvitation,
+}

--- a/frontend/src/pages/AccountManager.tsx
+++ b/frontend/src/pages/AccountManager.tsx
@@ -37,7 +37,6 @@ export default function AccountManager() {
   }
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true)
     loadAccounts()
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/scripts/check-schema-sync.sh
+++ b/scripts/check-schema-sync.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# FE↔BE 스키마 동기화 검증 스크립트
+#
+# BE OpenAPI 스펙에서 TypeScript 타입을 자동 생성하고,
+# FE 수동 타입 정의와의 구조적 호환성을 tsc로 검증한다.
+#
+# 사용법:
+#   ./scripts/check-schema-sync.sh
+#
+# 필요 조건:
+#   - uv (Python 패키지 매니저)
+#   - Node.js + npm (frontend 의존성 설치 상태)
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OPENAPI_JSON="$PROJECT_ROOT/frontend/openapi.json"
+GENERATED_TYPES="$PROJECT_ROOT/frontend/src/types/generated-api.ts"
+
+echo "🔍 FE↔BE 스키마 동기화 검증 시작"
+echo ""
+
+# Step 1: BE OpenAPI 스펙 추출
+echo "📋 Step 1: BE OpenAPI 스펙 추출..."
+cd "$PROJECT_ROOT"
+PYTHONPATH=backend uv run python scripts/extract-openapi.py "$OPENAPI_JSON"
+echo ""
+
+# Step 2: openapi-typescript로 타입 생성
+echo "📋 Step 2: TypeScript 타입 생성..."
+cd "$PROJECT_ROOT/frontend"
+npx openapi-typescript "$OPENAPI_JSON" -o "$GENERATED_TYPES" 2>&1
+echo ""
+
+# Step 3: tsc로 타입 호환성 검증
+echo "📋 Step 3: 타입 호환성 검증 (tsc)..."
+cd "$PROJECT_ROOT/frontend"
+
+# schema-sync-check.ts를 별도 tsconfig로 검증 (프로젝트 tsconfig와 독립)
+npx tsc \
+  --noEmit \
+  --strict \
+  --moduleResolution bundler \
+  --module esnext \
+  --target esnext \
+  --skipLibCheck \
+  scripts/schema-sync-check.ts
+
+echo ""
+echo "✅ 스키마 동기화 검증 통과 — FE 타입이 BE 스펙과 호환됩니다."

--- a/scripts/extract-openapi.py
+++ b/scripts/extract-openapi.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""BE OpenAPI 스펙을 JSON 파일로 추출하는 스크립트.
+
+BE 서버를 실행하지 않고 FastAPI app 인스턴스에서 직접 OpenAPI 스키마를 추출합니다.
+CI에서 FE 타입과의 동기화 검증에 사용됩니다.
+
+Usage:
+    PYTHONPATH=backend python scripts/extract-openapi.py [output_path]
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    output_path = sys.argv[1] if len(sys.argv) > 1 else "frontend/openapi.json"
+
+    # FastAPI app에서 OpenAPI 스키마 추출
+    from app.main import app
+
+    schema = app.openapi()
+
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(schema, indent=2, ensure_ascii=False) + "\n")
+
+    # 요약 출력
+    paths = schema.get("paths", {})
+    schemas = schema.get("components", {}).get("schemas", {})
+    endpoint_count = sum(len(methods) for methods in paths.values())
+    print(f"✅ OpenAPI 스펙 추출 완료: {output_path}")
+    print(f"   엔드포인트: {endpoint_count}개, 스키마: {len(schemas)}개")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- BE OpenAPI 스펙과 FE TypeScript 타입의 호환성을 CI에서 자동 검증
- 38개 응답 타입 매핑 (Expense, Income, Category, Budget, Asset, Household 등)
- BE 서버 없이 Python으로 스펙 추출 → openapi-typescript로 타입 생성 → tsc 검증
- CI에 schema-sync 잡 추가 (기존 테스트와 병렬)

## Test plan
- [x] `bash scripts/check-schema-sync.sh` 통과
- [x] FE 전체 테스트 1258개 통과
- [ ] CI schema-sync 잡 통과 확인

close #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)