### PR TITLE
fix: 다크모드 스와이프 뒤로가기 시 밝은 화면 번쩍임 수정

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,10 @@
         var d = t === 'dark' || (t !== 'light' && matchMedia('(prefers-color-scheme:dark)').matches)
         if (d) {
           document.documentElement.classList.add('dark')
+          document.documentElement.style.backgroundColor = '#1a1625'
           document.querySelector('meta[name="theme-color"]').content = '#1a1625'
+        } else {
+          document.documentElement.style.backgroundColor = '#fefce8'
         }
       })()
     </script>


### PR DESCRIPTION
## Summary
- 다크모드에서 스와이프 뒤로가기 시 흰색 배경 번쩍이는 문제 수정
- index.html FOUC 방지 스크립트에서 html 배경색을 인라인으로 즉시 지정
- 다크: #1a1625, 라이트: #fefce8

## 원인
브라우저가 스와이프 전환 중 이전 페이지 스냅샷을 보여주는데, CSS 로드 전의 기본 배경(흰색)이 노출됨

## Test plan
- [x] FE 1263 테스트 통과
- [x] 빌드 성공
- [ ] 모바일 다크모드에서 스와이프 뒤로가기 시 번쩍임 없는지 확인

close #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)