### PR TITLE
feat: 돌아보기 네비게이션 + 수입 전월 비교 + 예산 버그 수정

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,16 @@ repos:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
 
+  # mypy: 타입 검사 (pre-push — 느려서 커밋마다는 X)
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy (BE 타입 검사)
+        entry: bash -c 'cd backend && uv run mypy app/'
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+
   # 기본 체크
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/backend/app/api/budget.py
+++ b/backend/app/api/budget.py
@@ -277,7 +277,7 @@ async def get_monthly_stats(
         .where(
             budget_scope,  # type: ignore[arg-type]
             Budget.period == "monthly",
-            Budget.start_date <= start,
+            Budget.start_date < end,  # 해당 월 안에 시작된 예산 포함 (#434)
             or_(Budget.end_date.is_(None), Budget.end_date >= start),
         )
         .order_by(Budget.created_at.desc())

--- a/backend/app/api/e2e.py
+++ b/backend/app/api/e2e.py
@@ -43,7 +43,7 @@ class E2ESetupResponse(BaseModel):
 
 
 @router.post("/e2e/setup", response_model=E2ESetupResponse)
-async def e2e_setup(request: E2ESetupRequest):
+async def e2e_setup(request: E2ESetupRequest) -> object:
     """E2E 테스트 유저 생성 + JWT 발급"""
     if not settings.DEBUG:
         raise HTTPException(status_code=404, detail="Not Found")
@@ -80,7 +80,7 @@ async def e2e_setup(request: E2ESetupRequest):
                 household_id = household.id
             else:
                 result = await db.execute(select(HouseholdMember.household_id).where(HouseholdMember.user_id == user.id).limit(1))
-                household_id = result.scalar_one_or_none() or 1
+                household_id = result.scalar_one_or_none() or 1  # type: ignore[assignment]
 
             payload = {
                 "sub": str(user.auth_user_id),
@@ -106,7 +106,7 @@ class E2ECleanupResponse(BaseModel):
 
 
 @router.post("/e2e/cleanup", response_model=E2ECleanupResponse)
-async def e2e_cleanup(request: E2ECleanupRequest, db: AsyncSession = Depends(get_db)):
+async def e2e_cleanup(request: E2ECleanupRequest, db: AsyncSession = Depends(get_db)) -> object:
     """E2E 테스트 데이터 정리 — 특정 유저의 모든 데이터를 삭제
 
     household_id를 통해 해당 가구에 속한 지출/수입/카테고리/예산/정기거래를 삭제합니다.
@@ -137,7 +137,7 @@ async def e2e_cleanup(request: E2ECleanupRequest, db: AsyncSession = Depends(get
             result = await db.execute(
                 delete(model).where(model.household_id.in_(household_ids))  # type: ignore[attr-defined]
             )
-            deleted[name] = result.rowcount  # type: ignore[assignment]
+            deleted[name] = result.rowcount or 0
 
         await db.commit()
 

--- a/backend/app/api/income.py
+++ b/backend/app/api/income.py
@@ -10,10 +10,11 @@
 """
 
 import logging
+from calendar import monthrange
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import func, select
+from sqlalchemy import extract, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import get_household_member, get_user_active_household_id
@@ -22,7 +23,17 @@ from app.core.database import get_db
 from app.models.category import Category
 from app.models.income import Income
 from app.models.user import User
-from app.schemas.expense import CategoryStats, SearchSummary, StatsPeriod, StatsResponse, TrendPoint
+from app.schemas.expense import (
+    CategoryChange,
+    CategoryStats,
+    ChangeInfo,
+    ComparisonResponse,
+    PeriodTotal,
+    SearchSummary,
+    StatsPeriod,
+    StatsResponse,
+    TrendPoint,
+)
 from app.schemas.income import IncomeCreate, IncomeResponse, IncomeUpdate
 from app.utils.date_utils import get_month_range, get_week_label, get_week_range, get_year_range
 
@@ -244,6 +255,162 @@ async def get_incomes_search_summary(
     result = await db.execute(stmt)
     count, total = result.one()
     return SearchSummary(total_count=count, total_amount=float(total))
+
+
+@router.get("/stats/comparison", response_model=ComparisonResponse)
+async def get_income_stats_comparison(
+    period: str = Query(
+        ...,
+        description="비교 기간: monthly 또는 yearly",
+        pattern=r"^(monthly|yearly)$",
+    ),
+    date: str | None = Query(None, description="기준 날짜 YYYY-MM-DD (기본: 오늘)", alias="date"),
+    months: int = Query(3, ge=2, le=12, description="비교할 개월 수"),
+    household_id: int | None = None,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> object:
+    """수입 기간 비교 (전월 대비 + N개월 트렌드)"""
+    from datetime import date as date_type
+
+    ref_date = date_type.fromisoformat(date) if date else date_type.today()
+
+    # household_id 미지정 시 활성 가구 자동 감지
+    if household_id is None:
+        household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)
+    scope_filter = _build_income_scope_filter(household_id)
+
+    excl_filter = Income.exclude_from_stats == False  # noqa: E712
+
+    async def _month_total(year: int, month: int, end_day: int | None = None) -> float:
+        m_start = datetime(year, month, 1)
+        _, m_last = monthrange(year, month)
+        actual_end = min(end_day, m_last) if end_day is not None else m_last
+        m_end = datetime(year, month, actual_end, 23, 59, 59)
+        r = await db.execute(
+            select(func.coalesce(func.sum(Income.amount), 0)).where(scope_filter, excl_filter, Income.date >= m_start, Income.date <= m_end)  # type: ignore[arg-type]
+        )
+        return float(r.scalar())  # type: ignore[arg-type]
+
+    async def _month_by_category(year: int, month: int, end_day: int | None = None) -> dict[str, float]:
+        m_start = datetime(year, month, 1)
+        _, m_last = monthrange(year, month)
+        actual_end = min(end_day, m_last) if end_day is not None else m_last
+        m_end = datetime(year, month, actual_end, 23, 59, 59)
+        r = await db.execute(
+            select(Category.name, func.sum(Income.amount).label("amount"))
+            .join(Category, Income.category_id == Category.id, isouter=True)
+            .where(scope_filter, excl_filter, Income.date >= m_start, Income.date <= m_end)  # type: ignore[arg-type]
+            .group_by(Category.name)
+        )
+        return {row.name or "미분류": float(row.amount) for row in r.all()}
+
+    if period == "monthly":
+        cur_y, cur_m = ref_date.year, ref_date.month
+        prev_m = cur_m - 1 if cur_m > 1 else 12
+        prev_y = cur_y if cur_m > 1 else cur_y - 1
+
+        # 진행 중인 달이면 오늘까지만 비교 (전기 대비 동일 경과일 기준)
+        today = date_type.today()
+        is_current_month = cur_y == today.year and cur_m == today.month
+        end_day = today.day if is_current_month else None
+
+        current_total = await _month_total(cur_y, cur_m, end_day)
+        previous_total = await _month_total(prev_y, prev_m, end_day)
+
+        if is_current_month:
+            _, prev_last = monthrange(prev_y, prev_m)
+            prev_end_day = min(today.day, prev_last)
+            current_label = f"{cur_y}년 {cur_m}월 ({today.day}일까지)"
+            previous_label = f"{prev_y}년 {prev_m}월 ({prev_end_day}일까지)"
+        else:
+            current_label = f"{cur_y}년 {cur_m}월"
+            previous_label = f"{prev_y}년 {prev_m}월"
+
+        # N개월 트렌드 (현재 월 포함 과거 N개월) — 단일 GROUP BY 쿼리
+        trend_data: list[PeriodTotal] = []
+        y, m = cur_y, cur_m
+        for _ in range(months - 1):
+            m -= 1
+            if m < 1:
+                m = 12
+                y -= 1
+        start_y, start_m = y, m
+        _, end_last = monthrange(cur_y, cur_m)
+        trend_start = datetime(start_y, start_m, 1)
+        trend_end = datetime(cur_y, cur_m, end_last, 23, 59, 59)
+
+        yr_col = func.extract("year", Income.date).label("year")
+        mo_col = func.extract("month", Income.date).label("month")
+        trend_result = await db.execute(
+            select(yr_col, mo_col, func.coalesce(func.sum(Income.amount), 0).label("amount"))
+            .where(scope_filter, excl_filter, Income.date >= trend_start, Income.date <= trend_end)  # type: ignore[arg-type]
+            .group_by(yr_col, mo_col)
+            .order_by(yr_col, mo_col)
+        )
+        trend_map = {(int(r.year), int(r.month)): float(r.amount) for r in trend_result.all()}
+        for _ in range(months):
+            trend_data.append(PeriodTotal(label=f"{y}년 {m}월", total=trend_map.get((y, m), 0.0)))
+            m += 1
+            if m > 12:
+                m = 1
+                y += 1
+
+        # 카테고리별 비교 (동일 end_day 적용)
+        cur_cats = await _month_by_category(cur_y, cur_m, end_day)
+        prev_cats = await _month_by_category(prev_y, prev_m, end_day)
+        all_cats = set(cur_cats.keys()) | set(prev_cats.keys())
+        by_cat_comparison = []
+        for cat in sorted(all_cats):
+            c = cur_cats.get(cat, 0)
+            p = prev_cats.get(cat, 0)
+            change_pct = round((c - p) / p * 100, 1) if p > 0 else None
+            by_cat_comparison.append(
+                CategoryChange(
+                    category=cat,
+                    current=c,
+                    previous=p,
+                    change_amount=round(c - p, 2),
+                    change_percentage=change_pct,
+                )
+            )
+    else:  # yearly
+        cur_y = ref_date.year
+        prev_y = cur_y - 1
+
+        # 필요한 연도 목록 수집 (current, previous, trend)
+        trend_years = [cur_y - y_offset for y_offset in range(months - 1, -1, -1)]
+        years_needed = list({cur_y, prev_y, *trend_years})
+
+        # 연도별 합계를 단일 쿼리로 조회
+        year_totals_result = await db.execute(
+            select(extract("year", Income.date).label("year"), func.coalesce(func.sum(Income.amount), 0).label("total"))
+            .where(scope_filter, excl_filter, extract("year", Income.date).in_(years_needed))  # type: ignore[arg-type]
+            .group_by(extract("year", Income.date))
+        )
+        year_totals: dict[int, float] = {int(row.year): float(row.total) for row in year_totals_result.all()}
+
+        current_total = year_totals.get(cur_y, 0.0)
+        previous_total = year_totals.get(prev_y, 0.0)
+        current_label = f"{cur_y}년"
+        previous_label = f"{prev_y}년"
+
+        trend_data = [PeriodTotal(label=f"{y}년", total=year_totals.get(y, 0.0)) for y in trend_years]
+
+        by_cat_comparison = []
+
+    # 변화량 계산
+    change_amount = round(current_total - previous_total, 2)
+    change_pct = round(change_amount / previous_total * 100, 1) if previous_total > 0 else None
+
+    return ComparisonResponse(
+        current=PeriodTotal(label=current_label, total=current_total),
+        previous=PeriodTotal(label=previous_label, total=previous_total),
+        change=ChangeInfo(amount=change_amount, percentage=change_pct),
+        trend=trend_data,
+        by_category_comparison=by_cat_comparison,
+    )
 
 
 @router.get("/{income_id}", response_model=IncomeResponse)

--- a/backend/tests/integration/test_api_budget_extra.py
+++ b/backend/tests/integration/test_api_budget_extra.py
@@ -340,3 +340,43 @@ async def test_category_overview_null_category_expense(
     response = await authenticated_client.get("/api/budgets/category-overview")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
+
+@pytest.mark.asyncio
+async def test_monthly_stats_includes_mid_month_budget(authenticated_client: AsyncClient, test_user: User, test_household: Household, db_session: AsyncSession):
+    """같은 달 중간에 생성된 예산도 monthly-stats에 포함되어야 한다 (#434)"""
+    category = Category(user_id=test_user.id, name="식비", household_id=test_household.id)
+    db_session.add(category)
+    await db_session.commit()
+    await db_session.refresh(category)
+
+    # 3월 15일에 생성된 예산 (start_date = 3/15)
+    budget = Budget(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        category_id=category.id,
+        amount=300000,
+        period="monthly",
+        start_date=datetime(2026, 3, 15),
+    )
+    db_session.add(budget)
+
+    # 3월에 지출 발생
+    expense = Expense(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        category_id=category.id,
+        amount=80000,
+        description="김치찌개",
+        date=datetime(2026, 3, 20),
+    )
+    db_session.add(expense)
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/budgets/monthly-stats", params={"month": "2026-03"})
+    assert response.status_code == 200
+    data = response.json()
+
+    # 식비 카테고리가 포함되어야 함
+    cat_names = [c["category_name"] for c in data["categories"]]
+    assert "식비" in cat_names, f"식비 예산이 누락됨: {cat_names}"

--- a/backend/tests/integration/test_api_income_comparison.py
+++ b/backend/tests/integration/test_api_income_comparison.py
@@ -1,0 +1,160 @@
+"""수입 기간 비교 API 통합 테스트"""
+
+from datetime import datetime
+
+import pytest
+
+from app.models.category import Category
+from app.models.household import Household
+from app.models.income import Income
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_income_comparison_monthly(authenticated_client, test_user: User, test_household: Household, db_session):
+    """월간 수입 비교 — 이번 달 vs 전월"""
+    db_session.add_all(
+        [
+            # 2026년 2월 (현재)
+            Income(user_id=test_user.id, household_id=test_household.id, amount=3500000, description="2월 월급", date=datetime(2026, 2, 1)),
+            Income(user_id=test_user.id, household_id=test_household.id, amount=500000, description="2월 보너스", date=datetime(2026, 2, 15)),
+            # 2026년 1월 (전월)
+            Income(user_id=test_user.id, household_id=test_household.id, amount=3000000, description="1월 월급", date=datetime(2026, 1, 10)),
+        ]
+    )
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/income/stats/comparison?period=monthly&date=2026-02-15")
+    assert response.status_code == 200
+    data = response.json()
+
+    # 응답 구조
+    assert "current" in data
+    assert "previous" in data
+    assert "change" in data
+    assert "trend" in data
+    assert "by_category_comparison" in data
+
+    # 금액 검증
+    assert data["current"]["total"] == 4000000
+    assert data["previous"]["total"] == 3000000
+
+    # 변화량
+    assert data["change"]["amount"] == 1000000
+    assert data["change"]["percentage"] == pytest.approx(33.3, abs=0.1)
+
+    # 트렌드 (기본 3개월)
+    assert len(data["trend"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_income_comparison_monthly_no_previous(authenticated_client, test_user: User, test_household: Household, db_session):
+    """전월 수입이 없는 경우"""
+    db_session.add(Income(user_id=test_user.id, household_id=test_household.id, amount=3500000, description="월급", date=datetime(2026, 2, 1)))
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/income/stats/comparison?period=monthly&date=2026-02-15")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["current"]["total"] == 3500000
+    assert data["previous"]["total"] == 0
+    assert data["change"]["percentage"] is None  # 0으로 나눌 수 없음
+
+
+@pytest.mark.asyncio
+async def test_income_comparison_yearly(authenticated_client, test_user: User, test_household: Household, db_session):
+    """연간 수입 비교"""
+    db_session.add_all(
+        [
+            Income(user_id=test_user.id, household_id=test_household.id, amount=40000000, description="2026 연봉", date=datetime(2026, 6, 1)),
+            Income(user_id=test_user.id, household_id=test_household.id, amount=36000000, description="2025 연봉", date=datetime(2025, 6, 1)),
+        ]
+    )
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/income/stats/comparison?period=yearly&date=2026-06-15")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["current"]["total"] == 40000000
+    assert data["previous"]["total"] == 36000000
+    assert data["change"]["amount"] == 4000000
+
+
+@pytest.mark.asyncio
+async def test_income_comparison_with_categories(authenticated_client, test_user: User, test_household: Household, db_session):
+    """카테고리별 수입 비교"""
+    cat = Category(name="급여", type="income", user_id=test_user.id)
+    db_session.add(cat)
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            Income(user_id=test_user.id, household_id=test_household.id, amount=3500000, description="2월 월급", category_id=cat.id, date=datetime(2026, 2, 1)),
+            Income(user_id=test_user.id, household_id=test_household.id, amount=3000000, description="1월 월급", category_id=cat.id, date=datetime(2026, 1, 1)),
+        ]
+    )
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/income/stats/comparison?period=monthly&date=2026-02-15")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data["by_category_comparison"]) >= 1
+    salary_cat = next(c for c in data["by_category_comparison"] if c["category"] == "급여")
+    assert salary_cat["current"] == 3500000
+    assert salary_cat["previous"] == 3000000
+    assert salary_cat["change_amount"] == 500000
+
+
+@pytest.mark.asyncio
+async def test_income_comparison_empty(authenticated_client):
+    """수입이 전혀 없는 경우"""
+    response = await authenticated_client.get("/api/income/stats/comparison?period=monthly&date=2026-02-15")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current"]["total"] == 0
+    assert data["previous"]["total"] == 0
+    assert data["change"]["amount"] == 0
+    assert data["change"]["percentage"] is None
+
+
+@pytest.mark.asyncio
+async def test_income_comparison_invalid_period(authenticated_client):
+    """잘못된 period 값 → 422"""
+    response = await authenticated_client.get("/api/income/stats/comparison?period=daily")
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_income_comparison_custom_months(authenticated_client, test_user: User, test_household: Household, db_session):
+    """months 파라미터로 트렌드 기간 조절"""
+    db_session.add(Income(user_id=test_user.id, household_id=test_household.id, amount=1000000, description="수입", date=datetime(2026, 2, 1)))
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/income/stats/comparison?period=monthly&date=2026-02-15&months=6")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["trend"]) == 6
+
+
+@pytest.mark.asyncio
+async def test_income_comparison_excludes_stats_excluded(authenticated_client, test_user: User, test_household: Household, db_session):
+    """exclude_from_stats=True 수입은 비교에서 제외"""
+    db_session.add_all(
+        [
+            Income(
+                user_id=test_user.id, household_id=test_household.id, amount=3500000, description="월급", date=datetime(2026, 2, 1), exclude_from_stats=False
+            ),
+            Income(
+                user_id=test_user.id, household_id=test_household.id, amount=50000000, description="퇴직금", date=datetime(2026, 2, 15), exclude_from_stats=True
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/income/stats/comparison?period=monthly&date=2026-02-15")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["current"]["total"] == 3500000  # 퇴직금 제외

--- a/frontend/src/api/income.ts
+++ b/frontend/src/api/income.ts
@@ -1,7 +1,7 @@
 /* 수입 API */
 
 import apiClient from './client'
-import type { Income, StatsResponse } from '../types'
+import type { Income, StatsResponse, ComparisonResponse } from '../types'
 
 interface GetIncomesParams {
   skip?: number
@@ -38,6 +38,16 @@ export const incomeApi = {
       params: {
         period,
         ...(date && { date }),
+        ...(householdId != null && { household_id: householdId }),
+      },
+    }),
+
+  getComparison: (period: string, date?: string, months?: number, householdId?: number) =>
+    apiClient.get<ComparisonResponse>('/income/stats/comparison', {
+      params: {
+        period,
+        ...(date && { date }),
+        ...(months && { months }),
         ...(householdId != null && { household_id: householdId }),
       },
     }),

--- a/frontend/src/components/stats/BudgetVsActual.tsx
+++ b/frontend/src/components/stats/BudgetVsActual.tsx
@@ -12,9 +12,10 @@ import { formatAmount } from '../../utils/format'
 interface BudgetVsActualProps {
   budgetStats: BudgetMonthlyStatsResponse | null
   maxItems?: number
+  monthStr?: string
 }
 
-export default function BudgetVsActual({ budgetStats, maxItems = 5 }: BudgetVsActualProps) {
+export default function BudgetVsActual({ budgetStats, maxItems = 5, monthStr }: BudgetVsActualProps) {
   const [expanded, setExpanded] = useState(false)
 
   if (!budgetStats || budgetStats.categories.length === 0) return null
@@ -70,7 +71,12 @@ export default function BudgetVsActual({ budgetStats, maxItems = 5 }: BudgetVsAc
           <div key={cat.category_name}>
             <div className="flex justify-between items-center mb-1">
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-[var(--text-primary)]">{cat.category_name}</span>
+                <Link
+                  to={monthStr ? `/?month=${monthStr}&category=${cat.category_name}` : `/?category=${cat.category_name}`}
+                  className="text-sm font-medium text-[var(--text-primary)] hover:text-grape-600 transition-colors"
+                >
+                  {cat.category_name}
+                </Link>
                 {cat.is_exceeded && (
                   <span className="text-xs px-1.5 py-0.5 bg-red-100 text-red-600 rounded-full">초과</span>
                 )}

--- a/frontend/src/components/stats/CategoryTopList.tsx
+++ b/frontend/src/components/stats/CategoryTopList.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import type { CategoryStats } from '../../types'
 import { formatAmount } from '../../utils/format'
@@ -6,9 +7,10 @@ import { formatAmount } from '../../utils/format'
 interface CategoryTopListProps {
   categories: CategoryStats[]
   maxItems?: number
+  monthStr?: string
 }
 
-export default function CategoryTopList({ categories, maxItems = 5 }: CategoryTopListProps) {
+export default function CategoryTopList({ categories, maxItems = 5, monthStr }: CategoryTopListProps) {
   const [expanded, setExpanded] = useState(false)
   if (categories.length === 0) return null
 
@@ -19,23 +21,29 @@ export default function CategoryTopList({ categories, maxItems = 5 }: CategoryTo
     <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4">
       <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-3">지출 카테고리 TOP</h3>
       <div className="space-y-2.5">
-        {visible.map((cat, i) => (
-          <div key={cat.category}>
-            <div className="flex items-center justify-between mb-1">
-              <div className="flex items-center gap-2">
-                <span className="text-xs font-medium text-[var(--text-muted)] w-4">{i + 1}</span>
-                <span className="text-sm font-medium text-[var(--text-primary)]">{cat.category}</span>
+        {visible.map((cat, i) => {
+          const href = monthStr
+            ? `/?month=${monthStr}&category=${cat.category}`
+            : `/?category=${cat.category}`
+
+          return (
+            <Link key={cat.category} to={href} className="block hover:bg-[var(--surface-hover)] -mx-2 px-2 py-1 rounded-lg transition-colors">
+              <div className="flex items-center justify-between mb-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-medium text-[var(--text-muted)] w-4">{i + 1}</span>
+                  <span className="text-sm font-medium text-[var(--text-primary)]">{cat.category}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-[var(--text-secondary)]">{formatAmount(cat.amount)}</span>
+                  <span className="text-xs text-[var(--text-tertiary)] w-12 text-right">{cat.percentage.toFixed(1)}%</span>
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-[var(--text-secondary)]">{formatAmount(cat.amount)}</span>
-                <span className="text-xs text-[var(--text-tertiary)] w-12 text-right">{cat.percentage.toFixed(1)}%</span>
+              <div className="h-1.5 bg-[var(--surface-hover)] rounded-full overflow-hidden ml-6">
+                <div className="h-full rounded-full bg-grape-500" style={{ width: `${cat.percentage}%` }} />
               </div>
-            </div>
-            <div className="h-1.5 bg-[var(--surface-hover)] rounded-full overflow-hidden ml-6">
-              <div className="h-full rounded-full bg-grape-500" style={{ width: `${cat.percentage}%` }} />
-            </div>
-          </div>
-        ))}
+            </Link>
+          )
+        })}
       </div>
 
       {hasMore && (

--- a/frontend/src/components/stats/UnifiedSummaryCards.tsx
+++ b/frontend/src/components/stats/UnifiedSummaryCards.tsx
@@ -1,7 +1,10 @@
 /**
  * @file UnifiedSummaryCards.tsx
- * @description 종합 리포트 핵심 지표 카드 — (순자산) + 총수입/총지출/순수익/저축률
+ * @description 이달의 리포트 핵심 지표 카드 — (순자산) + 총수입/총지출/남은 돈/저축률
+ * 각 카드 클릭 시 관련 상세 페이지로 이동
  */
+
+import { Link } from 'react-router-dom'
 
 interface UnifiedSummaryCardsProps {
   incomeTotal: number
@@ -10,6 +13,7 @@ interface UnifiedSummaryCardsProps {
   prevNetWorth?: number | null
   prevIncome?: number | null
   prevExpense?: number | null
+  monthStr?: string
 }
 
 function formatAmount(amount: number): string {
@@ -43,6 +47,7 @@ export default function UnifiedSummaryCards({
   prevNetWorth,
   prevIncome,
   prevExpense,
+  monthStr,
 }: UnifiedSummaryCardsProps) {
   const net = incomeTotal - expenseTotal
   const savingsRate = incomeTotal > 0 ? (net / incomeTotal) * 100 : null
@@ -57,20 +62,23 @@ export default function UnifiedSummaryCards({
           ? 'text-amber-600'
           : 'text-red-600'
 
+  const cardBase = "rounded-2xl shadow-sm p-4 sm:p-5 block hover:ring-2 hover:ring-grape-200 transition-shadow"
+
   return (
     <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-      {/* 순자산 카드 (자산 데이터가 있을 때만) */}
+      {/* 순자산 카드 → 자산 페이지 */}
       {netWorth != null && (
-        <div className="col-span-2 lg:col-span-4 bg-gradient-to-br from-warm-50 to-warm-100 border border-[var(--border-default)] rounded-2xl shadow-sm p-4 sm:p-5 text-center">
+        <Link to="/assets" className={`col-span-2 lg:col-span-4 bg-gradient-to-br from-warm-50 to-warm-100 border border-[var(--border-default)] ${cardBase} text-center`}>
           <p className="text-sm text-[var(--text-tertiary)] mb-0.5">순자산</p>
           <p className="text-xl sm:text-2xl font-bold text-[var(--text-primary)]">{formatLargeAmount(netWorth)}</p>
           {prevNetWorth != null && prevNetWorth !== 0 && (
             <ChangeIndicator current={netWorth} previous={prevNetWorth} />
           )}
-        </div>
+        </Link>
       )}
 
-      <div className="bg-gradient-to-br from-leaf-50 to-leaf-100 border border-leaf-200/60 rounded-2xl shadow-sm p-4 sm:p-5">
+      {/* 총 수입 → 수입 필터 목록 */}
+      <Link to={monthStr ? `/?month=${monthStr}&filter=income` : '/?filter=income'} className={`bg-gradient-to-br from-leaf-50 to-leaf-100 border border-leaf-200/60 ${cardBase}`}>
         <p className="text-sm text-leaf-600/70">총 수입</p>
         <p className="text-xl sm:text-2xl font-bold tracking-tight text-[var(--text-primary)] mt-1">
           {formatAmount(incomeTotal)}
@@ -78,8 +86,10 @@ export default function UnifiedSummaryCards({
         {prevIncome != null && prevIncome > 0 && (
           <ChangeIndicator current={incomeTotal} previous={prevIncome} />
         )}
-      </div>
-      <div className="bg-gradient-to-br from-grape-50 to-grape-100 border border-grape-200/60 rounded-2xl shadow-sm p-4 sm:p-5">
+      </Link>
+
+      {/* 총 지출 → 지출 필터 목록 */}
+      <Link to={monthStr ? `/?month=${monthStr}&filter=expense` : '/?filter=expense'} className={`bg-gradient-to-br from-grape-50 to-grape-100 border border-grape-200/60 ${cardBase}`}>
         <p className="text-sm text-grape-600/70">총 지출</p>
         <p className="text-xl sm:text-2xl font-bold tracking-tight text-[var(--text-primary)] mt-1">
           {formatAmount(expenseTotal)}
@@ -87,14 +97,18 @@ export default function UnifiedSummaryCards({
         {prevExpense != null && prevExpense > 0 && (
           <ChangeIndicator current={expenseTotal} previous={prevExpense} />
         )}
-      </div>
-      <div className="bg-[var(--surface-card)] border border-[var(--border-default)] rounded-2xl shadow-sm p-4 sm:p-5">
+      </Link>
+
+      {/* 남은 돈 (네비게이션 없음) */}
+      <div className={`bg-[var(--surface-card)] border border-[var(--border-default)] rounded-2xl shadow-sm p-4 sm:p-5`}>
         <p className="text-sm text-[var(--text-tertiary)]">남은 돈</p>
         <p data-testid="net-income-value" className={`text-xl sm:text-2xl font-bold mt-1 ${netColor}`}>
           {formatAmount(net)}
         </p>
       </div>
-      <div className="bg-[var(--surface-card)] border border-[var(--border-default)] rounded-2xl shadow-sm p-4 sm:p-5">
+
+      {/* 저축률 (네비게이션 없음) */}
+      <div className={`bg-[var(--surface-card)] border border-[var(--border-default)] rounded-2xl shadow-sm p-4 sm:p-5`}>
         <p className="text-sm text-[var(--text-tertiary)]">저축률</p>
         <p data-testid="savings-rate-value" className={`text-xl sm:text-2xl font-bold mt-1 ${rateColor}`}>
           {savingsRate !== null ? `${savingsRate.toFixed(1)}%` : '-'}

--- a/frontend/src/components/stats/__tests__/CategoryTopList.test.tsx
+++ b/frontend/src/components/stats/__tests__/CategoryTopList.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 import CategoryTopList from '../CategoryTopList'
 
@@ -14,7 +15,7 @@ describe('CategoryTopList', () => {
   ]
 
   it('상위 5개 카테고리를 표시한다', () => {
-    render(<CategoryTopList categories={mockCategories} />)
+    render(<MemoryRouter><CategoryTopList categories={mockCategories} /></MemoryRouter>)
     expect(screen.getByText('식비')).toBeInTheDocument()
     expect(screen.getByText('주거')).toBeInTheDocument()
     expect(screen.getByText('교통')).toBeInTheDocument()
@@ -25,23 +26,23 @@ describe('CategoryTopList', () => {
   })
 
   it('빈 배열이면 null을 반환한다', () => {
-    const { container } = render(<CategoryTopList categories={[]} />)
+    const { container } = render(<MemoryRouter><CategoryTopList categories={[]} /></MemoryRouter>)
     expect(container.firstChild).toBeNull()
   })
 
   it('비율을 퍼센트로 표시한다', () => {
-    render(<CategoryTopList categories={mockCategories} />)
+    render(<MemoryRouter><CategoryTopList categories={mockCategories} /></MemoryRouter>)
     expect(screen.getByText('37.5%')).toBeInTheDocument()
   })
 
   it('6개 이상일 때 더보기 버튼을 표시한다', () => {
-    render(<CategoryTopList categories={mockCategories} />)
+    render(<MemoryRouter><CategoryTopList categories={mockCategories} /></MemoryRouter>)
     expect(screen.getByText(/더보기/)).toBeInTheDocument()
   })
 
   it('더보기 클릭 시 전체 목록을 표시한다', async () => {
     const user = userEvent.setup()
-    render(<CategoryTopList categories={mockCategories} />)
+    render(<MemoryRouter><CategoryTopList categories={mockCategories} /></MemoryRouter>)
 
     await user.click(screen.getByText(/더보기/))
     expect(screen.getByText('기타')).toBeInTheDocument()
@@ -49,7 +50,13 @@ describe('CategoryTopList', () => {
   })
 
   it('5개 이하이면 더보기 버튼이 없다', () => {
-    render(<CategoryTopList categories={mockCategories.slice(0, 5)} />)
+    render(<MemoryRouter><CategoryTopList categories={mockCategories.slice(0, 5)} /></MemoryRouter>)
     expect(screen.queryByText(/더보기/)).not.toBeInTheDocument()
+  })
+
+  it('카테고리 클릭 시 해당 카테고리 필터 목록으로 이동한다', () => {
+    render(<MemoryRouter><CategoryTopList categories={mockCategories} monthStr="2026-03" /></MemoryRouter>)
+    const link = screen.getByText('식비').closest('a')
+    expect(link).toHaveAttribute('href', '/?month=2026-03&category=식비')
   })
 })

--- a/frontend/src/components/stats/__tests__/UnifiedSummaryCards.test.tsx
+++ b/frontend/src/components/stats/__tests__/UnifiedSummaryCards.test.tsx
@@ -1,39 +1,66 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import UnifiedSummaryCards from '../UnifiedSummaryCards'
+
+const renderCards = (props = {}) => render(
+  <MemoryRouter>
+    <UnifiedSummaryCards incomeTotal={3200000} expenseTotal={2400000} monthStr="2026-03" {...props} />
+  </MemoryRouter>
+)
 
 describe('UnifiedSummaryCards', () => {
   it('총 수입을 표시한다', () => {
-    render(<UnifiedSummaryCards incomeTotal={3200000} expenseTotal={2400000} />)
+    renderCards()
     expect(screen.getByText('총 수입')).toBeInTheDocument()
     expect(screen.getByText('₩3,200,000')).toBeInTheDocument()
   })
 
   it('총 지출을 표시한다', () => {
-    render(<UnifiedSummaryCards incomeTotal={3200000} expenseTotal={2400000} />)
+    renderCards()
     expect(screen.getByText('총 지출')).toBeInTheDocument()
     expect(screen.getByText('₩2,400,000')).toBeInTheDocument()
   })
 
   it('남은 돈을 올바르게 계산한다', () => {
-    render(<UnifiedSummaryCards incomeTotal={3200000} expenseTotal={2400000} />)
+    renderCards()
     expect(screen.getByText('남은 돈')).toBeInTheDocument()
     expect(screen.getByText('₩800,000')).toBeInTheDocument()
   })
 
   it('저축률을 올바르게 계산한다', () => {
-    render(<UnifiedSummaryCards incomeTotal={3200000} expenseTotal={2400000} />)
+    renderCards()
     expect(screen.getByText('저축률')).toBeInTheDocument()
     expect(screen.getByText('25.0%')).toBeInTheDocument()
   })
 
   it('적자일 때 남은 돈 카드에 음수 금액을 표시한다', () => {
-    render(<UnifiedSummaryCards incomeTotal={2000000} expenseTotal={2400000} />)
+    renderCards({ incomeTotal: 2000000, expenseTotal: 2400000 })
     expect(screen.getByTestId('net-income-value')).toHaveTextContent('-₩400,000')
   })
 
   it('수입이 0일 때 저축률은 "-"를 표시한다', () => {
-    render(<UnifiedSummaryCards incomeTotal={0} expenseTotal={100000} />)
+    render(<MemoryRouter><UnifiedSummaryCards incomeTotal={0} expenseTotal={100000} monthStr="2026-03" /></MemoryRouter>)
     expect(screen.getByTestId('savings-rate-value')).toHaveTextContent('-')
+  })
+
+  describe('네비게이션', () => {
+    it('순자산 카드 클릭 시 자산 페이지로 이동한다', () => {
+      renderCards({ netWorth: 50000000 })
+      const link = screen.getByText('순자산').closest('a')
+      expect(link).toHaveAttribute('href', '/assets')
+    })
+
+    it('총 수입 카드 클릭 시 수입 필터 목록으로 이동한다', () => {
+      renderCards()
+      const link = screen.getByText('총 수입').closest('a')
+      expect(link).toHaveAttribute('href', '/?month=2026-03&filter=income')
+    })
+
+    it('총 지출 카드 클릭 시 지출 필터 목록으로 이동한다', () => {
+      renderCards()
+      const link = screen.getByText('총 지출').closest('a')
+      expect(link).toHaveAttribute('href', '/?month=2026-03&filter=expense')
+    })
   })
 })

--- a/frontend/src/hooks/useMonthlyTransactions.ts
+++ b/frontend/src/hooks/useMonthlyTransactions.ts
@@ -39,6 +39,7 @@ export function useMonthlyTransactions({ activeHouseholdId }: UseMonthlyTransact
   // 필터: URL → sessionStorage → 'all' 순서로 복원
   const urlFilter = searchParams.get('filter') as FilterType | null
   const filter: FilterType = urlFilter || (sessionStorage.getItem(FILTER_STORAGE_KEY) as FilterType) || 'all'
+  const categoryFilter = searchParams.get('category')
 
   // 필터 변경 시 sessionStorage에 백업 (상세→목록 복귀 시 복원용)
   useEffect(() => {
@@ -130,8 +131,14 @@ export function useMonthlyTransactions({ activeHouseholdId }: UseMonthlyTransact
       ...incomes.map(i => ({ ...i, type: 'income' as const })),
     ]
 
-    // 필터 적용
-    const filtered = filter === 'all' ? all : all.filter(t => t.type === filter)
+    // 필터 적용 (타입 + 카테고리)
+    let filtered = filter === 'all' ? all : all.filter(t => t.type === filter)
+    if (categoryFilter) {
+      filtered = filtered.filter(t => {
+        const cat = t.category_id != null ? categoryMap.get(t.category_id) : null
+        return cat?.name === categoryFilter
+      })
+    }
 
     // 날짜 역순 + 같은 날짜 내 id 역순
     filtered.sort((a, b) => {
@@ -155,9 +162,9 @@ export function useMonthlyTransactions({ activeHouseholdId }: UseMonthlyTransact
     for (const e of expenses) totalExpense += e.amount
     for (const i of incomes) totalIncome += i.amount
 
-    // 캘린더 날짜별 요약 (필터 반영)
+    // 캘린더 날짜별 요약 (타입+카테고리 필터 반영)
     const daySummaries = new Map<string, { expense: number; income: number }>()
-    const calendarSource = filter === 'all' ? all : all.filter(t => t.type === filter)
+    const calendarSource = filtered
     for (const tx of calendarSource) {
       const key = tx.date.slice(0, 10)
       const s = daySummaries.get(key) ?? { expense: 0, income: 0 }
@@ -167,7 +174,7 @@ export function useMonthlyTransactions({ activeHouseholdId }: UseMonthlyTransact
     }
 
     return { grouped, totalExpense, totalIncome, daySummaries }
-  }, [expenses, incomes, filter])
+  }, [expenses, incomes, filter, categoryFilter, categoryMap])
 
   const monthLabel = `${currentYear}년 ${currentMonth + 1}월`
 

--- a/frontend/src/mocks/fixtures.ts
+++ b/frontend/src/mocks/fixtures.ts
@@ -148,6 +148,24 @@ export const mockComparison: ComparisonResponse = {
 }
 
 /**
+ * 테스트용 수입 기간 비교
+ */
+export const mockIncomeComparison: ComparisonResponse = {
+  current: { label: '2024년 1월', total: 4000000 },
+  previous: { label: '2023년 12월', total: 3500000 },
+  change: { amount: 500000, percentage: 14.3 },
+  trend: [
+    { label: '2023년 11월', total: 3200000 },
+    { label: '2023년 12월', total: 3500000 },
+    { label: '2024년 1월', total: 4000000 },
+  ],
+  by_category_comparison: [
+    { category: '급여', current: 3500000, previous: 3000000, change_amount: 500000, change_percentage: 16.7 },
+    { category: '부수입', current: 500000, previous: 500000, change_amount: 0, change_percentage: 0 },
+  ],
+}
+
+/**
  * 테스트용 수입 카테고리 (type=income 또는 type=both인 카테고리 포함)
  */
 export const mockIncomeCategoriesAll: Category[] = [

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -24,6 +24,7 @@ import {
   mockFeedbacks,
   mockDashboardStats,
   mockStructuredInsights,
+  mockIncomeComparison,
 } from './fixtures'
 
 const BASE_URL = '/api'
@@ -213,6 +214,10 @@ export const handlers = [
 
     const paginated = filtered.slice(skip, skip + limit)
     return HttpResponse.json(paginated)
+  }),
+
+  http.get(`${BASE_URL}/income/stats/comparison`, () => {
+    return HttpResponse.json(mockIncomeComparison)
   }),
 
   http.get(`${BASE_URL}/income/stats`, () => {

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -70,6 +70,7 @@ export default function InsightsPage() {
   const [incomeStats, setIncomeStats] = useState<StatsResponse | null>(null)
   const [budgetStats, setBudgetStats] = useState<BudgetMonthlyStatsResponse | null>(null)
   const [comparison, setComparison] = useState<ComparisonResponse | null>(null)
+  const [incomeComparison, setIncomeComparison] = useState<ComparisonResponse | null>(null)
   const [assetSummary, setAssetSummary] = useState<AssetSummary | null>(null)
   const [prevSnapshot, setPrevSnapshot] = useState<AssetSnapshot | null>(null)
 
@@ -91,10 +92,11 @@ export default function InsightsPage() {
         const hhId = activeHouseholdId
 
         // 1차 병렬: 지출/수입 통계 + 비교 + 예산 + 자산
-        const [expRes, incRes, compRes, budgetRes, assetRes, snapRes] = await Promise.allSettled([
+        const [expRes, incRes, compRes, incCompRes, budgetRes, assetRes, snapRes] = await Promise.allSettled([
           statsApi.getStats('monthly', dateStr, hhId),
           incomeApi.getStats('monthly', dateStr, hhId),
           statsApi.getComparison('monthly', dateStr, 3, hhId),
+          incomeApi.getComparison('monthly', dateStr, 3, hhId),
           getMonthlyStats(monthStr),
           assetApi.getSummary(hhId),
           assetApi.getSnapshots(hhId, 2),
@@ -105,6 +107,7 @@ export default function InsightsPage() {
         const exp = expRes.status === 'fulfilled' ? expRes.value.data : null
         const inc = incRes.status === 'fulfilled' ? incRes.value.data : null
         const comp = compRes.status === 'fulfilled' ? compRes.value.data : null
+        const incComp = incCompRes.status === 'fulfilled' ? incCompRes.value.data : null
         const budget = budgetRes.status === 'fulfilled' ? budgetRes.value.data : null
         const asset = assetRes.status === 'fulfilled' ? assetRes.value.data : null
         const snaps = snapRes.status === 'fulfilled' ? snapRes.value.data : []
@@ -118,6 +121,7 @@ export default function InsightsPage() {
         setExpenseStats(exp)
         setIncomeStats(inc)
         setComparison(comp)
+        setIncomeComparison(incComp)
         setBudgetStats(budget)
         setAssetSummary(asset)
 
@@ -173,7 +177,7 @@ export default function InsightsPage() {
           : 0,
         health_score: healthScore,
         previous_month_expense: comparison?.previous?.total ?? null,
-        previous_month_income: null,
+        previous_month_income: incomeComparison?.previous?.total ?? null,
       }
 
       // 예산 데이터
@@ -212,7 +216,7 @@ export default function InsightsPage() {
     } finally {
       setAiLoading(false)
     }
-  }, [monthStr, expenseStats, incomeStats, budgetStats, assetSummary, prevSnapshot, healthScore, comparison])
+  }, [monthStr, expenseStats, incomeStats, budgetStats, assetSummary, prevSnapshot, healthScore, comparison, incomeComparison])
 
   const handlePrev = useCallback(() => setMonthStr(m => shiftMonth(m, -1)), [])
   const handleNext = useCallback(() => setMonthStr(m => shiftMonth(m, 1)), [])
@@ -263,8 +267,9 @@ export default function InsightsPage() {
               expenseTotal={expenseStats?.total ?? 0}
               netWorth={assetSummary?.net_worth ?? null}
               prevNetWorth={prevSnapshot?.net_worth ?? null}
-              prevIncome={comparison?.previous?.total ? null : null}
+              prevIncome={incomeComparison?.previous?.total ?? null}
               prevExpense={comparison?.previous?.total ?? null}
+              monthStr={monthStr}
             />
           )}
 
@@ -279,10 +284,10 @@ export default function InsightsPage() {
           )}
 
           {/* 3. 지출 카테고리 TOP */}
-          <CategoryTopList categories={expenseStats?.by_category ?? []} />
+          <CategoryTopList categories={expenseStats?.by_category ?? []} monthStr={monthStr} />
 
           {/* 4. 예산 상황 */}
-          <BudgetVsActual budgetStats={budgetStats} />
+          <BudgetVsActual budgetStats={budgetStats} monthStr={monthStr} />
 
           {/* 5. 자산 변화 */}
           <AssetChangeSummary summary={assetSummary} previousSnapshot={prevSnapshot} />

--- a/frontend/src/pages/__tests__/InsightsPage.test.tsx
+++ b/frontend/src/pages/__tests__/InsightsPage.test.tsx
@@ -90,6 +90,9 @@ describe('InsightsPage', () => {
       http.get('/api/expenses/stats/comparison', () => {
         return HttpResponse.json({ detail: 'Server Error' }, { status: 500 })
       }),
+      http.get('/api/income/stats/comparison', () => {
+        return HttpResponse.json({ detail: 'Server Error' }, { status: 500 })
+      }),
       http.get('/api/budgets/stats/monthly', () => {
         return HttpResponse.json({ detail: 'Server Error' }, { status: 500 })
       }),
@@ -119,6 +122,23 @@ describe('InsightsPage', () => {
 
     // 주목할 점이 카테고리 TOP보다 DOM에서 먼저 나온다
     expect(highlights.compareDocumentPosition(categoryTop) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('총 수입 카드에 전월 대비 변화율이 표시된다', async () => {
+    render(<MemoryRouter><InsightsPage /></MemoryRouter>)
+    await waitFor(() => {
+      expect(screen.getByText('총 수입')).toBeInTheDocument()
+    })
+    // mockIncomeComparison의 previous.total = 3500000, mockIncomeStats.total = 4000000
+    // ChangeIndicator: ((4000000 - 3500000) / 3500000) * 100 = 14%
+    await waitFor(() => {
+      const incomeCard = screen.getByText('총 수입').closest('a')
+      expect(incomeCard).toBeInTheDocument()
+      // 전월 대비 % 텍스트가 카드 내에 존재
+      const changeText = incomeCard?.querySelector('p.text-\\[10px\\]')
+      expect(changeText).toBeInTheDocument()
+      expect(changeText?.textContent).toMatch(/지난달/)
+    })
   })
 
   it('예산 상황 섹션에 편집 링크가 표시된다', async () => {


### PR DESCRIPTION
## Summary
- #431 돌아보기 섹션 클릭 → 상세 페이지 네비게이션 (순자산→자산, 수입/지출→목록, 카테고리→필터)
- #437 총수입 전월 대비 % 표시 (BE comparison API + FE 연동)
- #434 예산현황 카테고리 누락 버그 수정 (같은 달 중간 생성 예산 포함)

## Test plan
- [x] BE 1616 passed
- [x] FE 1263 passed
- [x] 예산 버그 재현 테스트 추가 (test_monthly_stats_includes_mid_month_budget)
- [x] 수입 comparison 테스트 8개 추가
- [ ] 돌아보기 → 카테고리 클릭 → 필터 목록 동작 확인
- [ ] 총수입 카드에 전월 대비 % 표시 확인

close #431 close #437 close #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)