### PR TITLE
feat: 결제수단 UX 전면 개선

### DIFF
--- a/backend/alembic/versions/x7y8z9a0b1c2_add_display_order_and_exclude_auto_payment.py
+++ b/backend/alembic/versions/x7y8z9a0b1c2_add_display_order_and_exclude_auto_payment.py
@@ -1,0 +1,39 @@
+"""add display_order and exclude_auto_payment
+
+결제수단에 display_order(표시 순서), 카테고리에 exclude_auto_payment(기본 결제수단 자동 적용 제외) 컬럼 추가.
+시스템 카테고리 중 저축/투자, 세금/공과금, 보험, 대출/이자는 자동 적용 제외로 시드.
+
+Revision ID: x7y8z9a0b1c2
+Revises: w6x7y8z9a0b1
+Create Date: 2026-03-27
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "x7y8z9a0b1c2"
+down_revision = "w6x7y8z9a0b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 결제수단 표시 순서
+    op.add_column("payment_methods", sa.Column("display_order", sa.Integer(), nullable=False, server_default="0"))
+
+    # 카테고리 기본 결제수단 자동 적용 제외
+    op.add_column("categories", sa.Column("exclude_auto_payment", sa.Boolean(), nullable=False, server_default="0"))
+
+    # 시스템 카테고리 시드: 저축/투자 성격 카테고리는 기본 결제수단 자동 적용 제외
+    op.execute(
+        "UPDATE categories SET exclude_auto_payment = true "
+        "WHERE name IN ('저축/투자', '세금/공과금', '보험', '대출/이자') "
+        "AND user_id IS NULL AND household_id IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("categories", "exclude_auto_payment")
+    op.drop_column("payment_methods", "display_order")

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -159,11 +159,12 @@ async def _save_and_respond(
         saved_amounts.append(amount)
 
         # 결제수단 매칭: LLM 파싱 → 이름 매칭 → 기본값 폴백
+        # exclude_auto_payment=true 카테고리(저축/투자, 세금 등)는 기본 결제수단 자동 적용 제외
         pm_name = item.get("payment_method")
         pm_id = None
         if pm_name and payment_method_map:
             pm_id = payment_method_map.get(pm_name)
-        if pm_id is None and item_type != "income":
+        if pm_id is None and item_type != "income" and not getattr(category, "exclude_auto_payment", False):
             pm_id = default_payment_method_id
 
         record_kwargs: dict[str, Any] = {

--- a/backend/app/api/expenses.py
+++ b/backend/app/api/expenses.py
@@ -22,6 +22,7 @@ from app.api.payment_methods import get_default_payment_method_id
 from app.core.auth import get_current_user
 from app.core.database import get_db
 from app.core.rate_limit import limiter
+from app.models.category import Category
 from app.models.expense import Expense
 from app.models.user import User
 from app.schemas.chat import ChatResponse, ParsedExpenseItem
@@ -102,8 +103,16 @@ async def create_expense(
     expense_data = expense.model_dump(exclude={"household_id"})
 
     # 기본 결제수단 자동 적용 — 명시적 지정이 없으면 사용자 기본값 폴백
+    # exclude_auto_payment=true 카테고리(저축/투자, 세금 등)는 기본 결제수단 자동 적용 제외
     if expense_data.get("payment_method_id") is None:
-        expense_data["payment_method_id"] = await get_default_payment_method_id(db, household_id, current_user.id)  # type: ignore[arg-type]
+        should_auto_apply = True
+        if expense_data.get("category_id"):
+            cat_result = await db.execute(select(Category.exclude_auto_payment).where(Category.id == expense_data["category_id"]))
+            exclude = cat_result.scalar_one_or_none()
+            if exclude:
+                should_auto_apply = False
+        if should_auto_apply:
+            expense_data["payment_method_id"] = await get_default_payment_method_id(db, household_id, current_user.id)  # type: ignore[arg-type]
 
     db_expense = Expense(**expense_data, user_id=current_user.id, household_id=household_id)
     db.add(db_expense)
@@ -170,8 +179,6 @@ async def get_stats(
 ) -> object:
     """기간별 통계 조회 (주간/월간/연간)"""
     from datetime import date as date_type
-
-    from app.models.category import Category
 
     # 기준 날짜 파싱
     ref_date = date_type.fromisoformat(date) if date else date_type.today()
@@ -286,8 +293,6 @@ async def get_stats_comparison(
 ) -> object:
     """기간 비교 (전월 대비 + N개월 트렌드)"""
     from datetime import date as date_type
-
-    from app.models.category import Category
 
     ref_date = date_type.fromisoformat(date) if date else date_type.today()
 
@@ -440,7 +445,6 @@ async def get_monthly_stats(
 
     household_id가 있으면 가구 전체 멤버의 월별 통계를 집계합니다.
     """
-    from app.models.category import Category
 
     year, mon = map(int, month.split("-"))
     start = datetime(year, mon, 1)

--- a/backend/app/api/kakao.py
+++ b/backend/app/api/kakao.py
@@ -28,6 +28,7 @@ from app.models.category import Category
 from app.models.expense import Expense
 from app.models.feedback import Feedback
 from app.models.income import Income
+from app.models.payment_method import PaymentMethod
 from app.services.bot_messages import (
     format_budget_status,
     format_budget_status_full,
@@ -43,6 +44,7 @@ from app.services.bot_messages import (
     format_report_message_full,
     format_server_error,
     format_timeout_message,
+    get_payment_method_icon,
 )
 from app.services.bot_strike_service import increment_strike, reset_strike
 from app.services.bot_user_service import get_or_create_bot_user, link_kakao_account_by_code
@@ -78,6 +80,8 @@ COMMAND_ALIASES: dict[str, tuple[str, bool]] = {
     "예산 전체": ("/budget_full", False),
     "피드백": ("/feedback", True),
     "건의": ("/feedback", True),
+    "결제수단변경": ("/change_payment", False),
+    "결제수단": ("/change_payment", False),
 }
 
 
@@ -319,6 +323,123 @@ async def _handle_feedback_command(utterance: str, bot_user: Any, db: AsyncSessi
     )
 
 
+async def _handle_change_payment_command(utterance: str, bot_user: Any, db: AsyncSession, active_household_id: int | None) -> dict[str, Any]:
+    """``/change_payment`` 명령어 처리 — 마지막 지출의 결제수단 변경
+
+    카카오는 stateless이므로 마지막 지출을 대상으로 합니다.
+    상위 3개 결제수단 + "선택 안 함" quickReply를 표시합니다.
+    """
+    # 마지막 지출 조회
+    result = await db.execute(select(Expense).where(Expense.user_id == bot_user.id).order_by(Expense.id.desc()).limit(1))
+    expense = result.scalar_one_or_none()
+
+    if not expense:
+        return make_simple_text_response("변경할 지출이 없어요.")
+
+    # 저축성 카테고리면 결제수단 변경 불가
+    if expense.category_id:
+        cat_result = await db.execute(select(Category).where(Category.id == expense.category_id))
+        category = cat_result.scalar_one_or_none()
+        if category and (category.exclude_auto_payment or category.is_savings):
+            return make_simple_text_response("저축성 지출은 결제수단을 설정할 수 없어요.")
+
+    # 사용자의 결제수단 목록 (display_order 순, 현재 제외, 상위 3개)
+    pm_query = (
+        select(PaymentMethod)
+        .where(
+            PaymentMethod.household_id == (expense.household_id or active_household_id),
+            PaymentMethod.is_active == True,  # noqa: E712
+        )
+        .order_by(PaymentMethod.display_order.asc(), PaymentMethod.id.asc())
+    )
+    pm_result = await db.execute(pm_query)
+    all_pms = list(pm_result.scalars().all())
+
+    # 현재 결제수단 제외 후 상위 3개
+    current_pm_id = expense.payment_method_id
+    candidates = [pm for pm in all_pms if pm.id != current_pm_id][:3]
+
+    if not candidates and not current_pm_id:
+        return make_simple_text_response(
+            "등록된 결제수단이 없어요.\n웹에서 결제수단을 먼저 등록해주세요.",
+        )
+
+    # 현재 결제수단 이름 조회
+    current_pm_name = None
+    if current_pm_id:
+        for pm in all_pms:
+            if pm.id == current_pm_id:
+                current_pm_name = pm.name
+                break
+
+    # quickReply 생성: 결제수단 + "선택 안 함"
+    quick_replies = []
+    for pm in candidates:
+        icon = get_payment_method_icon(pm.type)  # type: ignore[arg-type]
+        quick_replies.append(make_quick_reply(f"{icon} {pm.name}", f"/set_payment {pm.id}"))
+    quick_replies.append(make_quick_reply("🚫 선택 안 함", "/set_payment none"))
+
+    current_label = f" (현재: {current_pm_name})" if current_pm_name else ""
+    msg = f"💳 마지막 지출: {expense.amount:,.0f}원 - {expense.description}{current_label}\n\n결제수단을 선택해주세요."
+
+    return make_simple_text_response(msg, quick_replies=quick_replies)
+
+
+async def _handle_set_payment_command(utterance: str, bot_user: Any, db: AsyncSession, active_household_id: int | None) -> dict[str, Any]:
+    """``/set_payment`` 명령어 처리 — 마지막 지출의 결제수단 실제 변경"""
+    parts = utterance.split(maxsplit=1)
+    if len(parts) != 2:
+        return make_simple_text_response("결제수단 ID가 필요합니다.")
+
+    pm_arg = parts[1].strip()
+
+    # 마지막 지출 조회
+    result = await db.execute(select(Expense).where(Expense.user_id == bot_user.id).order_by(Expense.id.desc()).limit(1))
+    expense = result.scalar_one_or_none()
+    if not expense:
+        return make_simple_text_response("변경할 지출이 없어요.")
+
+    if pm_arg == "none":
+        expense.payment_method_id = None  # type: ignore[assignment]
+        await db.commit()
+        return make_simple_text_response(
+            f"✅ {expense.description} {expense.amount:,.0f}원의 결제수단을 해제했어요.",
+            quick_replies=[
+                make_quick_reply("📊 이번달 보기", "리포트"),
+                make_quick_reply("❓ 도움말", "도움말"),
+            ],
+        )
+
+    # 결제수단 ID로 조회
+    try:
+        pm_id = int(pm_arg)
+    except ValueError:
+        return make_simple_text_response("잘못된 결제수단입니다.")
+
+    pm_result = await db.execute(
+        select(PaymentMethod).where(
+            PaymentMethod.id == pm_id,
+            PaymentMethod.household_id == expense.household_id,
+            PaymentMethod.is_active == True,  # noqa: E712
+        )
+    )
+    pm = pm_result.scalar_one_or_none()
+    if not pm:
+        return make_simple_text_response("결제수단을 찾을 수 없어요.")
+
+    expense.payment_method_id = pm.id
+    await db.commit()
+
+    icon = get_payment_method_icon(pm.type)  # type: ignore[arg-type]
+    return make_simple_text_response(
+        f"✅ {expense.description} {expense.amount:,.0f}원 → {icon} {pm.name}으로 변경했어요.",
+        quick_replies=[
+            make_quick_reply("📊 이번달 보기", "리포트"),
+            make_quick_reply("❓ 도움말", "도움말"),
+        ],
+    )
+
+
 # 슬래시 명령어 디스패치 테이블
 # 키: 명령어 prefix, 값: 핸들러 함수
 # 핸들러 시그니처: (utterance, bot_user, db, active_household_id) -> dict
@@ -334,6 +455,8 @@ _COMMAND_HANDLERS: dict[  # type: ignore[type-arg]
     "/undo": _handle_undo_command,
     "/change": _handle_change_command,
     "/feedback": _handle_feedback_command,
+    "/change_payment": _handle_change_payment_command,
+    "/set_payment": _handle_set_payment_command,
 }
 
 
@@ -456,23 +579,48 @@ async def _handle_single_expense(db: AsyncSession, bot_user: Any, parsed: dict[s
             ],
         )
 
-    # 지출 (기본)
+    # 지출 (기본) — 기본 결제수단 자동 적용 (저축성 카테고리 제외)
+    is_savings_category = getattr(category, "exclude_auto_payment", False) or getattr(category, "is_savings", False)
+    pm_name: str | None = None
+    pm_type: str | None = None
+
+    if not is_savings_category and household_id:
+        from app.api.payment_methods import get_default_payment_method_id
+
+        default_pm_id = await get_default_payment_method_id(db, household_id, bot_user.id)
+        if default_pm_id:
+            record_kwargs["payment_method_id"] = default_pm_id
+            # 결제수단 이름/타입 조회 (응답 메시지용)
+            pm_result = await db.execute(select(PaymentMethod).where(PaymentMethod.id == default_pm_id))
+            pm = pm_result.scalar_one_or_none()
+            if pm:
+                pm_name = pm.name  # type: ignore[assignment]
+                pm_type = pm.type  # type: ignore[assignment]
+
     record = Expense(**record_kwargs)
     db.add(record)
     await db.commit()
     await db.refresh(record)
+
+    quick_replies = [
+        make_quick_reply("↩️ 방금 거 취소", "취소"),
+        make_quick_reply("🔄 카테고리 변경", "변경"),
+    ]
+    # 저축성 카테고리가 아닐 때만 결제수단 변경 버튼 표시
+    if not is_savings_category:
+        quick_replies.append(make_quick_reply("💳 결제수단 변경", "결제수단변경"))
+    quick_replies.append(make_quick_reply("📊 이번달 지출 보기", "리포트"))
+
     return make_simple_text_response(
         format_expense_saved(
             amount=parsed["amount"],
             category=category.name,  # type: ignore[arg-type]
             description=parsed.get("description", utterance),
             date=record_date.date().isoformat(),
+            payment_method_name=pm_name,
+            payment_method_type=pm_type,
         ),
-        quick_replies=[
-            make_quick_reply("↩️ 방금 거 취소", "취소"),
-            make_quick_reply("🔄 카테고리 변경", "변경"),
-            make_quick_reply("📊 이번달 지출 보기", "리포트"),
-        ],
+        quick_replies=quick_replies,
     )
 
 

--- a/backend/app/api/onboarding.py
+++ b/backend/app/api/onboarding.py
@@ -14,6 +14,7 @@ from app.core.auth import get_current_user
 from app.core.database import get_db
 from app.models.household import Household
 from app.models.household_member import HouseholdMember
+from app.models.payment_method import PaymentMethod
 from app.models.user import User
 from app.schemas.onboarding import CreateDefaultHousehold, OnboardingStatus
 
@@ -82,6 +83,28 @@ async def create_default_household(
         joined_at=datetime.now(UTC).replace(tzinfo=None),
     )
     db.add(member)
+
+    # 기본 결제수단 자동 생성 (현금 + 계좌이체)
+    default_pms = [
+        PaymentMethod(
+            household_id=household.id,
+            created_by=current_user.id,
+            name="현금",
+            type="cash",
+            is_default=False,
+            display_order=0,
+        ),
+        PaymentMethod(
+            household_id=household.id,
+            created_by=current_user.id,
+            name="계좌이체",
+            type="transfer",
+            is_default=False,
+            display_order=1,
+        ),
+    ]
+    db.add_all(default_pms)
+
     await db.commit()
     await db.refresh(household)
 

--- a/backend/app/api/payment_methods.py
+++ b/backend/app/api/payment_methods.py
@@ -21,6 +21,7 @@ from app.models.payment_method import PaymentMethod
 from app.models.user import User
 from app.schemas.payment_method import (
     PaymentMethodCreate,
+    PaymentMethodReorderRequest,
     PaymentMethodResponse,
     PaymentMethodUpdate,
     PaymentMethodUsage,
@@ -92,6 +93,7 @@ async def create_payment_method(
         type=payload.type,
         monthly_target=payload.monthly_target,
         is_default=payload.is_default,
+        display_order=payload.display_order,
     )
     db.add(pm)
     await db.commit()
@@ -117,9 +119,53 @@ async def list_payment_methods(
             PaymentMethod.household_id == household_id,
             PaymentMethod.is_active == True,  # noqa: E712
         )
-        .order_by(PaymentMethod.is_default.desc(), PaymentMethod.created_at)
+        .order_by(PaymentMethod.display_order, PaymentMethod.created_at)
     )
     return result.scalars().all()
+
+
+@router.post("/reorder", response_model=list[PaymentMethodResponse])
+async def reorder_payment_methods(
+    payload: PaymentMethodReorderRequest,
+    household_id: int | None = None,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> object:
+    """결제수단 순서 변경 — ID 목록 순서대로 display_order 재할당"""
+    if household_id is None:
+        household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)
+
+    # 요청된 ID들이 실제 해당 가구의 활성 결제수단인지 검증
+    result = await db.execute(
+        select(PaymentMethod).where(
+            PaymentMethod.id.in_(payload.payment_method_ids),
+            PaymentMethod.household_id == household_id,
+            PaymentMethod.is_active == True,  # noqa: E712
+        )
+    )
+    found_pms: dict[int, PaymentMethod] = {int(pm.id): pm for pm in result.scalars().all()}
+
+    # 중복 ID 검증
+    if len(set(payload.payment_method_ids)) != len(payload.payment_method_ids):
+        raise HTTPException(status_code=400, detail="중복된 결제수단 ID가 있습니다")
+
+    if len(found_pms) != len(payload.payment_method_ids):
+        raise HTTPException(
+            status_code=400,
+            detail="일부 결제수단을 찾을 수 없습니다",
+        )
+
+    # display_order 재할당
+    for idx, pm_id in enumerate(payload.payment_method_ids):
+        found_pms[pm_id].display_order = idx  # type: ignore[assignment]
+
+    await db.commit()
+    for pm in found_pms.values():
+        await db.refresh(pm)
+
+    # 정렬된 목록 반환
+    return sorted(found_pms.values(), key=lambda p: int(p.display_order))
 
 
 @router.put("/{payment_method_id}", response_model=PaymentMethodResponse)

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -33,6 +33,7 @@ from app.models.category import Category
 from app.models.expense import Expense
 from app.models.feedback import Feedback
 from app.models.income import Income
+from app.models.payment_method import PaymentMethod
 from app.schemas.bot import BotResponse
 from app.services.bot_messages import (
     format_budget_status,
@@ -49,6 +50,7 @@ from app.services.bot_messages import (
     format_report_message_full,
     format_server_error,
     format_welcome_message,
+    get_payment_method_icon,
 )
 from app.services.bot_strike_service import increment_strike, reset_strike
 from app.services.bot_user_service import get_or_create_bot_user, link_telegram_account_by_code
@@ -206,47 +208,62 @@ async def _save_and_respond_single(
             reply_markup=inline_keyboard,
         )
 
-    # 지출 (기본)
+    # 지출 (기본) — 기본 결제수단 자동 적용 (저축성 카테고리 제외)
+    is_savings_category = getattr(category, "exclude_auto_payment", False) or getattr(category, "is_savings", False)
+    pm_name: str | None = None
+    pm_type: str | None = None
+
+    if not is_savings_category and household_id:
+        from app.api.payment_methods import get_default_payment_method_id
+
+        default_pm_id = await get_default_payment_method_id(db, household_id, bot_user.id)
+        if default_pm_id:
+            record_kwargs["payment_method_id"] = default_pm_id
+            pm_result = await db.execute(select(PaymentMethod).where(PaymentMethod.id == default_pm_id))
+            pm = pm_result.scalar_one_or_none()
+            if pm:
+                pm_name = pm.name  # type: ignore[assignment]
+                pm_type = pm.type  # type: ignore[assignment]
+
     record = Expense(**record_kwargs)
     db.add(record)
     await db.commit()
     await db.refresh(record)
     reset_strike("telegram", str(chat_id))
-    inline_keyboard = {
-        "inline_keyboard": [
-            [
-                {"text": "🔄 카테고리 변경", "callback_data": f"change_category:{record.id}"},
-                {"text": "🗑️ 삭제", "callback_data": f"delete_expense:{record.id}"},
-            ],
-            [
-                {"text": "💰 수입으로 변경", "callback_data": f"convert_to_income:{record.id}"},
-            ],
-        ]
-    }
+    inline_keyboard = _build_expense_saved_keyboard(record.id, is_savings=is_savings_category)  # type: ignore[arg-type]
     return BotResponse(
         text=format_expense_saved(
             amount=parsed["amount"],
             category=category.name,  # type: ignore[arg-type]
             description=parsed.get("description", user_text),
             date=record_date.isoformat(),
+            payment_method_name=pm_name,
+            payment_method_type=pm_type,
         ),
         reply_markup=inline_keyboard,
     )
 
 
-def _build_expense_saved_keyboard(expense_id: int) -> dict[str, Any]:
-    """지출 저장 후 수정/삭제/변환 인라인 키보드 생성"""
-    return {
-        "inline_keyboard": [
-            [
-                {"text": "🔄 카테고리 변경", "callback_data": f"change_category:{expense_id}"},
-                {"text": "🗑️ 삭제", "callback_data": f"delete_expense:{expense_id}"},
-            ],
-            [
-                {"text": "💰 수입으로 변경", "callback_data": f"convert_to_income:{expense_id}"},
-            ],
-        ]
-    }
+def _build_expense_saved_keyboard(expense_id: int, *, is_savings: bool = False) -> dict[str, Any]:
+    """지출 저장 후 수정/삭제/변환 인라인 키보드 생성
+
+    Args:
+        expense_id: 지출 ID
+        is_savings: 저축성 카테고리 여부 (True면 결제수단 변경 버튼 미표시)
+    """
+    rows: list[list[dict[str, str]]] = [
+        [
+            {"text": "🔄 카테고리 변경", "callback_data": f"change_category:{expense_id}"},
+            {"text": "🗑️ 삭제", "callback_data": f"delete_expense:{expense_id}"},
+        ],
+    ]
+    bottom_row: list[dict[str, str]] = [
+        {"text": "💰 수입으로 변경", "callback_data": f"convert_to_income:{expense_id}"},
+    ]
+    if not is_savings:
+        bottom_row.append({"text": "💳 결제수단", "callback_data": f"change_payment:{expense_id}"})
+    rows.append(bottom_row)
+    return {"inline_keyboard": rows}
 
 
 # ---------------------------------------------------------------------------
@@ -873,6 +890,86 @@ async def _handle_convert_to_expense(db: AsyncSession, chat_id: int, callback_id
     )
 
 
+async def _handle_change_payment(db: AsyncSession, chat_id: int, callback_id: str, expense: Expense, bot_user: Any, parts: list[str]) -> BotResponse:
+    """결제수단 변경 버튼 목록 표시 (현재 제외 상위 3개 + none)"""
+    # 저축성 카테고리 체크
+    if expense.category_id:
+        cat_result = await db.execute(select(Category).where(Category.id == expense.category_id))
+        category = cat_result.scalar_one_or_none()
+        if category and (category.exclude_auto_payment or category.is_savings):
+            return BotResponse(text="", callback_answer="저축성 지출은 결제수단을 설정할 수 없어요.")
+
+    # 사용자의 결제수단 목록 (display_order 순)
+    pm_query = (
+        select(PaymentMethod)
+        .where(
+            PaymentMethod.household_id == expense.household_id,
+            PaymentMethod.is_active == True,  # noqa: E712
+        )
+        .order_by(PaymentMethod.display_order.asc(), PaymentMethod.id.asc())
+    )
+    pm_result = await db.execute(pm_query)
+    all_pms = list(pm_result.scalars().all())
+
+    # 현재 결제수단 제외 후 상위 3개
+    current_pm_id = expense.payment_method_id
+    candidates = [pm for pm in all_pms if pm.id != current_pm_id][:3]
+
+    if not candidates and not current_pm_id:
+        return BotResponse(text="", callback_answer="등록된 결제수단이 없어요.")
+
+    # 인라인 키보드: 결제수단 + "선택 안 함"
+    buttons: list[list[dict[str, str]]] = []
+    for pm in candidates:
+        icon = get_payment_method_icon(pm.type)  # type: ignore[arg-type]
+        buttons.append([{"text": f"{icon} {pm.name}", "callback_data": f"set_payment:{expense.id}:{pm.id}"}])
+    buttons.append([{"text": "🚫 선택 안 함", "callback_data": f"set_payment:{expense.id}:none"}])
+
+    return BotResponse(
+        text=f"💳 {expense.amount:,.0f}원 지출의 결제수단을 선택해주세요:",
+        reply_markup={"inline_keyboard": buttons},
+        callback_answer="결제수단을 선택해주세요.",
+    )
+
+
+async def _handle_set_payment(db: AsyncSession, chat_id: int, callback_id: str, expense: Expense, bot_user: Any, parts: list[str]) -> BotResponse:
+    """결제수단 실제 변경 (callback_data: set_payment:expense_id:pm_id_or_none)"""
+    pm_arg = parts[2]
+
+    if pm_arg == "none":
+        expense.payment_method_id = None  # type: ignore[assignment]
+        await db.commit()
+        return BotResponse(
+            text=f"✅ {expense.description} {expense.amount:,.0f}원의 결제수단을 해제했어요.",
+            callback_answer="결제수단 해제!",
+        )
+
+    try:
+        pm_id = int(pm_arg)
+    except ValueError:
+        return BotResponse(text="", callback_answer="잘못된 결제수단입니다.")
+
+    pm_result = await db.execute(
+        select(PaymentMethod).where(
+            PaymentMethod.id == pm_id,
+            PaymentMethod.household_id == expense.household_id,
+            PaymentMethod.is_active == True,  # noqa: E712
+        )
+    )
+    pm = pm_result.scalar_one_or_none()
+    if not pm:
+        return BotResponse(text="", callback_answer="결제수단을 찾을 수 없어요.")
+
+    expense.payment_method_id = pm.id
+    await db.commit()
+
+    icon = get_payment_method_icon(pm.type)  # type: ignore[arg-type]
+    return BotResponse(
+        text=f"✅ {expense.description} {expense.amount:,.0f}원 → {icon} {pm.name}",
+        callback_answer=f"{pm.name}으로 변경!",
+    )
+
+
 # 콜백 액션 디스패치 테이블
 # 키: action prefix, 값: (핸들러 함수, 최소 parts 수)
 _CALLBACK_HANDLERS: dict[
@@ -890,6 +987,8 @@ _CALLBACK_HANDLERS: dict[
     "change_category": (_handle_change_category, 2),
     "set_category": (_handle_set_category, 3),
     "convert_to_income": (_handle_convert_to_income, 2),
+    "change_payment": (_handle_change_payment, 2),
+    "set_payment": (_handle_set_payment, 3),
 }
 
 # Income 관련 콜백 액션 — Income 모델에서 조회해야 하는 액션들

--- a/backend/app/models/category.py
+++ b/backend/app/models/category.py
@@ -39,6 +39,7 @@ class Category(Base):  # type: ignore[misc]
     type = Column(String(10), nullable=False, default="expense")  # expense | income | both
     sort_order = Column(BigInteger, nullable=False, default=0, server_default="0")  # 사용 횟수 기반 정렬 (높을수록 앞)
     is_savings = Column(Boolean, nullable=False, default=False, server_default="0")  # 저축성 지출 여부 (적금, 투자, 보험 등)
+    exclude_auto_payment = Column(Boolean, nullable=False, default=False, server_default="0")  # 기본 결제수단 자동 적용 제외 (저축/투자, 세금 등)
     created_at = Column(DateTime, default=func.now(), server_default=func.now(), nullable=False)
 
     # Relationships

--- a/backend/app/models/payment_method.py
+++ b/backend/app/models/payment_method.py
@@ -40,5 +40,6 @@ class PaymentMethod(Base):  # type: ignore[misc]
     billing_day = Column(Integer, nullable=True)  # 결제일 (v2용, 현재 미사용)
     is_default = Column(Boolean, nullable=False, default=False)
     is_active = Column(Boolean, nullable=False, default=True)
+    display_order = Column(Integer, nullable=False, default=0, server_default="0")  # 목록 표시 순서 (낮을수록 앞)
     created_at = Column(DateTime, nullable=False, server_default=func.now())
     updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())

--- a/backend/app/schemas/category.py
+++ b/backend/app/schemas/category.py
@@ -13,6 +13,7 @@ class CategoryBase(BaseModel):
 class CategoryCreate(CategoryBase):
     type: str = "expense"
     is_savings: bool = False
+    exclude_auto_payment: bool = False
 
 
 class CategoryUpdate(BaseModel):
@@ -20,6 +21,7 @@ class CategoryUpdate(BaseModel):
     description: str | None = Field(None, max_length=500, description="카테고리 설명 (최대 500자)")
     type: str | None = None
     is_savings: bool | None = None
+    exclude_auto_payment: bool | None = None
 
 
 class CategoryReorderRequest(BaseModel):
@@ -33,6 +35,7 @@ class CategoryResponse(CategoryBase):
     type: str = "expense"
     sort_order: int = 0
     is_savings: bool = False
+    exclude_auto_payment: bool = False
     is_system: bool = False
     created_at: datetime
 

--- a/backend/app/schemas/payment_method.py
+++ b/backend/app/schemas/payment_method.py
@@ -19,6 +19,7 @@ class PaymentMethodCreate(BaseModel):
     type: PaymentType
     monthly_target: Decimal | None = None
     is_default: bool = False
+    display_order: int = 0
     household_id: int | None = None
 
 
@@ -30,6 +31,13 @@ class PaymentMethodUpdate(BaseModel):
     monthly_target: Decimal | None = None
     is_default: bool | None = None
     is_active: bool | None = None
+    display_order: int | None = None
+
+
+class PaymentMethodReorderRequest(BaseModel):
+    """결제수단 순서 변경 요청 — 순서대로 정렬된 결제수단 ID 목록"""
+
+    payment_method_ids: list[int]
 
 
 class PaymentMethodResponse(BaseModel):
@@ -43,6 +51,7 @@ class PaymentMethodResponse(BaseModel):
     monthly_target: float | None
     is_default: bool
     is_active: bool
+    display_order: int
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/services/bot_messages.py
+++ b/backend/app/services/bot_messages.py
@@ -39,13 +39,41 @@ def format_korean_date(d: date | datetime | str) -> str:
     return f"{d.month}월 {d.day}일 ({weekday})"
 
 
-def format_expense_saved(amount: float, category: str, description: str, date: str) -> str:
+def get_payment_method_icon(pm_type: str | None) -> str:
+    """결제수단 유형별 아이콘 반환
+
+    Args:
+        pm_type: 결제수단 유형 (credit_card, debit_card, cash, transfer)
+
+    Returns:
+        해당 유형의 이모지 아이콘
+    """
+    icons = {
+        "credit_card": "💳",
+        "debit_card": "💳",
+        "cash": "💵",
+        "transfer": "🏦",
+    }
+    return icons.get(pm_type or "", "💳")
+
+
+def format_expense_saved(
+    amount: float,
+    category: str,
+    description: str,
+    date: str,
+    payment_method_name: str | None = None,
+    payment_method_type: str | None = None,
+) -> str:
     """지출 저장 성공 메시지
 
-    Before: "✅ 지출이 기록되었어요!\n\n💰 8,000원\n📂 식비\n📅 2026-03-20\n📝 김치찌개"
-    After:  "🍇 김치찌개 8,000원 기록했어요\n\n3월 20일 (금) · 식비"
+    Before: "🍇 김치찌개 8,000원 기록했어요\n\n3월 20일 (금) · 식비"
+    After:  "🍇 김치찌개 8,000원 기록했어요\n\n3월 20일 (금) · 📂 식비 | 💳 삼성카드"
     """
     korean_date = format_korean_date(date)
+    if payment_method_name:
+        icon = get_payment_method_icon(payment_method_type)
+        return f"🍇 {description} {amount:,.0f}원 기록했어요\n\n{korean_date} · 📂 {category} | {icon} {payment_method_name}"
     return f"🍇 {description} {amount:,.0f}원 기록했어요\n\n{korean_date} · {category}"
 
 

--- a/backend/tests/integration/test_payment_method_ux.py
+++ b/backend/tests/integration/test_payment_method_ux.py
@@ -1,0 +1,378 @@
+"""결제수단 UX 개선 통합 테스트
+
+- exclude_auto_payment=true 카테고리 지출 시 기본 결제수단 미적용
+- 가구 생성(온보딩) 시 현금+계좌이체 자동 생성
+- display_order 기반 정렬
+- 순서 변경 API (reorder)
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.category import Category
+from app.models.payment_method import PaymentMethod
+from app.models.user import User
+
+# ── exclude_auto_payment 테스트 ──
+
+
+@pytest.mark.asyncio
+async def test_exclude_auto_payment_skips_default_pm(
+    authenticated_client: AsyncClient,
+    test_user: User,
+    test_household,
+    db_session: AsyncSession,
+):
+    """exclude_auto_payment=true 카테고리의 지출 생성 시 기본 결제수단이 적용되지 않는다"""
+    # 카테고리 생성: exclude_auto_payment=true
+    cat = Category(
+        name="저축/투자",
+        type="expense",
+        household_id=test_household.id,
+        exclude_auto_payment=True,
+    )
+    db_session.add(cat)
+    await db_session.flush()
+
+    # 기본 결제수단 생성
+    pm = PaymentMethod(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="삼성카드",
+        type="credit_card",
+        is_default=True,
+    )
+    db_session.add(pm)
+    await db_session.commit()
+
+    # 지출 생성 (payment_method_id 미지정 + exclude_auto_payment 카테고리)
+    response = await authenticated_client.post(
+        "/api/expenses",
+        json={
+            "amount": 500000,
+            "description": "적금 이체",
+            "category_id": cat.id,
+            "date": "2026-03-27T10:00:00",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    # 기본 결제수단이 자동 적용되지 않아야 함
+    assert data.get("payment_method_id") is None
+
+
+@pytest.mark.asyncio
+async def test_normal_category_gets_default_pm(
+    authenticated_client: AsyncClient,
+    test_user: User,
+    test_household,
+    db_session: AsyncSession,
+):
+    """exclude_auto_payment=false 카테고리의 지출 생성 시 기본 결제수단이 적용된다"""
+    # 일반 카테고리 생성
+    cat = Category(
+        name="식비",
+        type="expense",
+        household_id=test_household.id,
+        exclude_auto_payment=False,
+    )
+    db_session.add(cat)
+    await db_session.flush()
+
+    # 기본 결제수단 생성
+    pm = PaymentMethod(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="삼성카드",
+        type="credit_card",
+        is_default=True,
+    )
+    db_session.add(pm)
+    await db_session.commit()
+
+    response = await authenticated_client.post(
+        "/api/expenses",
+        json={
+            "amount": 8000,
+            "description": "김치찌개",
+            "category_id": cat.id,
+            "date": "2026-03-27T12:00:00",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    # 기본 결제수단이 자동 적용되어야 함
+    assert data["payment_method_id"] == pm.id
+
+
+@pytest.mark.asyncio
+async def test_chat_exclude_auto_payment_skips_default_pm(
+    authenticated_client: AsyncClient,
+    test_user: User,
+    test_household,
+    db_session: AsyncSession,
+    mock_llm_parse_expense,
+):
+    """chat API에서도 exclude_auto_payment=true 카테고리는 기본 결제수단이 적용되지 않는다"""
+    # exclude_auto_payment 카테고리
+    cat = Category(
+        name="저축/투자",
+        type="expense",
+        household_id=test_household.id,
+        exclude_auto_payment=True,
+    )
+    db_session.add(cat)
+    await db_session.flush()
+
+    # 기본 결제수단
+    pm = PaymentMethod(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="삼성카드",
+        type="credit_card",
+        is_default=True,
+    )
+    db_session.add(pm)
+    await db_session.commit()
+
+    # LLM이 저축/투자 카테고리로 파싱한 경우
+    mock_llm_parse_expense.return_value = {
+        "amount": 500000,
+        "category": "저축/투자",
+        "description": "적금 이체",
+        "date": "2026-03-27",
+        "memo": "",
+    }
+
+    response = await authenticated_client.post(
+        "/api/chat",
+        json={"message": "적금 50만원 이체", "preview": False},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    # 저장된 지출의 payment_method_id가 None이어야 함
+    assert data["expenses_created"] is not None
+    assert data["expenses_created"][0].get("payment_method_id") is None
+
+
+# ── 온보딩 시 기본 결제수단 자동 생성 테스트 ──
+
+
+@pytest_asyncio.fixture
+async def fresh_user(db_session: AsyncSession):
+    """가구 미소속 사용자 — 온보딩 테스트용"""
+    from tests.conftest import TEST_AUTH_USER_ID_1
+
+    user = User(
+        auth_user_id=TEST_AUTH_USER_ID_1,
+        username="freshuser",
+        email="fresh@example.com",
+        hashed_password=None,
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    return user
+
+
+@pytest.mark.asyncio
+async def test_onboarding_creates_default_payment_methods(
+    client: AsyncClient,
+    fresh_user: User,
+    db_session: AsyncSession,
+):
+    """온보딩으로 가구 생성 시 현금+계좌이체 결제수단이 자동 생성된다"""
+    from tests.conftest import create_test_token
+
+    token = create_test_token(
+        auth_user_id=fresh_user.auth_user_id,
+        email=fresh_user.email,
+        name=fresh_user.username,
+    )
+
+    response = await client.post(
+        "/api/onboarding/create-household",
+        json={"name": "테스트 가계부"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 201
+    household_id = response.json()["id"]
+
+    # 결제수단 목록 조회
+    pm_response = await client.get(
+        f"/api/payment-methods?household_id={household_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert pm_response.status_code == 200
+    pms = pm_response.json()
+
+    # 현금 + 계좌이체 2개 자동 생성
+    assert len(pms) == 2
+    names = {pm["name"] for pm in pms}
+    assert names == {"현금", "계좌이체"}
+
+    # type 확인
+    types = {pm["name"]: pm["type"] for pm in pms}
+    assert types["현금"] == "cash"
+    assert types["계좌이체"] == "transfer"
+
+    # is_default는 둘 다 False
+    assert all(pm["is_default"] is False for pm in pms)
+
+    # display_order 확인 (현금=0, 계좌이체=1)
+    orders = {pm["name"]: pm["display_order"] for pm in pms}
+    assert orders["현금"] == 0
+    assert orders["계좌이체"] == 1
+
+
+# ── display_order 정렬 테스트 ──
+
+
+@pytest.mark.asyncio
+async def test_list_payment_methods_sorted_by_display_order(
+    authenticated_client: AsyncClient,
+    test_user: User,
+    test_household,
+    db_session: AsyncSession,
+):
+    """결제수단 목록이 display_order → created_at 순서로 정렬된다"""
+    # display_order 역순으로 생성
+    pm1 = PaymentMethod(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="카드C",
+        type="credit_card",
+        display_order=2,
+    )
+    pm2 = PaymentMethod(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="카드A",
+        type="credit_card",
+        display_order=0,
+    )
+    pm3 = PaymentMethod(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="카드B",
+        type="debit_card",
+        display_order=1,
+    )
+    db_session.add_all([pm1, pm2, pm3])
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/payment-methods")
+    assert response.status_code == 200
+    data = response.json()
+    names = [pm["name"] for pm in data]
+    # display_order 오름차순: A(0) → B(1) → C(2)
+    assert names == ["카드A", "카드B", "카드C"]
+
+
+# ── 순서 변경 API 테스트 ──
+
+
+@pytest.mark.asyncio
+async def test_reorder_payment_methods(
+    authenticated_client: AsyncClient,
+    test_user: User,
+    test_household,
+    db_session: AsyncSession,
+):
+    """POST /api/payment-methods/reorder로 순서 변경이 반영된다"""
+    pm1 = PaymentMethod(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="현금",
+        type="cash",
+        display_order=0,
+    )
+    pm2 = PaymentMethod(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="카드",
+        type="credit_card",
+        display_order=1,
+    )
+    pm3 = PaymentMethod(
+        household_id=test_household.id,
+        created_by=test_user.id,
+        name="계좌이체",
+        type="transfer",
+        display_order=2,
+    )
+    db_session.add_all([pm1, pm2, pm3])
+    await db_session.commit()
+
+    # 순서 변경: 카드 → 현금 → 계좌이체
+    response = await authenticated_client.post(
+        "/api/payment-methods/reorder",
+        json={"payment_method_ids": [pm2.id, pm1.id, pm3.id]},
+    )
+    assert response.status_code == 200
+
+    # 목록 재조회로 순서 확인
+    list_response = await authenticated_client.get("/api/payment-methods")
+    assert list_response.status_code == 200
+    names = [pm["name"] for pm in list_response.json()]
+    assert names == ["카드", "현금", "계좌이체"]
+
+
+@pytest.mark.asyncio
+async def test_reorder_with_invalid_ids(
+    authenticated_client: AsyncClient,
+    test_user: User,
+    test_household,
+    db_session: AsyncSession,
+):
+    """존재하지 않는 결제수단 ID로 reorder 시 400 에러"""
+    response = await authenticated_client.post(
+        "/api/payment-methods/reorder",
+        json={"payment_method_ids": [9999, 8888]},
+    )
+    assert response.status_code == 400
+
+
+# ── display_order 응답 필드 테스트 ──
+
+
+@pytest.mark.asyncio
+async def test_create_payment_method_with_display_order(
+    authenticated_client: AsyncClient,
+    test_user: User,
+    test_household,
+):
+    """결제수단 생성 시 display_order가 응답에 포함된다"""
+    response = await authenticated_client.post(
+        "/api/payment-methods",
+        json={"name": "테스트카드", "type": "credit_card", "display_order": 5},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["display_order"] == 5
+
+
+# ── exclude_auto_payment 카테고리 응답 필드 테스트 ──
+
+
+@pytest.mark.asyncio
+async def test_category_response_includes_exclude_auto_payment(
+    authenticated_client: AsyncClient,
+    test_user: User,
+    test_household,
+):
+    """카테고리 생성 시 exclude_auto_payment 필드가 응답에 포함된다"""
+    response = await authenticated_client.post(
+        "/api/categories",
+        json={
+            "name": "보험료",
+            "type": "expense",
+            "exclude_auto_payment": True,
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["exclude_auto_payment"] is True

--- a/frontend/src/api/paymentMethods.ts
+++ b/frontend/src/api/paymentMethods.ts
@@ -42,4 +42,8 @@ export const paymentMethodApi = {
     apiClient.get<PaymentMethodUsage[]>('/payment-methods/stats/monthly', {
       params: { month, household_id: householdId },
     }),
+
+  /** 결제수단 순서 변경 */
+  reorder: (ids: number[]) =>
+    apiClient.put('/payment-methods/reorder', { ids }),
 }

--- a/frontend/src/components/BotNudgeCard.tsx
+++ b/frontend/src/components/BotNudgeCard.tsx
@@ -1,0 +1,67 @@
+/**
+ * @file BotNudgeCard.tsx
+ * @description 봇 연동 넛지 카드 — 첫 지출 저장 후 카카오톡/텔레그램 연동을 유도.
+ *
+ * 표시 조건:
+ * - 봇 미연동 (is_telegram_linked=false && is_kakao_linked=false)
+ * - 지출 1건 이상 존재
+ * - localStorage 'podo-bot-nudge-dismissed' !== 'true'
+ *
+ * "나중에" 클릭 시 localStorage에 플래그 저장하여 재표시 방지.
+ */
+
+import { useNavigate } from 'react-router-dom'
+import { MessageCircle, X } from 'lucide-react'
+
+interface BotNudgeCardProps {
+  onDismiss: () => void
+}
+
+export default function BotNudgeCard({ onDismiss }: BotNudgeCardProps) {
+  const navigate = useNavigate()
+
+  return (
+    <div className="bg-gradient-to-r from-grape-50 to-leaf-50/40 rounded-2xl shadow-sm border border-grape-200/60 overflow-hidden">
+      <div className="px-4 py-4">
+        {/* 헤더 */}
+        <div className="flex items-start justify-between mb-2">
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 rounded-full bg-grape-100 flex items-center justify-center">
+              <MessageCircle className="w-4 h-4 text-grape-600" />
+            </div>
+            <p className="text-sm font-bold text-[var(--text-primary)]">
+              카카오톡으로 더 빠르게 입력할 수 있어요
+            </p>
+          </div>
+          <button
+            onClick={onDismiss}
+            className="p-1 -mr-1 rounded-lg hover:bg-grape-100 text-[var(--text-muted)] transition-colors"
+            aria-label="봇 연동 안내 닫기"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <p className="text-xs text-[var(--text-tertiary)] mb-3 ml-10">
+          봇을 연동하면 메신저에서 바로 가계부를 쓸 수 있어요
+        </p>
+
+        {/* 버튼 그룹 */}
+        <div className="flex items-center gap-2 ml-10">
+          <button
+            onClick={() => navigate('/settings/my-account')}
+            className="px-4 py-2 bg-grape-600 text-white text-sm font-medium rounded-xl hover:bg-grape-700 active:scale-[0.98] transition-all shadow-sm shadow-grape-200"
+          >
+            카카오톡 연동하기
+          </button>
+          <button
+            onClick={onDismiss}
+            className="px-4 py-2 text-sm font-medium text-[var(--text-secondary)] rounded-xl hover:bg-[var(--surface-hover)] transition-colors"
+          >
+            나중에
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TransactionForm.tsx
+++ b/frontend/src/components/TransactionForm.tsx
@@ -513,7 +513,16 @@ export default function TransactionForm({ type }: TransactionFormProps) {
             <select
               id={`${idPrefix}-category`}
               value={formData.category_id}
-              onChange={(e) => setFormData({ ...formData, category_id: e.target.value })}
+              onChange={(e) => {
+                const catId = e.target.value
+                const selectedCat = formCategories.find((cat) => String(cat.id) === catId)
+                const isSavings = selectedCat ? (selectedCat.exclude_auto_payment || selectedCat.is_savings) : false
+                if (isSavings) {
+                  setFormData({ ...formData, category_id: catId, payment_method_id: '' })
+                } else {
+                  setFormData({ ...formData, category_id: catId })
+                }
+              }}
               className={`w-full px-4 py-3 border border-[var(--input-border)] rounded-xl focus:ring-2 focus:ring-${c}-500/30 focus:border-${c}-500`}
               disabled={loading}
             >
@@ -564,27 +573,36 @@ export default function TransactionForm({ type }: TransactionFormProps) {
           </div>
 
           {/* 결제수단 (지출 모드 전용, 선택) */}
-          {type === 'expense' && (
-            <div>
-              <label htmlFor={`${idPrefix}-payment-method`} className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
-                결제수단
-              </label>
-              <select
-                id={`${idPrefix}-payment-method`}
-                value={formData.payment_method_id}
-                onChange={(e) => setFormData({ ...formData, payment_method_id: e.target.value })}
-                className={`w-full px-4 py-3 border border-[var(--input-border)] rounded-xl focus:ring-2 focus:ring-${c}-500/30 focus:border-${c}-500`}
-                disabled={loading}
-              >
-                <option value="">선택 안 함</option>
-                {paymentMethods.map((pm) => (
-                  <option key={pm.id} value={pm.id}>
-                    {pm.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
+          {type === 'expense' && (() => {
+            const selectedCat = formCategories.find((cat) => String(cat.id) === formData.category_id)
+            const isSavingsCategory = selectedCat ? (selectedCat.exclude_auto_payment || selectedCat.is_savings) : false
+            return (
+              <div>
+                <label htmlFor={`${idPrefix}-payment-method`} className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+                  결제수단
+                </label>
+                <select
+                  id={`${idPrefix}-payment-method`}
+                  value={formData.payment_method_id}
+                  onChange={(e) => setFormData({ ...formData, payment_method_id: e.target.value })}
+                  className={`w-full px-4 py-3 border border-[var(--input-border)] rounded-xl focus:ring-2 focus:ring-${c}-500/30 focus:border-${c}-500`}
+                  disabled={loading}
+                >
+                  <option value="">선택 안 함</option>
+                  {paymentMethods.map((pm) => (
+                    <option key={pm.id} value={pm.id}>
+                      {pm.name}
+                    </option>
+                  ))}
+                </select>
+                {isSavingsCategory && (
+                  <p className="mt-1.5 text-xs text-[var(--text-muted)]" data-testid="savings-payment-hint">
+                    저축성 지출은 결제수단이 자동 적용되지 않아요
+                  </p>
+                )}
+              </div>
+            )
+          })()}
 
           {/* 날짜 (기본 오늘) */}
           <div>

--- a/frontend/src/components/__tests__/ParsedItemPreviewCard.test.tsx
+++ b/frontend/src/components/__tests__/ParsedItemPreviewCard.test.tsx
@@ -163,7 +163,7 @@ describe('ParsedItemPreviewCard', () => {
 
     it('카테고리 변경 시 onUpdate를 호출한다', () => {
       const onUpdate = vi.fn()
-      const categories = [{ id: 1, name: '식비', type: 'expense' as const, description: null, sort_order: 1, is_savings: false, is_system: true, created_at: '' }]
+      const categories = [{ id: 1, name: '식비', type: 'expense' as const, description: null, sort_order: 1, is_savings: false, is_system: true, exclude_auto_payment: false, created_at: '' }]
       render(
         <ParsedItemPreviewCard
           {...defaultProps}
@@ -181,7 +181,7 @@ describe('ParsedItemPreviewCard', () => {
     it('카테고리 "분류 안 됨"으로 변경 시 null을 전달한다', () => {
       const onUpdate = vi.fn()
       const itemWithCat = { ...mockItem, category_id: 1 }
-      const categories = [{ id: 1, name: '식비', type: 'expense' as const, description: null, sort_order: 1, is_savings: false, is_system: true, created_at: '' }]
+      const categories = [{ id: 1, name: '식비', type: 'expense' as const, description: null, sort_order: 1, is_savings: false, is_system: true, exclude_auto_payment: false, created_at: '' }]
       render(
         <ParsedItemPreviewCard
           {...defaultProps}
@@ -340,8 +340,8 @@ describe('ParsedItemPreviewCard', () => {
 
   describe('결제수단 선택', () => {
     const paymentMethods = [
-      { id: 1, household_id: 1, created_by: 1, name: '삼성카드', type: 'credit_card' as const, monthly_target: null, is_default: true, is_active: true, created_at: '', updated_at: '' },
-      { id: 2, household_id: 1, created_by: 1, name: '현금', type: 'cash' as const, monthly_target: null, is_default: false, is_active: true, created_at: '', updated_at: '' },
+      { id: 1, household_id: 1, created_by: 1, name: '삼성카드', type: 'credit_card' as const, monthly_target: null, is_default: true, is_active: true, display_order: 0, created_at: '', updated_at: '' },
+      { id: 2, household_id: 1, created_by: 1, name: '현금', type: 'cash' as const, monthly_target: null, is_default: false, is_active: true, display_order: 1, created_at: '', updated_at: '' },
     ]
 
     it('결제수단 드롭다운을 표시한다', () => {

--- a/frontend/src/components/__tests__/TransactionForm.test.tsx
+++ b/frontend/src/components/__tests__/TransactionForm.test.tsx
@@ -11,7 +11,7 @@ import { MemoryRouter } from 'react-router-dom'
 import TransactionForm from '../TransactionForm'
 import { server } from '../../mocks/server'
 import { http, HttpResponse } from 'msw'
-import { mockIncomeCategoriesAll } from '../../mocks/fixtures'
+import { mockIncomeCategoriesAll, mockSavingsCategory, mockCategories } from '../../mocks/fixtures'
 
 /** navigate 모킹 */
 const mockNavigate = vi.fn()
@@ -526,6 +526,79 @@ describe('TransactionForm', () => {
         expect(screen.getByPlaceholderText('월급')).toBeInTheDocument()
       })
       expect(screen.queryByLabelText('결제수단')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('저축성 카테고리 결제수단 skip', () => {
+    it('저축성 카테고리 선택 시 결제수단이 "선택 안 함"으로 리셋된다', async () => {
+      const categoriesWithSavings = [...mockCategories, mockSavingsCategory]
+      server.use(
+        http.get('/api/categories', () => {
+          return HttpResponse.json(categoriesWithSavings)
+        })
+      )
+
+      const user = userEvent.setup()
+      renderForm('expense')
+      await user.click(screen.getByText('직접 입력'))
+
+      // 결제수단을 선택
+      await waitFor(() => {
+        expect(screen.getByLabelText('결제수단')).toBeInTheDocument()
+      })
+      const paymentSelect = screen.getByLabelText('결제수단')
+      await user.selectOptions(paymentSelect, '1') // 삼성카드
+
+      // 카테고리를 저축성으로 변경
+      const categorySelect = screen.getByLabelText('카테고리')
+      await user.selectOptions(categorySelect, String(mockSavingsCategory.id))
+
+      // 결제수단이 "선택 안 함"(빈 문자열)으로 리셋되어야 함
+      await waitFor(() => {
+        expect((paymentSelect as HTMLSelectElement).value).toBe('')
+      })
+    })
+
+    it('저축성 카테고리 선택 시 안내 텍스트가 표시된다', async () => {
+      const categoriesWithSavings = [...mockCategories, mockSavingsCategory]
+      server.use(
+        http.get('/api/categories', () => {
+          return HttpResponse.json(categoriesWithSavings)
+        })
+      )
+
+      const user = userEvent.setup()
+      renderForm('expense')
+      await user.click(screen.getByText('직접 입력'))
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('카테고리')).toBeInTheDocument()
+      })
+
+      // 저축성 카테고리 선택
+      const categorySelect = screen.getByLabelText('카테고리')
+      await user.selectOptions(categorySelect, String(mockSavingsCategory.id))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('savings-payment-hint')).toBeInTheDocument()
+        expect(screen.getByText('저축성 지출은 결제수단이 자동 적용되지 않아요')).toBeInTheDocument()
+      })
+    })
+
+    it('일반 카테고리에서는 저축성 안내가 표시되지 않는다', async () => {
+      const user = userEvent.setup()
+      renderForm('expense')
+      await user.click(screen.getByText('직접 입력'))
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('카테고리')).toBeInTheDocument()
+      })
+
+      // 식비 카테고리 선택 (일반)
+      const categorySelect = screen.getByLabelText('카테고리')
+      await user.selectOptions(categorySelect, '1')
+
+      expect(screen.queryByTestId('savings-payment-hint')).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/recurring/__tests__/RecurringModal.test.tsx
+++ b/frontend/src/components/recurring/__tests__/RecurringModal.test.tsx
@@ -25,9 +25,9 @@ const emptyForm: RecurringFormData = {
 }
 
 const mockCategories: Category[] = [
-  { id: 1, name: '식비', type: 'expense', description: null, sort_order: 1, is_savings: false, is_system: true, created_at: '2026-01-01T00:00:00Z' },
-  { id: 2, name: '급여', type: 'income', description: null, sort_order: 2, is_savings: false, is_system: true, created_at: '2026-01-01T00:00:00Z' },
-  { id: 3, name: '기타', type: 'both', description: null, sort_order: 3, is_savings: false, is_system: true, created_at: '2026-01-01T00:00:00Z' },
+  { id: 1, name: '식비', type: 'expense', description: null, sort_order: 1, is_savings: false, is_system: true, exclude_auto_payment: false, created_at: '2026-01-01T00:00:00Z' },
+  { id: 2, name: '급여', type: 'income', description: null, sort_order: 2, is_savings: false, is_system: true, exclude_auto_payment: false, created_at: '2026-01-01T00:00:00Z' },
+  { id: 3, name: '기타', type: 'both', description: null, sort_order: 3, is_savings: false, is_system: true, exclude_auto_payment: false, created_at: '2026-01-01T00:00:00Z' },
 ]
 
 const defaultProps = {

--- a/frontend/src/components/transaction/MonthlyView.tsx
+++ b/frontend/src/components/transaction/MonthlyView.tsx
@@ -11,6 +11,7 @@ import TransactionItem from '../TransactionItem'
 import PendingRecurring from '../PendingRecurring'
 import EmptyState from '../EmptyState'
 import WelcomeCard from '../WelcomeCard'
+import BotNudgeCard from '../BotNudgeCard'
 import { Search } from 'lucide-react'
 import { formatAmount } from '../../utils/format'
 import { formatDateHeader } from '../../utils/calendar'
@@ -27,6 +28,9 @@ interface MonthlyViewProps {
   totalTransactionCount: number
   isBotLinked: boolean
   onWelcomeDismiss: () => void
+  /** 봇 넛지 카드 */
+  botNudgeDismissed: boolean
+  onBotNudgeDismiss: () => void
 }
 
 export default function MonthlyView({
@@ -37,6 +41,8 @@ export default function MonthlyView({
   totalTransactionCount,
   isBotLinked,
   onWelcomeDismiss,
+  botNudgeDismissed,
+  onBotNudgeDismiss,
 }: MonthlyViewProps) {
   const { addToast } = useToast()
 
@@ -105,6 +111,12 @@ export default function MonthlyView({
           isBotLinked={isBotLinked}
           onDismiss={onWelcomeDismiss}
         />
+      )}
+
+      {/* 봇 연동 넛지 카드 — 웰컴 카드 완료 후, 봇 미연동 + 지출 1건 이상 */}
+      {welcomeDismissed && !botNudgeDismissed && !isBotLinked && !monthly.loading
+        && monthly.expenses.length > 0 && (
+        <BotNudgeCard onDismiss={onBotNudgeDismiss} />
       )}
 
       {/* 반복 거래 알림 */}

--- a/frontend/src/data/changelogs.ts
+++ b/frontend/src/data/changelogs.ts
@@ -18,6 +18,16 @@ export interface Changelog {
 
 export const changelogs: Changelog[] = [
   {
+    version: '0.12.0',
+    date: '2026-03-27',
+    title: '결제수단 UX 개선',
+    items: [
+      { tag: '개선', text: '결제수단 UX 개선 — 주 결제수단, 편집 모드, 순서 변경' },
+      { tag: '개선', text: '봇 응답에 결제수단 표시 + 변경 버튼' },
+      { tag: '개선', text: '가구 생성 시 현금/계좌이체 기본 등록' },
+    ],
+  },
+  {
     version: '0.9.2',
     date: '2026-03-24',
     title: '검색 + 온보딩 + UX 개선',

--- a/frontend/src/hooks/__tests__/useNaturalInput.test.ts
+++ b/frontend/src/hooks/__tests__/useNaturalInput.test.ts
@@ -39,10 +39,10 @@ import type { Category } from '../../types'
 // ── 테스트용 데이터 ──
 
 const mockCategories: Category[] = [
-  { id: 1, name: '식비', type: 'expense', description: null, sort_order: 1, is_savings: false, is_system: true, created_at: '2024-01-01T00:00:00Z' },
-  { id: 2, name: '교통', type: 'expense', description: null, sort_order: 2, is_savings: false, is_system: true, created_at: '2024-01-01T00:00:00Z' },
-  { id: 3, name: '급여', type: 'income', description: null, sort_order: 3, is_savings: false, is_system: true, created_at: '2024-01-01T00:00:00Z' },
-  { id: 4, name: '부업', type: 'both', description: null, sort_order: 4, is_savings: false, is_system: false, created_at: '2024-01-01T00:00:00Z' },
+  { id: 1, name: '식비', type: 'expense', description: null, sort_order: 1, is_savings: false, is_system: true, exclude_auto_payment: false, created_at: '2024-01-01T00:00:00Z' },
+  { id: 2, name: '교통', type: 'expense', description: null, sort_order: 2, is_savings: false, is_system: true, exclude_auto_payment: false, created_at: '2024-01-01T00:00:00Z' },
+  { id: 3, name: '급여', type: 'income', description: null, sort_order: 3, is_savings: false, is_system: true, exclude_auto_payment: false, created_at: '2024-01-01T00:00:00Z' },
+  { id: 4, name: '부업', type: 'both', description: null, sort_order: 4, is_savings: false, is_system: false, exclude_auto_payment: false, created_at: '2024-01-01T00:00:00Z' },
 ]
 
 function setupCategoryHandler(categories: Category[] = mockCategories) {
@@ -549,6 +549,7 @@ describe('useNaturalInput', () => {
         sort_order: 99,
         is_savings: false,
         is_system: false,
+        exclude_auto_payment: false,
         created_at: '2026-03-25T00:00:00Z',
       }
 

--- a/frontend/src/mocks/fixtures.ts
+++ b/frontend/src/mocks/fixtures.ts
@@ -18,6 +18,7 @@ export const mockCategories: Category[] = [
     sort_order: 3,
     is_savings: false,
     is_system: true,
+    exclude_auto_payment: false,
     created_at: '2024-01-01T00:00:00Z',
   },
   {
@@ -28,6 +29,7 @@ export const mockCategories: Category[] = [
     sort_order: 2,
     is_savings: false,
     is_system: true,
+    exclude_auto_payment: false,
     created_at: '2024-01-01T00:00:00Z',
   },
   {
@@ -38,6 +40,7 @@ export const mockCategories: Category[] = [
     sort_order: 1,
     is_savings: false,
     is_system: false,
+    exclude_auto_payment: false,
     created_at: '2024-01-01T00:00:00Z',
   },
 ]
@@ -184,6 +187,7 @@ export const mockIncomeCategoriesAll: Category[] = [
     sort_order: 0,
     is_savings: false,
     is_system: true,
+    exclude_auto_payment: false,
     created_at: '2024-01-01T00:00:00Z',
   },
   {
@@ -194,9 +198,25 @@ export const mockIncomeCategoriesAll: Category[] = [
     sort_order: 0,
     is_savings: false,
     is_system: false,
+    exclude_auto_payment: false,
     created_at: '2024-01-01T00:00:00Z',
   },
 ]
+
+/**
+ * 테스트용 저축성 카테고리 (exclude_auto_payment=true)
+ */
+export const mockSavingsCategory: Category = {
+  id: 10,
+  name: '저축/투자',
+  type: 'expense',
+  description: '적금, 투자 등',
+  sort_order: 0,
+  is_savings: true,
+  is_system: true,
+  exclude_auto_payment: true,
+  created_at: '2024-01-01T00:00:00Z',
+}
 
 /**
  * 테스트용 수입 목록
@@ -548,6 +568,7 @@ export const mockPaymentMethods: PaymentMethod[] = [
     monthly_target: 300000,
     is_default: true,
     is_active: true,
+    display_order: 0,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
   },
@@ -560,6 +581,7 @@ export const mockPaymentMethods: PaymentMethod[] = [
     monthly_target: null,
     is_default: false,
     is_active: true,
+    display_order: 1,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
   },
@@ -572,6 +594,7 @@ export const mockPaymentMethods: PaymentMethod[] = [
     monthly_target: 500000,
     is_default: false,
     is_active: true,
+    display_order: 2,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
   },

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -598,6 +598,18 @@ export const handlers = [
   }),
 
   /**
+   * PUT /api/payment-methods/reorder - 결제수단 순서 변경
+   */
+  http.put(`${BASE_URL}/payment-methods/reorder`, async ({ request }) => {
+    const body = (await request.json()) as { ids: number[] }
+    const reordered = body.ids.map((id, index) => {
+      const method = mockPaymentMethods.find((m) => m.id === id)
+      return method ? { ...method, display_order: index } : null
+    }).filter(Boolean)
+    return HttpResponse.json(reordered)
+  }),
+
+  /**
    * PUT /api/payment-methods/:id - 결제수단 수정
    */
   http.put(`${BASE_URL}/payment-methods/:id`, async ({ params, request }) => {

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -1,12 +1,12 @@
 /**
  * @file PaymentMethodManager.tsx
- * @description 결제수단 관리 페이지 (#305)
- * 결제수단 CRUD + 월 실적 프로그레스 바를 제공한다.
+ * @description 결제수단 관리 페이지 (#305, #477)
+ * 주 결제수단 드롭다운 + 일반/편집 모드 + 실적 넛지를 제공한다.
  */
 
 import { useState, useEffect, useCallback } from 'react'
 import { Link } from 'react-router-dom'
-import { ArrowLeft, CreditCard, Plus, Trash2, Star } from 'lucide-react'
+import { ArrowLeft, CreditCard, Plus, Trash2, Pencil, ChevronUp, ChevronDown } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { paymentMethodApi } from '../api/paymentMethods'
@@ -40,14 +40,22 @@ export default function PaymentMethodManager() {
   const [methods, setMethods] = useState<PaymentMethod[]>([])
   const [usageMap, setUsageMap] = useState<Map<number, PaymentMethodUsage>>(new Map())
   const [loading, setLoading] = useState(true)
+  const [editMode, setEditMode] = useState(false)
 
   // 추가 폼 상태
   const [showForm, setShowForm] = useState(false)
   const [formName, setFormName] = useState('')
   const [formType, setFormType] = useState<PaymentMethodType>('credit_card')
   const [formTarget, setFormTarget] = useState('')
-  const [formDefault, setFormDefault] = useState(false)
+  const [showDetailSettings, setShowDetailSettings] = useState(false)
   const [saving, setSaving] = useState(false)
+
+  // 편집 폼 상태
+  const [editingMethod, setEditingMethod] = useState<PaymentMethod | null>(null)
+  const [editName, setEditName] = useState('')
+  const [editType, setEditType] = useState<PaymentMethodType>('credit_card')
+  const [editTarget, setEditTarget] = useState('')
+  const [editSaving, setEditSaving] = useState(false)
 
   const fetchData = useCallback(async () => {
     if (!activeHouseholdId) return
@@ -57,7 +65,9 @@ export default function PaymentMethodManager() {
         paymentMethodApi.getAll(activeHouseholdId),
         paymentMethodApi.getMonthlyUsage(getCurrentMonth(), activeHouseholdId),
       ])
-      setMethods(methodsRes.data)
+      // display_order 기준 정렬
+      const sorted = [...methodsRes.data].sort((a, b) => a.display_order - b.display_order)
+      setMethods(sorted)
       const map = new Map<number, PaymentMethodUsage>()
       usageRes.data.forEach((u) => map.set(u.id, u))
       setUsageMap(map)
@@ -72,6 +82,40 @@ export default function PaymentMethodManager() {
     fetchData()
   }, [fetchData])
 
+  /** 주 결제수단 드롭다운 변경 */
+  const handlePrimaryChange = useCallback(async (newDefaultId: string) => {
+    const currentDefault = methods.find((m) => m.is_default)
+
+    // 현재 기본 해제
+    if (currentDefault) {
+      try {
+        await paymentMethodApi.update(currentDefault.id, { is_default: false })
+      } catch {
+        addToast('error', '주 결제수단 변경에 실패했습니다')
+        return
+      }
+    }
+
+    // "없음" 선택
+    if (!newDefaultId) {
+      addToast('info', '주 결제수단을 해제했어요')
+      await fetchData()
+      return
+    }
+
+    // 새 기본 설정
+    const target = methods.find((m) => m.id === Number(newDefaultId))
+    if (!target) return
+
+    try {
+      await paymentMethodApi.update(target.id, { is_default: true })
+      addToast('success', `${target.name}을 주 결제수단으로 설정했어요 ✅`)
+      await fetchData()
+    } catch {
+      addToast('error', '주 결제수단 변경에 실패했습니다')
+    }
+  }, [methods, fetchData, addToast])
+
   /** 결제수단 추가 */
   const handleCreate = useCallback(async () => {
     if (!formName.trim()) {
@@ -84,37 +128,21 @@ export default function PaymentMethodManager() {
         name: formName.trim(),
         type: formType,
         monthly_target: formTarget ? Number(formTarget) : null,
-        is_default: formDefault,
+        is_default: false,
       })
       addToast('success', `"${formName.trim()}" 결제수단이 추가되었습니다`)
       setShowForm(false)
       setFormName('')
       setFormType('credit_card')
       setFormTarget('')
-      setFormDefault(false)
+      setShowDetailSettings(false)
       await fetchData()
     } catch {
       addToast('error', '결제수단 추가에 실패했습니다')
     } finally {
       setSaving(false)
     }
-  }, [formName, formType, formTarget, formDefault, fetchData, addToast])
-
-  /** 기본 결제수단 설정 */
-  const handleToggleDefault = useCallback(async (method: PaymentMethod) => {
-    try {
-      const newDefault = !method.is_default
-      await paymentMethodApi.update(method.id, { is_default: newDefault })
-      if (newDefault) {
-        addToast('success', `이제부터 결제수단을 따로 말하지 않으면 ${method.name}(으)로 자동 저장됩니다`)
-      } else {
-        addToast('info', `${method.name} 기본 결제수단이 해제되었습니다`)
-      }
-      await fetchData()
-    } catch {
-      addToast('error', '기본 결제수단 변경에 실패했습니다')
-    }
-  }, [fetchData, addToast])
+  }, [formName, formType, formTarget, fetchData, addToast])
 
   /** 결제수단 삭제 */
   const handleDelete = useCallback(async (method: PaymentMethod) => {
@@ -126,6 +154,53 @@ export default function PaymentMethodManager() {
       addToast('error', '결제수단 삭제에 실패했습니다')
     }
   }, [fetchData, addToast])
+
+  /** 순서 변경 (위/아래) */
+  const handleReorder = useCallback(async (index: number, direction: 'up' | 'down') => {
+    const newMethods = [...methods]
+    const swapIndex = direction === 'up' ? index - 1 : index + 1
+    if (swapIndex < 0 || swapIndex >= newMethods.length) return
+
+    ;[newMethods[index], newMethods[swapIndex]] = [newMethods[swapIndex], newMethods[index]]
+    setMethods(newMethods)
+
+    try {
+      await paymentMethodApi.reorder(newMethods.map((m) => m.id))
+    } catch {
+      addToast('error', '순서 변경에 실패했습니다')
+      await fetchData()
+    }
+  }, [methods, fetchData, addToast])
+
+  /** 편집 시작 */
+  const handleStartEdit = useCallback((method: PaymentMethod) => {
+    setEditingMethod(method)
+    setEditName(method.name)
+    setEditType(method.type)
+    setEditTarget(method.monthly_target ? String(method.monthly_target) : '')
+  }, [])
+
+  /** 편집 저장 */
+  const handleSaveEdit = useCallback(async () => {
+    if (!editingMethod || !editName.trim()) return
+    setEditSaving(true)
+    try {
+      await paymentMethodApi.update(editingMethod.id, {
+        name: editName.trim(),
+        type: editType,
+        monthly_target: editTarget ? Number(editTarget) : null,
+      })
+      addToast('success', `"${editName.trim()}" 결제수단이 수정되었습니다`)
+      setEditingMethod(null)
+      await fetchData()
+    } catch {
+      addToast('error', '결제수단 수정에 실패했습니다')
+    } finally {
+      setEditSaving(false)
+    }
+  }, [editingMethod, editName, editType, editTarget, fetchData, addToast])
+
+  const defaultMethodId = methods.find((m) => m.is_default)?.id ?? ''
 
   return (
     <div className="space-y-4 max-w-2xl">
@@ -144,14 +219,226 @@ export default function PaymentMethodManager() {
             <h1 className="text-lg font-semibold text-[var(--text-primary)]">결제수단</h1>
           </div>
         </div>
-        <button
-          onClick={() => setShowForm(true)}
-          className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
-        >
-          <Plus className="w-4 h-4" />
-          추가
-        </button>
+        {!loading && methods.length > 0 && (
+          <button
+            onClick={() => setEditMode(!editMode)}
+            className="text-sm font-medium text-grape-600 hover:text-grape-700 transition-colors"
+          >
+            {editMode ? '완료' : '편집'}
+          </button>
+        )}
       </div>
+
+      {/* 로딩 */}
+      {loading && (
+        <div className="space-y-3">
+          {[...Array(2)].map((_, i) => (
+            <div key={i} className="bg-[var(--surface-card)] rounded-2xl p-4 animate-pulse">
+              <div className="h-4 w-24 bg-warm-200 rounded mb-2" />
+              <div className="h-3 w-16 bg-warm-200 rounded" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* 빈 상태 */}
+      {!loading && methods.length === 0 && (
+        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-8 text-center">
+          <CreditCard className="w-10 h-10 text-[var(--text-muted)] mx-auto mb-3" />
+          <p className="text-sm font-medium text-[var(--text-secondary)]">결제수단을 추가하면 지출에 태깅할 수 있어요</p>
+        </div>
+      )}
+
+      {/* 주 결제수단 + 목록 */}
+      {!loading && methods.length > 0 && !editMode && (
+        <div className="space-y-4">
+          {/* 주 결제수단 드롭다운 */}
+          <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-5">
+            <label htmlFor="primary-payment" className="block text-sm font-semibold text-[var(--text-primary)] mb-2">
+              주 결제수단
+            </label>
+            <select
+              id="primary-payment"
+              value={defaultMethodId}
+              onChange={(e) => handlePrimaryChange(e.target.value)}
+              className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+            >
+              <option value="">없음</option>
+              {methods.map((m) => (
+                <option key={m.id} value={m.id}>{m.name}</option>
+              ))}
+            </select>
+            {defaultMethodId && (
+              <p className="mt-2 text-xs text-[var(--text-muted)]">
+                입력 시 자동으로 이 결제수단이 선택돼요
+              </p>
+            )}
+          </div>
+
+          {/* 내 결제수단 목록 — 일반 모드 */}
+          <div>
+            <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-3">내 결제수단</h2>
+            <div className="space-y-3">
+              {methods.map((method) => {
+                const usage = usageMap.get(method.id)
+                const hasTarget = method.monthly_target && method.monthly_target > 0
+                const remaining = hasTarget && usage ? method.monthly_target! - usage.spent_amount : null
+                const isAchieved = hasTarget && usage && (usage.usage_percentage ?? 0) >= 100
+
+                return (
+                  <div
+                    key={method.id}
+                    data-testid={`payment-method-${method.id}`}
+                    className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4"
+                  >
+                    <div className="flex items-center justify-between mb-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-semibold text-[var(--text-primary)]">{method.name}</span>
+                        <span className="text-xs text-[var(--text-muted)]">{TYPE_LABELS[method.type]}</span>
+                      </div>
+                    </div>
+
+                    {/* 실적 프로그레스 바: monthly_target이 있는 경우만 */}
+                    {hasTarget && usage && (
+                      <div className="mt-2" data-testid={`usage-bar-${method.id}`}>
+                        <div className="flex justify-between items-center mb-1">
+                          <span className="text-xs text-[var(--text-secondary)]">
+                            {formatAmount(usage.spent_amount)} / {formatAmount(method.monthly_target!)}
+                          </span>
+                          <span className={`text-xs ${isAchieved ? 'text-leaf-600 font-medium' : 'text-[var(--text-muted)]'}`}>
+                            {isAchieved ? '실적 달성' : `잔여 ${formatAmount(usage.remaining ?? 0)}`}
+                          </span>
+                        </div>
+                        <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
+                          <div
+                            className={`h-1.5 rounded-full transition-all ${
+                              isAchieved
+                                ? 'bg-leaf-500'
+                                : (usage.usage_percentage ?? 0) >= 80
+                                  ? 'bg-grape-500'
+                                  : 'bg-grape-400'
+                            }`}
+                            style={{ width: `${Math.min(usage.usage_percentage ?? 0, 100)}%` }}
+                          />
+                        </div>
+                        {/* 실적 넛지 */}
+                        {!isAchieved && remaining !== null && remaining > 0 && (
+                          <p className="text-xs text-grape-600 mt-1" data-testid={`nudge-${method.id}`}>
+                            실적까지 {formatAmount(remaining)} 남음
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 편집 모드 */}
+      {!loading && methods.length > 0 && editMode && (
+        <div className="space-y-3">
+          {methods.map((method, index) => (
+            <div
+              key={method.id}
+              data-testid={`payment-method-${method.id}`}
+              className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4"
+            >
+              {/* 편집 중인 항목 */}
+              {editingMethod?.id === method.id ? (
+                <div className="space-y-3">
+                  <input
+                    type="text"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                    placeholder="결제수단 이름"
+                  />
+                  <select
+                    value={editType}
+                    onChange={(e) => setEditType(e.target.value as PaymentMethodType)}
+                    className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm"
+                  >
+                    {TYPE_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                  </select>
+                  <div className="relative">
+                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] text-sm">₩</span>
+                    <input
+                      type="number"
+                      value={editTarget}
+                      onChange={(e) => setEditTarget(e.target.value)}
+                      placeholder="월 실적 목표 (선택)"
+                      min="0"
+                      className="w-full pl-7 pr-3 py-2 border border-[var(--input-border)] rounded-xl text-sm"
+                    />
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setEditingMethod(null)}
+                      className="flex-1 px-3 py-2 text-sm text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-xl"
+                    >
+                      취소
+                    </button>
+                    <button
+                      onClick={handleSaveEdit}
+                      disabled={editSaving || !editName.trim()}
+                      className="flex-1 px-3 py-2 text-sm font-medium text-white bg-grape-600 rounded-xl hover:bg-grape-700 disabled:opacity-50"
+                    >
+                      {editSaving ? '저장 중...' : '저장'}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    {/* 순서 변경 버튼 */}
+                    <div className="flex flex-col gap-0.5">
+                      <button
+                        onClick={() => handleReorder(index, 'up')}
+                        disabled={index === 0}
+                        aria-label="위로"
+                        className="p-0.5 rounded hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-30"
+                      >
+                        <ChevronUp className="w-4 h-4 text-[var(--text-muted)]" />
+                      </button>
+                      <button
+                        onClick={() => handleReorder(index, 'down')}
+                        disabled={index === methods.length - 1}
+                        aria-label="아래로"
+                        className="p-0.5 rounded hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-30"
+                      >
+                        <ChevronDown className="w-4 h-4 text-[var(--text-muted)]" />
+                      </button>
+                    </div>
+                    <span className="text-sm font-semibold text-[var(--text-primary)]">{method.name}</span>
+                    <span className="text-xs text-[var(--text-muted)]">{TYPE_LABELS[method.type]}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <button
+                      onClick={() => handleStartEdit(method)}
+                      aria-label="편집"
+                      className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-grape-600"
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => handleDelete(method)}
+                      aria-label="삭제"
+                      className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-rose-500"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* 추가 폼 */}
       {showForm && (
@@ -159,7 +446,7 @@ export default function PaymentMethodManager() {
           <h2 className="text-sm font-semibold text-[var(--text-primary)]">새 결제수단</h2>
 
           <div>
-            <label htmlFor="pm-name" className="block text-xs text-[var(--text-tertiary)] mb-1">이름</label>
+            <label htmlFor="pm-name" className="block text-xs text-[var(--text-tertiary)] mb-1">이름 <span className="text-rose-500">*</span></label>
             <input
               id="pm-name"
               type="text"
@@ -170,50 +457,52 @@ export default function PaymentMethodManager() {
             />
           </div>
 
-          <div>
-            <label htmlFor="pm-type" className="block text-xs text-[var(--text-tertiary)] mb-1">유형</label>
-            <select
-              id="pm-type"
-              value={formType}
-              onChange={(e) => setFormType(e.target.value as PaymentMethodType)}
-              className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-            >
-              {TYPE_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
-          </div>
+          {/* 상세 설정 (접힘) */}
+          <button
+            type="button"
+            onClick={() => setShowDetailSettings(!showDetailSettings)}
+            className="text-sm text-grape-600 hover:text-grape-700 font-medium"
+          >
+            {showDetailSettings ? '상세 설정 접기' : '상세 설정'}
+          </button>
 
-          <div>
-            <label htmlFor="pm-target" className="block text-xs text-[var(--text-tertiary)] mb-1">월 실적 목표 (선택)</label>
-            <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] text-sm">₩</span>
-              <input
-                id="pm-target"
-                type="number"
-                value={formTarget}
-                onChange={(e) => setFormTarget(e.target.value)}
-                placeholder="0"
-                min="0"
-                className="w-full pl-7 pr-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-              />
-            </div>
-          </div>
+          {showDetailSettings && (
+            <>
+              <div>
+                <label htmlFor="pm-type" className="block text-xs text-[var(--text-tertiary)] mb-1">유형</label>
+                <select
+                  id="pm-type"
+                  value={formType}
+                  onChange={(e) => setFormType(e.target.value as PaymentMethodType)}
+                  className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                >
+                  {TYPE_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
 
-          <label htmlFor="pm-default" className="flex items-center gap-2 cursor-pointer select-none">
-            <input
-              id="pm-default"
-              type="checkbox"
-              checked={formDefault}
-              onChange={(e) => setFormDefault(e.target.checked)}
-              className="w-4 h-4 rounded border-[var(--input-border)] text-grape-600 focus:ring-grape-500"
-            />
-            <span className="text-sm text-[var(--text-secondary)]">기본 결제수단으로 설정</span>
-          </label>
+              <div>
+                <label htmlFor="pm-target" className="block text-xs text-[var(--text-tertiary)] mb-1">월 실적 목표</label>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] text-sm">₩</span>
+                  <input
+                    id="pm-target"
+                    type="number"
+                    value={formTarget}
+                    onChange={(e) => setFormTarget(e.target.value)}
+                    placeholder="0"
+                    min="0"
+                    className="w-full pl-7 pr-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                  />
+                </div>
+              </div>
+            </>
+          )}
 
           <div className="flex gap-3">
             <button
-              onClick={() => { setShowForm(false); setFormName(''); setFormTarget(''); setFormDefault(false) }}
+              onClick={() => { setShowForm(false); setFormName(''); setFormTarget(''); setShowDetailSettings(false) }}
               className="flex-1 px-4 py-2.5 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-xl hover:bg-[var(--surface-hover)] transition-colors"
             >
               취소
@@ -229,98 +518,15 @@ export default function PaymentMethodManager() {
         </div>
       )}
 
-      {/* 로딩 */}
-      {loading && (
-        <div className="space-y-3">
-          {[...Array(3)].map((_, i) => (
-            <div key={i} className="bg-[var(--surface-card)] rounded-2xl p-4 animate-pulse">
-              <div className="h-4 w-24 bg-warm-200 rounded mb-2" />
-              <div className="h-3 w-16 bg-warm-200 rounded" />
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* 빈 상태 */}
-      {!loading && methods.length === 0 && (
-        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-8 text-center">
-          <CreditCard className="w-10 h-10 text-[var(--text-muted)] mx-auto mb-3" />
-          <p className="text-sm font-medium text-[var(--text-secondary)]">등록된 결제수단이 없습니다</p>
-          <p className="text-xs text-[var(--text-muted)] mt-1">카드나 현금 등 결제수단을 추가하면 지출별로 태깅할 수 있습니다</p>
-        </div>
-      )}
-
-      {/* 결제수단 목록 */}
-      {!loading && methods.length > 0 && (
-        <div className="space-y-3">
-          {methods.map((method) => {
-            const usage = usageMap.get(method.id)
-            return (
-              <div
-                key={method.id}
-                data-testid={`payment-method-${method.id}`}
-                className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4"
-              >
-                <div className="flex items-center justify-between mb-1">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-semibold text-[var(--text-primary)]">{method.name}</span>
-                    <span className="text-xs text-[var(--text-muted)]">{TYPE_LABELS[method.type]}</span>
-                    {method.is_default && (
-                      <span className="text-xs px-1.5 py-0.5 bg-grape-100 text-grape-600 rounded-full font-medium">기본</span>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <button
-                      onClick={() => handleToggleDefault(method)}
-                      aria-label={method.is_default ? '기본 해제' : '기본으로 설정'}
-                      className={`p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors ${
-                        method.is_default ? 'text-grape-600' : 'text-[var(--text-muted)] hover:text-grape-600'
-                      }`}
-                    >
-                      <Star className="w-4 h-4" fill={method.is_default ? 'currentColor' : 'none'} />
-                    </button>
-                    <button
-                      onClick={() => handleDelete(method)}
-                      aria-label="삭제"
-                      className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-rose-500"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  </div>
-                </div>
-
-                {/* 실적 프로그레스 바: monthly_target이 있는 경우만 */}
-                {method.monthly_target && usage && (
-                  <div className="mt-2" data-testid={`usage-bar-${method.id}`}>
-                    <div className="flex justify-between items-center mb-1">
-                      <span className="text-xs text-[var(--text-secondary)]">
-                        {formatAmount(usage.spent_amount)} / {formatAmount(method.monthly_target)}
-                      </span>
-                      <span className={`text-xs ${(usage.usage_percentage ?? 0) >= 100 ? 'text-leaf-600 font-medium' : 'text-[var(--text-muted)]'}`}>
-                        {(usage.usage_percentage ?? 0) >= 100 ? '✅ 실적 달성' : `잔여 ${formatAmount(usage.remaining ?? 0)}`}
-                      </span>
-                    </div>
-                    <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
-                      <div
-                        className={`h-1.5 rounded-full transition-all ${
-                          (usage.usage_percentage ?? 0) >= 100
-                            ? 'bg-leaf-500'
-                            : (usage.usage_percentage ?? 0) >= 80
-                              ? 'bg-grape-500'
-                              : 'bg-grape-400'
-                        }`}
-                        style={{ width: `${Math.min(usage.usage_percentage ?? 0, 100)}%` }}
-                      />
-                    </div>
-                    <p className="text-xs text-[var(--text-muted)] mt-0.5 text-right">
-                      {(usage.usage_percentage ?? 0).toFixed(1)}%
-                    </p>
-                  </div>
-                )}
-              </div>
-            )
-          })}
-        </div>
+      {/* 추가 버튼 (하단) */}
+      {!loading && !showForm && (
+        <button
+          onClick={() => setShowForm(true)}
+          className="w-full flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium text-grape-600 bg-[var(--surface-card)] border border-dashed border-grape-300 rounded-2xl hover:bg-grape-50 transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          결제수단 추가
+        </button>
       )}
     </div>
   )

--- a/frontend/src/pages/TransactionList.tsx
+++ b/frontend/src/pages/TransactionList.tsx
@@ -37,6 +37,12 @@ export default function TransactionList() {
   )
   const [totalTransactionCount, setTotalTransactionCount] = useState(0)
 
+  // 봇 넛지 카드 상태
+  const isBotLinked = !!user?.is_telegram_linked || !!user?.is_kakao_linked
+  const [botNudgeDismissed, setBotNudgeDismissed] = useState(() =>
+    localStorage.getItem('podo-bot-nudge-dismissed') === 'true'
+  )
+
   // 전체 기간 거래 건수 조회 (웰컴 카드 단계 판정용)
   useEffect(() => {
     if (welcomeDismissed || !activeHouseholdId) return
@@ -51,6 +57,11 @@ export default function TransactionList() {
   const handleWelcomeDismiss = useCallback(() => {
     setWelcomeDismissed(true)
     localStorage.setItem('podo-welcome-dismissed', 'true')
+  }, [])
+
+  const handleBotNudgeDismiss = useCallback(() => {
+    setBotNudgeDismissed(true)
+    localStorage.setItem('podo-bot-nudge-dismissed', 'true')
   }, [])
 
   // 웰컴 카드 단계 갱신 — 거래 추가 후 돌아왔을 때 반영
@@ -169,8 +180,10 @@ export default function TransactionList() {
           onEnterSearchMode={search.enterSearchMode}
           welcomeDismissed={welcomeDismissed}
           totalTransactionCount={totalTransactionCount}
-          isBotLinked={!!user?.is_telegram_linked || !!user?.is_kakao_linked}
+          isBotLinked={isBotLinked}
           onWelcomeDismiss={handleWelcomeDismiss}
+          botNudgeDismissed={botNudgeDismissed}
+          onBotNudgeDismiss={handleBotNudgeDismiss}
         />
       )}
 

--- a/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
+++ b/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @file PaymentMethodManager.test.tsx
- * @description 결제수단 관리 페이지 테스트 (#305)
- * 목록 표시, 추가, 기본 설정, 삭제, 실적 프로그레스 바를 테스트한다.
+ * @description 결제수단 관리 페이지 테스트 (#305, #477)
+ * 주 결제수단 드롭다운, 편집 모드, 실적 넛지, 추가 폼 접힘 등을 테스트한다.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -50,28 +50,181 @@ describe('PaymentMethodManager', () => {
       expect(screen.getByTestId('payment-method-3')).toBeInTheDocument()
     })
 
-    it('기본 결제수단에 기본 배지를 표시한다', async () => {
+    it('monthly_target이 있는 결제수단에 실적 프로그레스 바를 표시한다', async () => {
       renderPage()
       await waitFor(() => {
-        expect(screen.getByText('삼성카드')).toBeInTheDocument()
+        expect(screen.getByTestId('usage-bar-1')).toBeInTheDocument()
       })
-      expect(screen.getByText('기본')).toBeInTheDocument()
     })
 
     it('결제수단 추가 버튼을 표시한다', async () => {
       renderPage()
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: '추가' })).toBeInTheDocument()
+        expect(screen.getByText('결제수단 추가')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('주 결제수단 드롭다운', () => {
+    it('주 결제수단 드롭다운이 표시된다', async () => {
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByLabelText('주 결제수단')).toBeInTheDocument()
       })
     })
 
-    it('monthly_target이 있는 결제수단에 실적 프로그레스 바를 표시한다', async () => {
+    it('현재 기본 결제수단이 드롭다운에 선택되어 있다', async () => {
       renderPage()
       await waitFor(() => {
-        expect(screen.getByText('삼성카드')).toBeInTheDocument()
+        const dropdown = screen.getByLabelText('주 결제수단') as HTMLSelectElement
+        // 삼성카드가 is_default=true이므로 선택되어 있어야 함
+        expect(dropdown.value).toBe('1')
       })
-      // 삼성카드의 프로그레스 바 (73.3%)
-      expect(screen.getByTestId('usage-bar-1')).toBeInTheDocument()
+    })
+
+    it('주 결제수단 변경 시 토스트를 표시한다', async () => {
+      const user = userEvent.setup()
+
+      // 현재 기본 해제 + 새 기본 설정 응답
+      server.use(
+        http.put('/api/payment-methods/:id', async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>
+          const id = Number(request.url.split('/').pop())
+          const method = mockPaymentMethods.find((m) => m.id === id)
+          return HttpResponse.json({
+            ...method,
+            ...body,
+            updated_at: new Date().toISOString(),
+          })
+        })
+      )
+
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByLabelText('주 결제수단')).toBeInTheDocument()
+      })
+
+      const dropdown = screen.getByLabelText('주 결제수단')
+      // 국민카드(id=3)로 변경
+      await user.selectOptions(dropdown, '3')
+
+      await waitFor(() => {
+        expect(mockAddToast).toHaveBeenCalledWith(
+          'success',
+          expect.stringContaining('국민카드')
+        )
+      })
+    })
+
+    it('주 결제수단 "없음" 선택 시 해제 토스트를 표시한다', async () => {
+      const user = userEvent.setup()
+
+      server.use(
+        http.put('/api/payment-methods/:id', async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>
+          const id = Number(request.url.split('/').pop())
+          const method = mockPaymentMethods.find((m) => m.id === id)
+          return HttpResponse.json({
+            ...method,
+            ...body,
+            updated_at: new Date().toISOString(),
+          })
+        })
+      )
+
+      renderPage()
+      await waitFor(() => {
+        expect(screen.getByLabelText('주 결제수단')).toBeInTheDocument()
+      })
+
+      const dropdown = screen.getByLabelText('주 결제수단')
+      await user.selectOptions(dropdown, '')
+
+      await waitFor(() => {
+        expect(mockAddToast).toHaveBeenCalledWith('info', '주 결제수단을 해제했어요')
+      })
+    })
+
+    it('주 결제수단 설정 시 안내 텍스트가 표시된다', async () => {
+      renderPage()
+      await waitFor(() => {
+        // 삼성카드가 기본이므로 안내 텍스트 표시
+        expect(screen.getByText('입력 시 자동으로 이 결제수단이 선택돼요')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('편집 모드', () => {
+    it('편집 버튼 클릭 시 편집 모드 진입한다', async () => {
+      const user = userEvent.setup()
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByText('편집')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('편집'))
+
+      // 편집 모드에서 순서 변경 + 편집 + 삭제 버튼이 표시
+      await waitFor(() => {
+        expect(screen.getByText('완료')).toBeInTheDocument()
+      })
+      expect(screen.getAllByRole('button', { name: '위로' }).length).toBeGreaterThan(0)
+      expect(screen.getAllByRole('button', { name: '아래로' }).length).toBeGreaterThan(0)
+      expect(screen.getAllByRole('button', { name: '편집' }).length).toBeGreaterThan(0)
+      expect(screen.getAllByRole('button', { name: '삭제' }).length).toBeGreaterThan(0)
+    })
+
+    it('일반 모드에서 편집/삭제 버튼이 숨겨진다', async () => {
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('payment-method-1')).toBeInTheDocument()
+      })
+
+      // 일반 모드에서는 편집/삭제/순서 버튼이 없어야 함
+      expect(screen.queryByRole('button', { name: '삭제' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: '위로' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: '아래로' })).not.toBeInTheDocument()
+    })
+
+    it('편집 모드에서 삭제 버튼 클릭 시 결제수단을 삭제한다', async () => {
+      const user = userEvent.setup()
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByText('편집')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('편집'))
+
+      await waitFor(() => {
+        expect(screen.getByText('완료')).toBeInTheDocument()
+      })
+
+      const cashItem = screen.getByTestId('payment-method-2')
+      const deleteBtn = within(cashItem).getByRole('button', { name: '삭제' })
+      await user.click(deleteBtn)
+
+      await waitFor(() => {
+        expect(mockAddToast).toHaveBeenCalledWith('success', expect.stringContaining('삭제'))
+      })
+    })
+  })
+
+  describe('실적 넛지', () => {
+    it('실적까지 남은 금액 넛지를 표시한다', async () => {
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('payment-method-1')).toBeInTheDocument()
+      })
+
+      // 삼성카드: target 300000, spent 220000, 남은 80000
+      const nudge = screen.getByTestId('nudge-1')
+      expect(nudge).toBeInTheDocument()
+      expect(nudge.textContent).toContain('실적까지')
+      expect(nudge.textContent).toContain('남음')
     })
   })
 
@@ -81,12 +234,11 @@ describe('PaymentMethodManager', () => {
       renderPage()
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: '추가' })).toBeInTheDocument()
+        expect(screen.getByText('결제수단 추가')).toBeInTheDocument()
       })
 
-      await user.click(screen.getByRole('button', { name: '추가' }))
+      await user.click(screen.getByText('결제수단 추가'))
 
-      // 폼 필드 확인
       const nameInput = screen.getByPlaceholderText('결제수단 이름')
       expect(nameInput).toBeInTheDocument()
 
@@ -97,61 +249,29 @@ describe('PaymentMethodManager', () => {
         expect(mockAddToast).toHaveBeenCalledWith('success', expect.stringContaining('추가'))
       })
     })
-  })
 
-  describe('기본 결제수단 설정', () => {
-    it('기본 결제수단 설정 시 안내 토스트를 표시한다', async () => {
-      const user = userEvent.setup()
-
-      // 기본 설정 변경 시 is_default=true로 응답
-      server.use(
-        http.put(`/api/payment-methods/:id`, async ({ request }) => {
-          const body = (await request.json()) as Record<string, unknown>
-          return HttpResponse.json({
-            ...mockPaymentMethods[1],
-            ...body,
-            is_default: true,
-            updated_at: new Date().toISOString(),
-          })
-        })
-      )
-
-      renderPage()
-
-      await waitFor(() => {
-        expect(screen.getByTestId('payment-method-2')).toBeInTheDocument()
-      })
-
-      // 현금 항목의 기본 설정 버튼 클릭
-      const cashItem = screen.getByTestId('payment-method-2')
-      const setDefaultBtn = within(cashItem).getByRole('button', { name: '기본으로 설정' })
-      await user.click(setDefaultBtn)
-
-      await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith(
-          'success',
-          expect.stringContaining('현금')
-        )
-      })
-    })
-  })
-
-  describe('결제수단 삭제', () => {
-    it('삭제 버튼 클릭 시 결제수단을 삭제한다', async () => {
+    it('추가 폼에서 이름만 필수이고 타입/목표는 접힘 상태이다', async () => {
       const user = userEvent.setup()
       renderPage()
 
       await waitFor(() => {
-        expect(screen.getByTestId('payment-method-2')).toBeInTheDocument()
+        expect(screen.getByText('결제수단 추가')).toBeInTheDocument()
       })
 
-      const cashItem = screen.getByTestId('payment-method-2')
-      const deleteBtn = within(cashItem).getByRole('button', { name: '삭제' })
-      await user.click(deleteBtn)
+      await user.click(screen.getByText('결제수단 추가'))
 
-      await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', expect.stringContaining('삭제'))
-      })
+      // 이름 필드는 보이고
+      expect(screen.getByPlaceholderText('결제수단 이름')).toBeInTheDocument()
+
+      // 유형/목표 필드는 접힘 (안 보임)
+      expect(screen.queryByLabelText('유형')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('월 실적 목표')).not.toBeInTheDocument()
+
+      // 상세 설정 클릭 시 펼침
+      await user.click(screen.getByText('상세 설정'))
+
+      expect(screen.getByLabelText('유형')).toBeInTheDocument()
+      expect(screen.getByLabelText('월 실적 목표')).toBeInTheDocument()
     })
   })
 
@@ -169,7 +289,7 @@ describe('PaymentMethodManager', () => {
       renderPage()
 
       await waitFor(() => {
-        expect(screen.getByText('등록된 결제수단이 없습니다')).toBeInTheDocument()
+        expect(screen.getByText('결제수단을 추가하면 지출에 태깅할 수 있어요')).toBeInTheDocument()
       })
     })
   })

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -144,6 +144,7 @@ export interface Category {
   sort_order: number
   is_savings: boolean
   is_system: boolean
+  exclude_auto_payment: boolean
   created_at: string
 }
 
@@ -539,6 +540,7 @@ export interface PaymentMethod {
   monthly_target: number | null
   is_default: boolean
   is_active: boolean
+  display_order: number
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
## Summary
기획서 기반 결제수단 경험 전면 개선 (`docs/specs/2026-03-27-payment-method-ux.md`)

### BE
- Category에 `exclude_auto_payment` 플래그 + 시스템 카테고리 시드
- PaymentMethod에 `display_order` + 순서 변경 API (`POST /reorder`)
- 저축성 카테고리 지출 시 기본 결제수단 자동 적용 skip
- 가구 생성 시 현금/계좌이체 기본 등록
- 봇(카카오/텔레그램) 응답에 결제수단 표시 + 변경 버튼

### FE
- 결제수단 관리 페이지 리디자인 — 주 결제수단 드롭다운 + 편집 모드 + ↑↓ 순서
- 저축성 카테고리 선택 시 결제수단 자동 리셋 + 안내 텍스트
- 봇 연동 넛지 카드 (첫 지출 후 표시)

## Test plan
- [x] BE 1647 passed (9개 추가)
- [x] FE 1315 passed (18개 추가)
- [x] mypy 통과
- [ ] 주 결제수단 드롭다운 설정/해제 확인
- [ ] 편집 모드 순서 변경 확인
- [ ] 봇 결제수단 표시 + 변경 버튼 확인
- [ ] 저축성 카테고리 결제수단 skip 확인

close #477 close #480 close #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)