### PR TITLE
fix: Phase 6 버그 수정 6건

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import { lazy, Suspense } from 'react'
-import { Routes, Route, Navigate, useSearchParams } from 'react-router-dom'
+import { lazy, Suspense, useEffect, useRef } from 'react'
+import { Routes, Route, Navigate, useSearchParams, useLocation, useNavigationType } from 'react-router-dom'
 import Layout from './components/Layout'
 import ProtectedRoute from './components/ProtectedRoute'
 
@@ -48,9 +48,37 @@ function PageLoading() {
   )
 }
 
+/** 새 페이지 이동 시 스크롤 최상단, 뒤로가기 시 스크롤 복원 (#476) */
+function ScrollToTop() {
+  const { pathname } = useLocation()
+  const navType = useNavigationType()
+  const scrollPositions = useRef<Map<string, number>>(new Map())
+
+  useEffect(() => {
+    if (navType === 'POP') {
+      // 뒤로가기: 저장된 위치로 복원
+      const saved = scrollPositions.current.get(pathname)
+      if (saved != null) {
+        requestAnimationFrame(() => window.scrollTo(0, saved))
+      }
+    } else {
+      // 새 이동(PUSH/REPLACE): 최상단
+      window.scrollTo(0, 0)
+    }
+
+    // 페이지 떠날 때 현재 스크롤 위치 저장
+    return () => {
+      scrollPositions.current.set(pathname, window.scrollY)
+    }
+  }, [pathname, navType])
+
+  return null
+}
+
 function App() {
   return (
     <Suspense fallback={<PageLoading />}>
+      <ScrollToTop />
       <Routes>
         {/* podo-auth SSO 콜백 */}
         <Route path="/login" element={<LoginPage />} />

--- a/frontend/src/components/TransactionForm.tsx
+++ b/frontend/src/components/TransactionForm.tsx
@@ -6,7 +6,7 @@ import { getLocalDateString } from '../utils/format'
  * ExpenseForm과 IncomeForm에서 wrapper로 사용한다.
  */
 
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { ArrowLeft, Camera } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
@@ -14,9 +14,12 @@ import { expenseApi } from '../api/expenses'
 import { incomeApi } from '../api/income'
 import { categoryApi } from '../api/categories'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
+import { paymentMethodApi } from '../api/paymentMethods'
+import type { PaymentMethod } from '../types'
 import { useNaturalInput } from '../hooks/useNaturalInput'
 import ParsedItemPreviewCard from './ParsedItemPreviewCard'
 import { trackEvent } from '../utils/analytics'
+import { FILTER_STORAGE_KEY } from '../hooks/useMonthlyTransactions'
 
 type TransactionType = 'expense' | 'income'
 type InputMode = 'natural' | 'form' | 'ocr'
@@ -76,14 +79,26 @@ export default function TransactionForm({ type }: TransactionFormProps) {
   const [showNewCategoryForForm, setShowNewCategoryForForm] = useState(false)
   const [newCategoryNameForForm, setNewCategoryNameForForm] = useState('')
   const [creatingCategoryForForm, setCreatingCategoryForForm] = useState(false)
+  const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([])
   const [formData, setFormData] = useState({
     amount: '',
     description: '',
     category_id: '',
+    payment_method_id: '',
     date: getLocalDateString(),
     memo: '',
     exclude_from_stats: false,
   })
+
+  // 결제수단 목록 로드 (지출 모드 전용)
+  useEffect(() => {
+    if (type !== 'expense' || !activeHouseholdId) return
+    paymentMethodApi.getAll(activeHouseholdId).then((res) => {
+      setPaymentMethods(res.data.filter((m) => m.is_active))
+    }).catch(() => {
+      // 결제수단 로드 실패 시 무시 — 선택 필드이므로 동작에 지장 없음
+    })
+  }, [type, activeHouseholdId])
 
   const formCategories = ni.categories
 
@@ -165,6 +180,9 @@ export default function TransactionForm({ type }: TransactionFormProps) {
         amount,
         description: formData.description.trim(),
         category_id: formData.category_id ? Number(formData.category_id) : null,
+        ...(type === 'expense' && formData.payment_method_id
+          ? { payment_method_id: Number(formData.payment_method_id) }
+          : {}),
         date: formData.date.includes('T') ? formData.date : `${formData.date}T00:00:00`,
         household_id: activeHouseholdId,
         memo: formData.memo.trim() || undefined,
@@ -172,6 +190,7 @@ export default function TransactionForm({ type }: TransactionFormProps) {
       })
       trackEvent(cfg.eventName, { mode: 'form' })
       addToast('success', cfg.savedMessage)
+      sessionStorage.removeItem(FILTER_STORAGE_KEY)
       setTimeout(() => navigate(cfg.listRoute), 500)
     } catch {
       addToast('error', `${cfg.previewLabel} 저장에 실패했습니다`)
@@ -543,6 +562,29 @@ export default function TransactionForm({ type }: TransactionFormProps) {
               </button>
             )}
           </div>
+
+          {/* 결제수단 (지출 모드 전용, 선택) */}
+          {type === 'expense' && (
+            <div>
+              <label htmlFor={`${idPrefix}-payment-method`} className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+                결제수단
+              </label>
+              <select
+                id={`${idPrefix}-payment-method`}
+                value={formData.payment_method_id}
+                onChange={(e) => setFormData({ ...formData, payment_method_id: e.target.value })}
+                className={`w-full px-4 py-3 border border-[var(--input-border)] rounded-xl focus:ring-2 focus:ring-${c}-500/30 focus:border-${c}-500`}
+                disabled={loading}
+              >
+                <option value="">선택 안 함</option>
+                {paymentMethods.map((pm) => (
+                  <option key={pm.id} value={pm.id}>
+                    {pm.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
           {/* 날짜 (기본 오늘) */}
           <div>

--- a/frontend/src/components/__tests__/TransactionForm.test.tsx
+++ b/frontend/src/components/__tests__/TransactionForm.test.tsx
@@ -492,6 +492,43 @@ describe('TransactionForm', () => {
     })
   })
 
+  describe('결제수단 드롭다운', () => {
+    it('지출 모드에서 결제수단 드롭다운이 표시된다', async () => {
+      const user = userEvent.setup()
+      renderForm('expense')
+      await user.click(screen.getByText('직접 입력'))
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('결제수단')).toBeInTheDocument()
+      })
+
+      // 목 데이터의 결제수단이 옵션에 표시되는지 확인
+      const select = screen.getByLabelText('결제수단')
+      const options = within(select).getAllByRole('option')
+      const optionTexts = options.map((o) => o.textContent)
+      expect(optionTexts).toContain('선택 안 함')
+      expect(optionTexts).toContain('삼성카드')
+      expect(optionTexts).toContain('현금')
+      expect(optionTexts).toContain('국민카드')
+    })
+
+    it('수입 모드에서는 결제수단 드롭다운이 표시되지 않는다', async () => {
+      server.use(
+        http.get('/api/categories', () => {
+          return HttpResponse.json(mockIncomeCategoriesAll)
+        })
+      )
+      const user = userEvent.setup()
+      renderForm('income')
+      await user.click(screen.getByText('직접 입력'))
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('월급')).toBeInTheDocument()
+      })
+      expect(screen.queryByLabelText('결제수단')).not.toBeInTheDocument()
+    })
+  })
+
   describe('취소 버튼 라우팅', () => {
     it('expense: 취소 클릭 시 /expenses로 이동', async () => {
       const user = userEvent.setup()

--- a/frontend/src/components/stats/CardUsageSummary.tsx
+++ b/frontend/src/components/stats/CardUsageSummary.tsx
@@ -41,7 +41,7 @@ export default function CardUsageSummary({ usage }: CardUsageSummaryProps) {
               <div className="flex justify-between items-center mb-1">
                 <span className="text-sm font-medium text-[var(--text-primary)]">{item.name}</span>
                 <div className="text-right">
-                  <span className={`text-sm font-semibold ${pct > 100 ? 'text-red-600' : 'text-[var(--text-primary)]'}`}>
+                  <span className={`text-sm font-semibold ${pct >= 100 ? 'text-leaf-600' : 'text-[var(--text-primary)]'}`}>
                     {formatAmount(item.spent_amount)}
                   </span>
                   <span className="text-xs text-[var(--text-muted)]"> / {formatAmount(item.monthly_target!)}</span>
@@ -50,7 +50,7 @@ export default function CardUsageSummary({ usage }: CardUsageSummaryProps) {
               <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
                 <div
                   className={`h-1.5 rounded-full transition-all ${
-                    pct > 100 ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-grape-500'
+                    pct >= 100 ? 'bg-leaf-500' : pct >= 80 ? 'bg-grape-500' : 'bg-grape-400'
                   }`}
                   style={{ width: `${Math.min(pct, 100)}%` }}
                 />
@@ -60,8 +60,8 @@ export default function CardUsageSummary({ usage }: CardUsageSummaryProps) {
                   {pct.toFixed(1)}%
                 </span>
                 {item.remaining != null && (
-                  <span className="text-xs text-[var(--text-muted)]">
-                    잔여 {formatAmount(item.remaining)}
+                  <span className={`text-xs ${pct >= 100 ? 'text-leaf-600 font-medium' : 'text-[var(--text-muted)]'}`}>
+                    {pct >= 100 ? '✅ 실적 달성' : `잔여 ${formatAmount(item.remaining)}`}
                   </span>
                 )}
               </div>

--- a/frontend/src/components/stats/CategoryTopList.tsx
+++ b/frontend/src/components/stats/CategoryTopList.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown, ChevronUp, BarChart3, PieChart as PieChartIcon } from 'lucide-react'
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts'
 import type { CategoryStats } from '../../types'
 import { formatAmount } from '../../utils/format'
 
@@ -10,53 +11,167 @@ interface CategoryTopListProps {
   monthStr?: string
 }
 
+type ViewMode = 'list' | 'chart'
+
+// Grape 팔레트 기반 카테고리 색상
+const CATEGORY_COLORS = [
+  '#7c3aed', '#a78bfa', '#c4b5fd', '#22c55e', '#86efac',
+  '#f59e0b', '#fcd34d', '#fb923c', '#f87171', '#60a5fa',
+]
+
+function formatCompactAmount(amount: number): string {
+  if (amount >= 100_000_000) return `${(amount / 100_000_000).toFixed(1)}억원`
+  if (amount >= 10_000) return `${Math.round(amount / 10_000).toLocaleString()}만원`
+  return `${Math.round(amount).toLocaleString('ko-KR')}원`
+}
+
+function ChartTooltip({ active, payload }: { active?: boolean; payload?: Array<{ name: string; value: number; payload: { percentage: number } }> }) {
+  if (!active || !payload?.length) return null
+  const item = payload[0]
+  return (
+    <div className="bg-[var(--surface-card)] border border-[var(--border-default)] rounded-lg px-3 py-2 shadow-lg text-xs">
+      <p className="font-medium text-[var(--text-primary)]">{item.name}</p>
+      <p className="text-[var(--text-secondary)]">
+        {`₩${Math.round(item.value).toLocaleString('ko-KR')}`} ({item.payload.percentage.toFixed(1)}%)
+      </p>
+    </div>
+  )
+}
+
 export default function CategoryTopList({ categories, maxItems = 5, monthStr }: CategoryTopListProps) {
   const [expanded, setExpanded] = useState(false)
+  const [viewMode, setViewMode] = useState<ViewMode>('list')
+
   if (categories.length === 0) return null
 
   const hasMore = categories.length > maxItems
   const visible = expanded ? categories : categories.slice(0, maxItems)
+  const totalAmount = categories.reduce((sum, c) => sum + c.amount, 0)
+
+  // 차트용: 5개까지만 조각, 나머지 "기타"로 통합
+  const chartData = (() => {
+    if (categories.length <= 5) return categories
+    const top5 = categories.slice(0, 5)
+    const others = categories.slice(5)
+    const otherAmount = others.reduce((sum, c) => sum + c.amount, 0)
+    const otherPct = others.reduce((sum, c) => sum + c.percentage, 0)
+    return [...top5, { category: '기타', amount: otherAmount, count: 0, percentage: otherPct }]
+  })()
 
   return (
     <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4">
-      <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-3">지출 카테고리 TOP</h3>
-      <div className="space-y-2.5">
-        {visible.map((cat, i) => {
-          const href = monthStr
-            ? `/?month=${monthStr}&category=${cat.category}`
-            : `/?category=${cat.category}`
-
-          return (
-            <Link key={cat.category} to={href} className="block hover:bg-[var(--surface-hover)] -mx-2 px-2 py-1 rounded-lg transition-colors">
-              <div className="flex items-center justify-between mb-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-xs font-medium text-[var(--text-muted)] w-4">{i + 1}</span>
-                  <span className="text-sm font-medium text-[var(--text-primary)]">{cat.category}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-[var(--text-secondary)]">{formatAmount(cat.amount)}</span>
-                  <span className="text-xs text-[var(--text-tertiary)] w-12 text-right">{cat.percentage.toFixed(1)}%</span>
-                </div>
-              </div>
-              <div className="h-1.5 bg-[var(--surface-hover)] rounded-full overflow-hidden ml-6">
-                <div className="h-full rounded-full bg-grape-500" style={{ width: `${cat.percentage}%` }} />
-              </div>
-            </Link>
-          )
-        })}
+      {/* 헤더: 제목 + 탭 전환 */}
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">지출 카테고리</h3>
+        <div className="flex items-center gap-1 bg-[var(--surface-elevated)] rounded-lg p-0.5">
+          <button
+            onClick={() => setViewMode('list')}
+            className={`p-1.5 rounded-md transition-colors ${viewMode === 'list' ? 'bg-[var(--surface-card)] shadow-sm text-grape-600' : 'text-[var(--text-muted)]'}`}
+            aria-label="리스트 보기"
+          >
+            <BarChart3 className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={() => setViewMode('chart')}
+            className={`p-1.5 rounded-md transition-colors ${viewMode === 'chart' ? 'bg-[var(--surface-card)] shadow-sm text-grape-600' : 'text-[var(--text-muted)]'}`}
+            aria-label="그래프 보기"
+          >
+            <PieChartIcon className="w-3.5 h-3.5" />
+          </button>
+        </div>
       </div>
 
-      {hasMore && (
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="flex items-center justify-center gap-1 w-full mt-3 py-1.5 text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
-        >
-          {expanded ? (
-            <>접기 <ChevronUp className="w-3.5 h-3.5" /></>
-          ) : (
-            <>더보기 ({categories.length - maxItems}) <ChevronDown className="w-3.5 h-3.5" /></>
+      {/* 리스트 뷰 */}
+      {viewMode === 'list' && (
+        <>
+          <div className="space-y-2.5">
+            {visible.map((cat, i) => {
+              const href = monthStr
+                ? `/?month=${monthStr}&category=${cat.category}`
+                : `/?category=${cat.category}`
+
+              return (
+                <Link key={cat.category} to={href} className="block hover:bg-[var(--surface-hover)] -mx-2 px-2 py-1 rounded-lg transition-colors">
+                  <div className="flex items-center justify-between mb-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-medium text-[var(--text-muted)] w-4">{i + 1}</span>
+                      <span className="text-sm font-medium text-[var(--text-primary)]">{cat.category}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-[var(--text-secondary)]">{formatAmount(cat.amount)}</span>
+                      <span className="text-xs text-[var(--text-tertiary)] w-12 text-right">{cat.percentage.toFixed(1)}%</span>
+                    </div>
+                  </div>
+                  <div className="h-1.5 bg-[var(--surface-hover)] rounded-full overflow-hidden ml-6">
+                    <div className="h-full rounded-full bg-grape-500" style={{ width: `${cat.percentage}%` }} />
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+
+          {hasMore && (
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="flex items-center justify-center gap-1 w-full mt-3 py-1.5 text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
+            >
+              {expanded ? (
+                <>접기 <ChevronUp className="w-3.5 h-3.5" /></>
+              ) : (
+                <>더보기 ({categories.length - maxItems}) <ChevronDown className="w-3.5 h-3.5" /></>
+              )}
+            </button>
           )}
-        </button>
+        </>
+      )}
+
+      {/* 그래프 뷰 */}
+      {viewMode === 'chart' && (
+        <>
+          <div className="relative" style={{ height: 200 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  dataKey="amount"
+                  nameKey="category"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius="55%"
+                  outerRadius="80%"
+                  paddingAngle={2}
+                  strokeWidth={0}
+                >
+                  {chartData.map((_, index) => (
+                    <Cell key={index} fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip content={<ChartTooltip />} />
+              </PieChart>
+            </ResponsiveContainer>
+
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+              <div className="text-center">
+                <p className="text-xs text-[var(--text-tertiary)]">총 지출</p>
+                <p className="text-base font-bold text-[var(--text-primary)]">{formatCompactAmount(totalAmount)}</p>
+              </div>
+            </div>
+          </div>
+
+          {/* 범례 */}
+          <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5">
+            {chartData.map((cat, index) => (
+              <div key={cat.category} className="flex items-center gap-2 min-w-0">
+                <span
+                  className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: CATEGORY_COLORS[index % CATEGORY_COLORS.length] }}
+                />
+                <span className="text-xs text-[var(--text-primary)] truncate">{cat.category}</span>
+                <span className="text-xs text-[var(--text-tertiary)] ml-auto flex-shrink-0">{cat.percentage.toFixed(1)}%</span>
+              </div>
+            ))}
+          </div>
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/stats/SectionToggleModal.tsx
+++ b/frontend/src/components/stats/SectionToggleModal.tsx
@@ -47,7 +47,7 @@ export function saveSectionSettings(settings: SectionVisibility): void {
 // 토글 가능한 섹션 목록 (종합 요약은 제외 — 항상 ON)
 const SECTION_LIST: { key: keyof SectionVisibility; label: string }[] = [
   { key: 'highlights', label: '이달의 주목할 점' },
-  { key: 'categoryTop', label: '지출 카테고리 TOP' },
+  { key: 'categoryTop', label: '지출 카테고리' },
   { key: 'budget', label: '예산 상황' },
   { key: 'cardUsage', label: '카드 실적' },
   { key: 'assets', label: '자산 변화' },

--- a/frontend/src/hooks/useMonthlyTransactions.ts
+++ b/frontend/src/hooks/useMonthlyTransactions.ts
@@ -16,7 +16,7 @@ import type { UnifiedTransaction } from './useTransactionSearch'
 
 type FilterType = 'all' | 'expense' | 'income'
 
-const FILTER_STORAGE_KEY = 'podo-transaction-filter'
+export const FILTER_STORAGE_KEY = 'podo-transaction-filter'
 
 interface UseMonthlyTransactionsOptions {
   activeHouseholdId: number | null

--- a/frontend/src/hooks/useNaturalInput.ts
+++ b/frontend/src/hooks/useNaturalInput.ts
@@ -15,6 +15,7 @@ import { chatApi } from '../api/chat'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import type { Category, ParsedExpenseItem } from '../types'
 import { trackEvent } from '../utils/analytics'
+import { FILTER_STORAGE_KEY } from './useMonthlyTransactions'
 
 type TransactionType = 'expense' | 'income'
 
@@ -174,6 +175,7 @@ export function useNaturalInput(type: TransactionType) {
       addToast('success', config.successMessage)
       setPreviewItems(null)
       setNaturalInput('')
+      sessionStorage.removeItem(FILTER_STORAGE_KEY)
       setTimeout(() => navigate(config.listRoute), 500)
     } catch {
       addToast('error', '저장에 실패했습니다')

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -23,6 +23,7 @@ import { useHouseholdStore } from '../stores/useHouseholdStore'
 // 컴포넌트
 import PeriodNavigator from '../components/stats/PeriodNavigator'
 import UnifiedSummaryCards from '../components/stats/UnifiedSummaryCards'
+// CategoryPieChart는 CategoryTopList에 탭으로 통합됨
 import CategoryTopList from '../components/stats/CategoryTopList'
 import BudgetVsActual from '../components/stats/BudgetVsActual'
 import CardUsageSummary from '../components/stats/CardUsageSummary'
@@ -346,27 +347,27 @@ export default function InsightsPage() {
             />
           )}
 
-          {/* 3. 지출 카테고리 TOP */}
+          {/* 3. 지출 카테고리 (리스트/그래프 탭 통합) */}
           {sectionVisibility.categoryTop && (
             <CategoryTopList categories={expenseStats?.by_category ?? []} monthStr={monthStr} />
           )}
 
-          {/* 4. 예산 상황 */}
+          {/* 5. 예산 상황 */}
           {sectionVisibility.budget && (
             <BudgetVsActual budgetStats={budgetStats} monthStr={monthStr} />
           )}
 
-          {/* 5. 카드 실적 */}
+          {/* 6. 카드 실적 */}
           {sectionVisibility.cardUsage && cardUsage.length > 0 && (
             <CardUsageSummary usage={cardUsage} />
           )}
 
-          {/* 6. 자산 변화 */}
+          {/* 7. 자산 변화 */}
           {sectionVisibility.assets && (
             <AssetChangeSummary summary={assetSummary} previousSnapshot={prevSnapshot} />
           )}
 
-          {/* 7. AI 상세 분석 */}
+          {/* 8. AI 상세 분석 */}
           {sectionVisibility.ai && (
             <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-4">
               <div className="flex items-center justify-between mb-4">

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -101,13 +101,18 @@ export default function PaymentMethodManager() {
   }, [formName, formType, formTarget, formDefault, fetchData, addToast])
 
   /** 기본 결제수단 설정 */
-  const handleSetDefault = useCallback(async (method: PaymentMethod) => {
+  const handleToggleDefault = useCallback(async (method: PaymentMethod) => {
     try {
-      await paymentMethodApi.update(method.id, { is_default: true })
-      addToast('success', `이제부터 결제수단을 따로 말하지 않으면 ${method.name}(으)로 자동 저장됩니다`)
+      const newDefault = !method.is_default
+      await paymentMethodApi.update(method.id, { is_default: newDefault })
+      if (newDefault) {
+        addToast('success', `이제부터 결제수단을 따로 말하지 않으면 ${method.name}(으)로 자동 저장됩니다`)
+      } else {
+        addToast('info', `${method.name} 기본 결제수단이 해제되었습니다`)
+      }
       await fetchData()
     } catch {
-      addToast('error', '기본 결제수단 설정에 실패했습니다')
+      addToast('error', '기본 결제수단 변경에 실패했습니다')
     }
   }, [fetchData, addToast])
 
@@ -265,15 +270,15 @@ export default function PaymentMethodManager() {
                     )}
                   </div>
                   <div className="flex items-center gap-1">
-                    {!method.is_default && (
-                      <button
-                        onClick={() => handleSetDefault(method)}
-                        aria-label="기본으로 설정"
-                        className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-grape-600"
-                      >
-                        <Star className="w-4 h-4" />
-                      </button>
-                    )}
+                    <button
+                      onClick={() => handleToggleDefault(method)}
+                      aria-label={method.is_default ? '기본 해제' : '기본으로 설정'}
+                      className={`p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors ${
+                        method.is_default ? 'text-grape-600' : 'text-[var(--text-muted)] hover:text-grape-600'
+                      }`}
+                    >
+                      <Star className="w-4 h-4" fill={method.is_default ? 'currentColor' : 'none'} />
+                    </button>
                     <button
                       onClick={() => handleDelete(method)}
                       aria-label="삭제"
@@ -291,18 +296,18 @@ export default function PaymentMethodManager() {
                       <span className="text-xs text-[var(--text-secondary)]">
                         {formatAmount(usage.spent_amount)} / {formatAmount(method.monthly_target)}
                       </span>
-                      <span className="text-xs text-[var(--text-muted)]">
-                        잔여 {formatAmount(usage.remaining ?? 0)}
+                      <span className={`text-xs ${(usage.usage_percentage ?? 0) >= 100 ? 'text-leaf-600 font-medium' : 'text-[var(--text-muted)]'}`}>
+                        {(usage.usage_percentage ?? 0) >= 100 ? '✅ 실적 달성' : `잔여 ${formatAmount(usage.remaining ?? 0)}`}
                       </span>
                     </div>
                     <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
                       <div
                         className={`h-1.5 rounded-full transition-all ${
-                          (usage.usage_percentage ?? 0) > 100
-                            ? 'bg-red-500'
+                          (usage.usage_percentage ?? 0) >= 100
+                            ? 'bg-leaf-500'
                             : (usage.usage_percentage ?? 0) >= 80
-                              ? 'bg-amber-500'
-                              : 'bg-grape-500'
+                              ? 'bg-grape-500'
+                              : 'bg-grape-400'
                         }`}
                         style={{ width: `${Math.min(usage.usage_percentage ?? 0, 100)}%` }}
                       />

--- a/frontend/src/pages/__tests__/InsightsPage.test.tsx
+++ b/frontend/src/pages/__tests__/InsightsPage.test.tsx
@@ -38,10 +38,10 @@ describe('InsightsPage', () => {
     })
   })
 
-  it('지출 카테고리 TOP이 표시된다', async () => {
+  it('지출 카테고리가 표시된다', async () => {
     render(<MemoryRouter><InsightsPage /></MemoryRouter>)
     await waitFor(() => {
-      expect(screen.getByText('지출 카테고리 TOP')).toBeInTheDocument()
+      expect(screen.getByText('지출 카테고리')).toBeInTheDocument()
     })
   })
 
@@ -122,7 +122,7 @@ describe('InsightsPage', () => {
     })
 
     const highlights = screen.getByText(/이번 달 주목할 점/)
-    const categoryTop = screen.getByText('지출 카테고리 TOP')
+    const categoryTop = screen.getByText('지출 카테고리')
 
     // 주목할 점이 카테고리 TOP보다 DOM에서 먼저 나온다
     expect(highlights.compareDocumentPosition(categoryTop) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
@@ -181,7 +181,7 @@ describe('InsightsPage', () => {
     const modal = screen.getByText('섹션 표시 설정').closest('div.relative')!
     expect(modal).toHaveTextContent('종합 요약 카드')
     expect(modal).toHaveTextContent('이달의 주목할 점')
-    expect(modal).toHaveTextContent('지출 카테고리 TOP')
+    expect(modal).toHaveTextContent('지출 카테고리')
     expect(modal).toHaveTextContent('예산 상황')
     expect(modal).toHaveTextContent('자산 변화')
     expect(modal).toHaveTextContent('AI 상세 분석')
@@ -191,15 +191,15 @@ describe('InsightsPage', () => {
     const user = userEvent.setup()
     render(<MemoryRouter><InsightsPage /></MemoryRouter>)
     await waitFor(() => {
-      expect(screen.getByText('지출 카테고리 TOP')).toBeInTheDocument()
+      expect(screen.getByText('지출 카테고리')).toBeInTheDocument()
     })
 
     // 설정 모달 열기
     await user.click(screen.getByLabelText('섹션 설정'))
     expect(screen.getByText('섹션 표시 설정')).toBeInTheDocument()
 
-    // '지출 카테고리 TOP' 토글 끄기
-    const categoryToggle = screen.getByRole('checkbox', { name: '지출 카테고리 TOP' })
+    // '지출 카테고리' 토글 끄기
+    const categoryToggle = screen.getByRole('checkbox', { name: '지출 카테고리' })
     await user.click(categoryToggle)
 
     // 모달 닫기
@@ -207,7 +207,7 @@ describe('InsightsPage', () => {
 
     // 해당 섹션이 더 이상 표시되지 않는다
     await waitFor(() => {
-      expect(screen.queryByText('지출 카테고리 TOP')).not.toBeInTheDocument()
+      expect(screen.queryByText('지출 카테고리')).not.toBeInTheDocument()
     })
   })
 
@@ -254,6 +254,6 @@ describe('InsightsPage', () => {
     // 주목할 점 섹션이 숨겨져 있다
     expect(screen.queryByText(/이번 달 주목할 점/)).not.toBeInTheDocument()
     // 다른 섹션은 정상 표시
-    expect(screen.getByText('지출 카테고리 TOP')).toBeInTheDocument()
+    expect(screen.getByText('지출 카테고리')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- #484 입력 후 목록 복귀 시 필터 토글 초기화
- #489 카드 실적 달성 → 초록색 축하 표현
- #476 페이지 이동 시 스크롤 최상단 (ScrollToTop)
- #478 직접 입력 폼에 결제수단 드롭다운 추가
- #486 기본 결제수단 해제 토글
- #488 카테고리 리스트/그래프 탭 통합 (도넛 차트)

## Test plan
- [x] FE 1305 passed
- [x] pre-commit + pre-push 통과
- [ ] 입력 후 필터 초기화 확인
- [ ] 카드 실적 달성 시 초록색 확인
- [ ] 페이지 이동 시 스크롤 상단 확인
- [ ] 카테고리 탭 전환 (리스트↔그래프) 확인

close #484 close #489 close #476 close #478 close #486 close #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)