### PR TITLE
feat: 토스트 알림 전면 리디자인

### DIFF
--- a/frontend/src/components/RegisterRecurringModal.tsx
+++ b/frontend/src/components/RegisterRecurringModal.tsx
@@ -7,6 +7,7 @@
 import { useState } from 'react'
 import { X } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { recurringApi } from '../api/recurring'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import type { Category, RecurringTransactionCreate } from '../types'
@@ -85,10 +86,10 @@ export default function RegisterRecurringModal({
         payload.interval = Number(formData.interval)
       }
       await recurringApi.create(payload)
-      addToast('success', '반복 거래로 등록되었습니다')
+      addToast('success', TOAST.RECURRING_ADDED)
       onSuccess()
     } catch {
-      addToast('error', '등록에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setSubmitting(false)
     }

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,8 +1,8 @@
 /**
  * @file Toast.tsx
  * @description 토스트 알림 컴포넌트
- * 성공, 에러, 경고, 정보 4가지 타입의 알림을 표시하며
- * 자동 사라짐, 수동 닫기, 애니메이션 기능을 제공한다.
+ * Pill shape 다크 포도색 반투명 스타일.
+ * 아이콘 색상만으로 타입을 구분하며, 자동 사라짐만 지원한다 (닫기 버튼 없음).
  */
 
 import type { ReactNode } from 'react'
@@ -19,62 +19,34 @@ export interface ToastProps {
   onClose: (id: string) => void
 }
 
-/**
- * 토스트 타입별 스타일 및 아이콘 정의
- * @param type - 토스트 타입
- * @returns 배경색, 테두리색, 아이콘 컴포넌트를 포함한 스타일 객체
- */
-const getToastStyle = (type: ToastType): {
-  bg: string
-  border: string
-  text: string
-  icon: ReactNode
-  iconBg: string
-} => {
-  const iconClassName = 'w-4 h-4'
-
-  const styles = {
-    success: {
-      bg: 'bg-green-50',
-      border: 'border-green-200',
-      text: 'text-green-600',
-      icon: <Check className={iconClassName} />,
-      iconBg: 'bg-green-100',
-    },
-    error: {
-      bg: 'bg-red-50',
-      border: 'border-red-200',
-      text: 'text-red-600',
-      icon: <X className={iconClassName} />,
-      iconBg: 'bg-red-100',
-    },
-    warning: {
-      bg: 'bg-yellow-50',
-      border: 'border-yellow-200',
-      text: 'text-yellow-600',
-      icon: <AlertTriangle className={iconClassName} />,
-      iconBg: 'bg-yellow-100',
-    },
-    info: {
-      bg: 'bg-blue-50',
-      border: 'border-blue-200',
-      text: 'text-blue-800',
-      icon: <Info className={iconClassName} />,
-      iconBg: 'bg-blue-100',
-    },
-  }
-  return styles[type]
+/** 타입별 아이콘 컴포넌트와 색상 */
+const TOAST_ICONS: Record<ToastType, { icon: ReactNode; color: string }> = {
+  success: {
+    icon: <Check className="w-4 h-4" />,
+    color: 'text-leaf-400',
+  },
+  error: {
+    icon: <X className="w-4 h-4" />,
+    color: 'text-red-400',
+  },
+  warning: {
+    icon: <AlertTriangle className="w-4 h-4" />,
+    color: 'text-amber-400',
+  },
+  info: {
+    icon: <Info className="w-4 h-4" />,
+    color: 'text-grape-300',
+  },
 }
 
 /**
  * 개별 토스트 컴포넌트
- * 지정된 시간 후 자동으로 사라지며, X 버튼으로 수동 닫기 가능
+ * 지정된 시간 후 자동으로 사라진다.
  */
 export default function Toast({ id, type, message, duration = 3000, onClose }: ToastProps) {
-  const style = getToastStyle(type)
+  const { icon, color } = TOAST_ICONS[type]
 
   useEffect(() => {
-    // 자동 사라짐 타이머
     const timer = setTimeout(() => {
       onClose(id)
     }, duration)
@@ -85,30 +57,18 @@ export default function Toast({ id, type, message, duration = 3000, onClose }: T
   return (
     <div
       className={`
-        ${style.bg} ${style.border} ${style.text}
-        border rounded-xl shadow-lg p-4 mb-3 mx-4 sm:mx-0
-        flex items-start gap-3
-        animate-slideIn
-        max-w-md w-full
+        bg-[#1a1625]/90 backdrop-blur-sm
+        rounded-full px-5 py-3
+        flex items-center gap-2
+        animate-toastIn
       `}
       role="alert"
     >
-      {/* 아이콘 */}
-      <div className={`${style.iconBg} rounded-full w-6 h-6 flex items-center justify-center flex-shrink-0`}>
-        {style.icon}
-      </div>
+      {/* 아이콘 — 타입별 색상 */}
+      <span className={`flex-shrink-0 ${color}`}>{icon}</span>
 
-      {/* 메시지 */}
-      <p className="flex-1 text-sm font-medium leading-relaxed break-words">{message}</p>
-
-      {/* 닫기 버튼 */}
-      <button
-        onClick={() => onClose(id)}
-        className="flex-shrink-0 hover:opacity-70 transition-opacity"
-        aria-label="닫기"
-      >
-        <span className="text-lg leading-none">×</span>
-      </button>
+      {/* 메시지 — 1줄 강제 */}
+      <p className="text-sm text-white font-medium truncate">{message}</p>
     </div>
   )
 }

--- a/frontend/src/components/TransactionForm.tsx
+++ b/frontend/src/components/TransactionForm.tsx
@@ -10,6 +10,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { ArrowLeft, Camera } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { expenseApi } from '../api/expenses'
 import { incomeApi } from '../api/income'
 import { categoryApi } from '../api/categories'
@@ -34,7 +35,7 @@ const TYPE_CONFIG = {
     naturalHint: '날짜, 내용, 금액을 편하게 입력하면 AI가 자동으로 분석합니다. 결과를 확인한 뒤 저장됩니다.',
     formPlaceholder: { amount: '10000', description: '김치찌개' },
     previewLabel: '지출',
-    savedMessage: '지출이 저장되었습니다',
+    savedMessage: TOAST.SAVED,
     statsExcludeHint: '저축, 퇴직금 등 비정형 거래를 차트/통계에서 제외합니다',
     eventName: 'expense_saved',
     hasOcr: true,
@@ -47,7 +48,7 @@ const TYPE_CONFIG = {
     naturalHint: '수입 내용을 편하게 입력하면 AI가 자동으로 분석합니다. 결과를 확인한 뒤 저장됩니다.',
     formPlaceholder: { amount: '3500000', description: '월급' },
     previewLabel: '수입',
-    savedMessage: '수입이 저장되었습니다',
+    savedMessage: TOAST.SAVED,
     statsExcludeHint: '퇴직금, 일시금 등 비정형 수입을 차트/통계에서 제외합니다',
     eventName: 'income_saved',
     hasOcr: false,
@@ -116,9 +117,9 @@ export default function TransactionForm({ type }: TransactionFormProps) {
       setFormData((prev) => ({ ...prev, category_id: String(newCat.id) }))
       setShowNewCategoryForForm(false)
       setNewCategoryNameForForm('')
-      addToast('success', `"${name}" 카테고리가 추가되었습니다`)
+      addToast('success', TOAST.CATEGORY_ADDED)
     } catch {
-      addToast('error', '카테고리 생성에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setCreatingCategoryForForm(false)
     }
@@ -144,7 +145,7 @@ export default function TransactionForm({ type }: TransactionFormProps) {
         setOcrPreview(null)
       }
     } catch {
-      addToast('error', 'OCR 처리에 실패했습니다')
+      addToast('error', TOAST.PARSE_FAILED)
       setOcrPreview(null)
     } finally {
       setFormLoading(false)
@@ -193,7 +194,7 @@ export default function TransactionForm({ type }: TransactionFormProps) {
       sessionStorage.removeItem(FILTER_STORAGE_KEY)
       setTimeout(() => navigate(cfg.listRoute), 500)
     } catch {
-      addToast('error', `${cfg.previewLabel} 저장에 실패했습니다`)
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setFormLoading(false)
     }

--- a/frontend/src/components/__tests__/Toast.test.tsx
+++ b/frontend/src/components/__tests__/Toast.test.tsx
@@ -1,11 +1,11 @@
 /**
  * @file Toast.test.tsx
  * @description Toast 컴포넌트 테스트
- * 토스트 렌더링, 자동 닫기, 수동 닫기 동작을 테스트한다.
+ * pill shape 디자인, 타입별 아이콘 색상, 자동 닫기 동작을 테스트한다.
  */
 
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import Toast from '../Toast'
 
 describe('Toast', () => {
@@ -39,15 +39,55 @@ describe('Toast', () => {
       expect(screen.getByRole('alert')).toBeInTheDocument()
       expect(screen.getByText('테스트 메시지')).toBeInTheDocument()
     })
+  })
 
-    it('각 토스트 타입은 서로 다른 스타일을 가진다', () => {
-      const { rerender } = render(<Toast {...defaultProps} type="success" />)
-      const successClass = screen.getByRole('alert').className
+  describe('pill shape 디자인', () => {
+    it('rounded-full 클래스가 적용된다', () => {
+      render(<Toast {...defaultProps} type="success" />)
+      const alert = screen.getByRole('alert')
+      expect(alert.className).toContain('rounded-full')
+    })
 
-      rerender(<Toast {...defaultProps} type="error" />)
-      const errorClass = screen.getByRole('alert').className
+    it('다크 포도색 배경이 적용된다', () => {
+      render(<Toast {...defaultProps} type="success" />)
+      const alert = screen.getByRole('alert')
+      expect(alert.className).toContain('bg-[#1a1625]')
+    })
 
-      expect(successClass).not.toBe(errorClass)
+    it('메시지가 truncate로 1줄 강제된다', () => {
+      render(<Toast {...defaultProps} type="success" />)
+      const message = screen.getByText('테스트 메시지')
+      expect(message.className).toContain('truncate')
+    })
+  })
+
+  describe('타입별 아이콘 색상', () => {
+    it('성공 토스트는 leaf-400 아이콘 색상을 가진다', () => {
+      render(<Toast {...defaultProps} type="success" />)
+      const alert = screen.getByRole('alert')
+      const iconSpan = alert.querySelector('span')
+      expect(iconSpan?.className).toContain('text-leaf-400')
+    })
+
+    it('에러 토스트는 red-400 아이콘 색상을 가진다', () => {
+      render(<Toast {...defaultProps} type="error" />)
+      const alert = screen.getByRole('alert')
+      const iconSpan = alert.querySelector('span')
+      expect(iconSpan?.className).toContain('text-red-400')
+    })
+
+    it('경고 토스트는 amber-400 아이콘 색상을 가진다', () => {
+      render(<Toast {...defaultProps} type="warning" />)
+      const alert = screen.getByRole('alert')
+      const iconSpan = alert.querySelector('span')
+      expect(iconSpan?.className).toContain('text-amber-400')
+    })
+
+    it('정보 토스트는 grape-300 아이콘 색상을 가진다', () => {
+      render(<Toast {...defaultProps} type="info" />)
+      const alert = screen.getByRole('alert')
+      const iconSpan = alert.querySelector('span')
+      expect(iconSpan?.className).toContain('text-grape-300')
     })
   })
 
@@ -58,11 +98,9 @@ describe('Toast', () => {
 
       render(<Toast {...defaultProps} type="success" duration={2000} onClose={onClose} />)
 
-      // 2초 전에는 호출되지 않음
       vi.advanceTimersByTime(1999)
       expect(onClose).not.toHaveBeenCalled()
 
-      // 2초 후 호출됨
       vi.advanceTimersByTime(1)
       expect(onClose).toHaveBeenCalledTimes(1)
       expect(onClose).toHaveBeenCalledWith('test-toast-1')
@@ -81,37 +119,6 @@ describe('Toast', () => {
 
       vi.advanceTimersByTime(1)
       expect(onClose).toHaveBeenCalledTimes(1)
-
-      vi.useRealTimers()
-    })
-  })
-
-  describe('닫기 버튼', () => {
-    it('닫기 버튼이 표시된다', () => {
-      render(<Toast {...defaultProps} type="success" />)
-
-      const closeButton = screen.getByRole('button', { name: '닫기' })
-      expect(closeButton).toBeInTheDocument()
-    })
-
-    it('모바일에서 메시지가 단어 단위로 줄바꿈된다', () => {
-      render(<Toast {...defaultProps} type="success" />)
-      const alert = screen.getByRole('alert')
-      // 모바일 대응: 화면 좌우 패딩 확보 + 단어 줄바꿈
-      expect(alert.className).toMatch(/mx-4/)
-      expect(alert.querySelector('p')?.className).toContain('break-words')
-    })
-
-    it('닫기 버튼 클릭 시 onClose가 호출된다', () => {
-      vi.useFakeTimers()
-      const onClose = vi.fn()
-
-      render(<Toast {...defaultProps} type="error" onClose={onClose} />)
-
-      const closeButton = screen.getByRole('button', { name: '닫기' })
-      fireEvent.click(closeButton)
-
-      expect(onClose).toHaveBeenCalledWith('test-toast-1')
 
       vi.useRealTimers()
     })

--- a/frontend/src/components/__tests__/TransactionForm.test.tsx
+++ b/frontend/src/components/__tests__/TransactionForm.test.tsx
@@ -260,7 +260,7 @@ describe('TransactionForm', () => {
       await user.click(screen.getByText('저장하기'))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '지출이 저장되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '저장했어요')
       })
     })
 
@@ -284,7 +284,7 @@ describe('TransactionForm', () => {
       await user.click(screen.getByText('저장하기'))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '수입이 저장되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '저장했어요')
       })
     })
 
@@ -305,7 +305,7 @@ describe('TransactionForm', () => {
       await user.click(screen.getByText('저장하기'))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '지출 저장에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했어요')
       })
     })
 
@@ -370,7 +370,7 @@ describe('TransactionForm', () => {
       await user.click(screen.getByText('추가'))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '"테스트 카테고리" 카테고리가 추가되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '카테고리를 추가했어요')
       })
     })
 
@@ -391,7 +391,7 @@ describe('TransactionForm', () => {
       await user.click(screen.getByText('추가'))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '카테고리 생성에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했어요')
       })
     })
   })
@@ -442,7 +442,7 @@ describe('TransactionForm', () => {
       await user.upload(fileInput, file)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', 'OCR 처리에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '분석에 실패했어요')
       })
     })
 
@@ -465,7 +465,7 @@ describe('TransactionForm', () => {
       await user.upload(fileInput, file)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('info', '결제 정보를 인식하지 못했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('info', expect.any(String))
       })
     })
   })

--- a/frontend/src/components/admin/AdminFeedbackDashboard.tsx
+++ b/frontend/src/components/admin/AdminFeedbackDashboard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { MessageSquare, Bug, Lightbulb } from 'lucide-react'
 import { feedbackApi } from '../../api/feedback'
 import { useToast } from '../../hooks/useToast'
+import { TOAST } from '../../constants/toastMessages'
 import type { Feedback, FeedbackSource, FeedbackStatus, FeedbackType } from '../../types'
 
 const STATUS_META: Record<string, { label: string; color: string }> = {
@@ -36,7 +37,7 @@ export default function AdminFeedbackDashboard() {
       const res = await feedbackApi.getAll()
       setFeedbacks(res.data)
     } catch {
-      addToast('error', '피드백 로딩에 실패했습니다')
+      addToast('error', TOAST.FEEDBACK_LOAD_FAILED)
     } finally {
       setLoading(false)
     }
@@ -48,9 +49,9 @@ export default function AdminFeedbackDashboard() {
     try {
       const res = await feedbackApi.updateStatus(id, newStatus)
       setFeedbacks(prev => prev.map(f => f.id === id ? res.data : f))
-      addToast('success', '상태가 변경되었습니다')
+      addToast('success', TOAST.FEEDBACK_STATUS_CHANGED)
     } catch {
-      addToast('error', '상태 변경에 실패했습니다')
+      addToast('error', TOAST.FEEDBACK_STATUS_FAILED)
     }
   }
 

--- a/frontend/src/components/admin/AdminUserManager.tsx
+++ b/frontend/src/components/admin/AdminUserManager.tsx
@@ -5,6 +5,7 @@ import { Search, ChevronLeft, ChevronRight, ToggleLeft, ToggleRight } from 'luci
 import { adminApi } from '../../api/admin'
 import { maskUsername } from '../../utils/format'
 import { useToast } from '../../hooks/useToast'
+import { TOAST } from '../../constants/toastMessages'
 import type { AdminUserItem, AdminUserDetail, AdminUserListResponse } from '../../types'
 
 export default function AdminUserManager() {
@@ -21,7 +22,7 @@ export default function AdminUserManager() {
       const res = await adminApi.getUserList(page, 20, search || undefined)
       setData(res.data)
     } catch {
-      addToast('error', '사용자 목록 로딩에 실패했습니다')
+      addToast('error', TOAST.USER_LOAD_FAILED)
     } finally {
       setLoading(false)
     }
@@ -40,7 +41,7 @@ export default function AdminUserManager() {
       const res = await adminApi.getUserDetail(userId)
       setSelectedUser(res.data)
     } catch {
-      addToast('error', '사용자 정보 로딩에 실패했습니다')
+      addToast('error', TOAST.USER_DETAIL_FAILED)
     }
   }
 
@@ -48,10 +49,10 @@ export default function AdminUserManager() {
     try {
       const res = await adminApi.updateUser(userId, { is_active: !currentActive })
       setSelectedUser(res.data)
-      addToast('success', res.data.is_active ? '사용자가 활성화되었습니다' : '사용자가 비활성화되었습니다')
+      addToast('success', res.data.is_active ? TOAST.USER_ACTIVATED : TOAST.USER_DEACTIVATED)
       fetchUsers()
     } catch {
-      addToast('error', '상태 변경에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
     }
   }
 

--- a/frontend/src/components/settings/MyAccountSection.tsx
+++ b/frontend/src/components/settings/MyAccountSection.tsx
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom'
 import { LogOut, Send, MessageCircle, Key, Trash2 } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import { useToast } from '../../hooks/useToast'
+import { TOAST } from '../../constants/toastMessages'
 import { useBotLinking } from '../../hooks/useBotLinking'
 import { supabase } from '../../utils/supabase'
 import apiClient from '../../api/client'
@@ -285,9 +286,9 @@ export default function MyAccountSection() {
                     try {
                       await navigator.clipboard.writeText(`연동 ${kakao.linkCode!.code}`)
                       window.open(KAKAO_CHANNEL_CHAT_URL, '_blank')
-                      addToast('success', '연동 코드가 복사되었습니다')
+                      addToast('success', TOAST.LINK_CODE_COPIED)
                     } catch {
-                      addToast('error', '복사에 실패했습니다')
+                      addToast('error', TOAST.COPY_FAILED)
                     }
                   }}
                   className="block w-full text-center bg-[#FEE500] text-[#191919] rounded-xl py-3 font-medium hover:bg-[#FDD835] transition-colors"
@@ -363,7 +364,7 @@ function PasswordChangeCard() {
       const { error: updateError } = await supabase.auth.updateUser({ password: newPassword })
       if (updateError) throw updateError
 
-      addToast('success', '비밀번호가 변경되었습니다')
+      addToast('success', TOAST.PASSWORD_CHANGED)
       setOpen(false)
       setNewPassword('')
       setConfirmPassword('')
@@ -448,13 +449,13 @@ function AccountDeleteCard() {
       // 백엔드에 계정 삭제 요청 (소프트 삭제 + 익명화)
       await apiClient.delete('/api/auth/me')
     } catch {
-      addToast('error', '계정 삭제에 실패했습니다. 다시 시도해주세요.')
+      addToast('error', TOAST.DELETE_FAILED)
       setStep('idle')
       return
     }
     // 백엔드 삭제 성공 후에는 무조건 로그아웃 (Supabase signOut 실패해도 진행)
     try { await supabase.auth.signOut() } catch { /* 무시 */ }
-    addToast('success', '계정이 삭제되었습니다')
+    addToast('success', TOAST.ACCOUNT_DELETED)
     logout()
   }, [logout, addToast])
 

--- a/frontend/src/components/settings/__tests__/MyAccountSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/MyAccountSection.test.tsx
@@ -255,7 +255,7 @@ describe('MyAccountSection 컴포넌트', () => {
       expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'newpassword123' })
     })
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('success', '비밀번호가 변경되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '비밀번호를 변경했어요')
     })
     // 폼이 닫힌다
     await waitFor(() => {
@@ -401,7 +401,7 @@ describe('MyAccountSection 컴포넌트', () => {
     await user.click(screen.getByText('계정 영구 삭제'))
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('error', '계정 삭제에 실패했습니다. 다시 시도해주세요.')
+      expect(mockAddToast).toHaveBeenCalledWith('error', '삭제에 실패했어요')
     })
   })
 
@@ -465,7 +465,7 @@ describe('MyAccountSection 컴포넌트', () => {
 
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalled()
-      expect(mockAddToast).toHaveBeenCalledWith('success', '계정이 삭제되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '계정이 삭제되었어요')
       expect(mockLogout).toHaveBeenCalled()
     })
   })

--- a/frontend/src/components/transaction/MonthlyView.tsx
+++ b/frontend/src/components/transaction/MonthlyView.tsx
@@ -17,6 +17,7 @@ import { formatAmount } from '../../utils/format'
 import { formatDateHeader } from '../../utils/calendar'
 import { recurringApi } from '../../api/recurring'
 import { useToast } from '../../hooks/useToast'
+import { TOAST } from '../../constants/toastMessages'
 import type { useMonthlyTransactions } from '../../hooks/useMonthlyTransactions'
 
 interface MonthlyViewProps {
@@ -125,11 +126,11 @@ export default function MonthlyView({
         onExecute={async (id) => {
           try {
             await recurringApi.execute(id)
-            addToast('success', '거래가 등록되었습니다')
+            addToast('success', TOAST.RECURRING_EXECUTED)
             monthly.setPendingRecurring((prev) => prev.filter((r) => r.id !== id))
             monthly.fetchData()
           } catch {
-            addToast('error', '반복 거래 등록에 실패했습니다')
+            addToast('error', TOAST.RECURRING_EXECUTE_FAILED)
           }
         }}
         onSkip={async (id) => {
@@ -138,7 +139,7 @@ export default function MonthlyView({
             addToast('success', `다음 예정일: ${res.data.next_due_date}`)
             monthly.setPendingRecurring((prev) => prev.filter((r) => r.id !== id))
           } catch {
-            addToast('error', '건너뛰기에 실패했습니다')
+            addToast('error', TOAST.RECURRING_SKIP_FAILED)
           }
         }}
       />

--- a/frontend/src/constants/toastMessages.ts
+++ b/frontend/src/constants/toastMessages.ts
@@ -1,0 +1,130 @@
+export const TOAST = {
+  // 공통
+  SAVED: '저장했어요',
+  DELETED: '삭제했어요',
+  COPIED: '복사했어요',
+  SAVE_FAILED: '저장에 실패했어요',
+  DELETE_FAILED: '삭제에 실패했어요',
+  LOAD_FAILED: '불러오지 못했어요',
+  PROCESS_FAILED: '처리에 실패했어요',
+  NO_PERMISSION: '권한이 없어요',
+  SEARCH_FAILED: '검색에 실패했어요',
+  CATEGORY_CHANGE_FAILED: '카테고리 변경에 실패했어요',
+  ORDER_CHANGE_FAILED: '순서 변경에 실패했어요',
+  ROLE_CHANGED: '역할을 변경했어요',
+  STATUS_CHANGED: '상태를 변경했어요',
+  PASSWORD_CHANGED: '비밀번호를 변경했어요',
+  ACCOUNT_DELETED: '계정이 삭제되었어요',
+
+  // 카테고리
+  CATEGORY_ADDED: '카테고리를 추가했어요',
+  CATEGORY_UPDATED: '카테고리를 수정했어요',
+  CATEGORY_DELETED: '카테고리를 삭제했어요',
+
+  // 결제수단
+  PAYMENT_DEFAULT_SET: (name: string) =>
+    `${name}을(를) 주 결제수단으로 설정했어요`,
+  PAYMENT_DEFAULT_UNSET: '주 결제수단을 해제했어요',
+  PAYMENT_ADDED: '결제수단을 추가했어요',
+  PAYMENT_DELETED: '결제수단을 삭제했어요',
+  PAYMENT_UPDATED: '결제수단을 수정했어요',
+  PAYMENT_CHANGE_FAILED: '결제수단 변경에 실패했어요',
+
+  // 예산
+  BUDGET_SAVED: '예산을 저장했어요',
+  BUDGET_DELETED: '예산을 삭제했어요',
+
+  // AI
+  AI_COMPLETE: 'AI 분석 완료',
+  AI_FAILED: 'AI 분석에 실패했어요',
+  AI_NO_DATA: '분석할 데이터가 없어요',
+  PARSE_FAILED: '분석에 실패했어요',
+
+  // 가구
+  HOUSEHOLD_CREATED: '가구를 만들었어요',
+  HOUSEHOLD_UPDATED: '가구 정보를 수정했어요',
+  HOUSEHOLD_DELETED: '가구를 삭제했어요',
+  HOUSEHOLD_LEFT: '가구를 나갔어요',
+  HOUSEHOLD_JOINED: (name: string) => `${name}에 참여했어요`,
+  MEMBER_REMOVED: '멤버를 내보냈어요',
+  INVITE_SENT: '초대를 보냈어요',
+  INVITE_CANCELLED: '초대를 취소했어요',
+  INVITE_ACCEPTED: '초대를 수락했어요',
+  INVITE_REJECTED: '초대를 거절했어요',
+  INVITE_LINK_COPIED: '초대 링크를 복사했어요',
+
+  // 계정
+  ACCOUNT_SAVED: '계정을 저장했어요',
+  BANK_ACCOUNT_SAVED: '계좌를 등록했어요',
+  BANK_ACCOUNT_DELETED: '계좌를 삭제했어요',
+  LOGOUT: '로그아웃했어요',
+
+  // 피드백
+  FEEDBACK_SENT: '피드백을 보냈어요',
+
+  // 봇 연동
+  BOT_LINKED: '연동했어요',
+  BOT_UNLINKED: (name: string) => `${name} 연동을 해제했어요`,
+  LINK_CODE_COPIED: '연동 코드를 복사했어요',
+
+  // 정기거래
+  RECURRING_ADDED: '정기 거래를 등록했어요',
+  RECURRING_UPDATED: '정기 거래를 수정했어요',
+  RECURRING_DELETED: '정기 거래를 삭제했어요',
+  RECURRING_EXECUTED: '정기 거래를 실행했어요',
+  RECURRING_SKIPPED: '정기 거래를 건너뛰었어요',
+
+  // 자산
+  ASSET_SAVED: '자산을 저장했어요',
+  ASSET_DELETED: '자산을 삭제했어요',
+  GOAL_SAVED: '목표를 설정했어요',
+  GOAL_DELETED: '목표를 삭제했어요',
+
+  // 온보딩
+  ONBOARDING_CREATED: '가계부를 만들었어요',
+
+  // 사용자 관리
+  USER_ACTIVATED: '사용자를 활성화했어요',
+  USER_DEACTIVATED: '사용자를 비활성화했어요',
+  USER_LOAD_FAILED: '사용자 목록을 불러오지 못했어요',
+  USER_DETAIL_FAILED: '사용자 정보를 불러오지 못했어요',
+
+  // 피드백 (관리자)
+  FEEDBACK_LOAD_FAILED: '피드백을 불러오지 못했어요',
+  FEEDBACK_STATUS_CHANGED: '상태를 변경했어요',
+  FEEDBACK_STATUS_FAILED: '상태 변경에 실패했어요',
+  FEEDBACK_SUBMIT_FAILED: '제출에 실패했어요',
+
+  // 초대 수락/거절
+  INVITE_ACCEPT_FAILED: '초대 수락에 실패했어요',
+  INVITE_REJECT_FAILED: '초대 거절에 실패했어요',
+  INVITE_LOAD_FAILED: '초대 목록을 불러오지 못했어요',
+  INVITE_LINK_INVALID: '유효하지 않은 초대 링크예요',
+
+  // 가구
+  HOUSEHOLD_CREATE_FAILED: '가구 생성에 실패했어요',
+
+  // 계좌
+  BANK_ACCOUNT_ADDED: '계좌를 등록했어요',
+
+  // 반복거래 (추가 메시지)
+  RECURRING_EXECUTE_FAILED: '반복 거래 등록에 실패했어요',
+  RECURRING_SKIP_FAILED: '건너뛰기에 실패했어요',
+  RECURRING_TOGGLE_FAILED: '변경에 실패했어요',
+
+  // 복사
+  COPY_FAILED: '복사에 실패했어요',
+  LINK_CODE_COPY_FAILED: '연동 코드 복사에 실패했어요',
+
+  // 인사이트
+  AI_ANALYSIS_COMPLETE: 'AI 분석이 완료됐어요',
+  AI_ANALYSIS_FAILED: 'AI 분석에 실패했어요',
+
+  // 자산 (추가 메시지)
+  ASSET_LOAD_FAILED: '자산 정보를 불러오지 못했어요',
+  ASSET_UPDATED: '자산을 수정했어요',
+  ASSET_PARSE_FAILED: '분석에 실패했어요',
+
+  // 온보딩
+  ONBOARDING_FAILED: '가계부 생성에 실패했어요',
+} as const

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,8 +1,8 @@
 /**
  * @file ToastContext.tsx
  * @description 전역 토스트 알림 상태 관리
- * React Context를 사용하여 애플리케이션 전역에서
- * 토스트 알림을 추가/제거할 수 있는 기능을 제공한다.
+ * 항상 1개의 토스트만 표시하며, 새 토스트 추가 시 기존 토스트를 교체한다.
+ * addToast/removeToast 인터페이스는 하위 호환을 위해 유지한다.
  */
 
 import { createContext, useContext, useState, useCallback, useMemo } from 'react'
@@ -20,9 +20,10 @@ interface ToastItem {
 interface ToastContextType {
   /**
    * 새로운 토스트 알림을 추가한다
+   * 기존 토스트가 있으면 교체한다 (항상 1개만 표시).
    * @param type - 토스트 타입 (success, error, warning, info)
    * @param message - 표시할 메시지
-   * @param duration - 자동 사라질 시간 (밀리초, 기본 3000ms)
+   * @param duration - 자동 사라질 시간 (밀리초). 미지정 시 타입별 기본값 적용
    */
   addToast: (type: ToastType, message: string, duration?: number) => void
   /**
@@ -32,6 +33,14 @@ interface ToastContextType {
   removeToast: (id: string) => void
 }
 
+/** 타입별 기본 duration (ms) */
+const DEFAULT_DURATIONS: Record<ToastType, number> = {
+  success: 3000,
+  error: 5000,
+  warning: 4000,
+  info: 3000,
+}
+
 const ToastContext = createContext<ToastContextType | undefined>(undefined)
 
 /**
@@ -39,41 +48,40 @@ const ToastContext = createContext<ToastContextType | undefined>(undefined)
  * 애플리케이션 최상위에서 감싸서 사용한다
  */
 export function ToastProvider({ children }: { children: ReactNode }) {
-  const [toasts, setToasts] = useState<ToastItem[]>([])
+  const [toast, setToast] = useState<ToastItem | null>(null)
 
-  // useCallback으로 참조 안정화 — toasts 변경 시 Context value 재생성 → 구독 컴포넌트 리렌더 방지 (#167)
-  const addToast = useCallback((type: ToastType, message: string, duration = 3000) => {
+  const addToast = useCallback((type: ToastType, message: string, duration?: number) => {
     const id = `toast-${Date.now()}-${Math.random()}`
-    setToasts((prev) => [...prev, { id, type, message, duration }])
+    const resolvedDuration = duration ?? DEFAULT_DURATIONS[type]
+    setToast({ id, type, message, duration: resolvedDuration })
   }, [])
 
-  // useCallback으로 참조 안정화: Toast의 useEffect deps에 onClose가 포함되어
-  // removeToast가 재생성될 때마다 타이머가 리셋되는 stale closure 방지
   const removeToast = useCallback((id: string) => {
-    setToasts((prev) => prev.filter((toast) => toast.id !== id))
+    setToast((prev) => (prev?.id === id ? null : prev))
   }, [])
 
-  // useMemo로 value 객체 안정화 — addToast/removeToast가 변경될 때만 재생성 (#167)
   const contextValue = useMemo(() => ({ addToast, removeToast }), [addToast, removeToast])
 
   return (
     <ToastContext.Provider value={contextValue}>
       {children}
-      {/* 토스트 컨테이너: 화면 하단 중앙에 고정 — aria-live로 스크린 리더에 알림 전달 */}
-      <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 pointer-events-none" role="status" aria-live="polite">
-        <div className="pointer-events-auto">
-          {toasts.map((toast) => (
-            <Toast
-              key={toast.id}
-              id={toast.id}
-              type={toast.type}
-              message={toast.message}
-              duration={toast.duration}
-              onClose={removeToast}
-            />
-          ))}
+      {/* 토스트 컨테이너: 하단 네비(56px) + 16px 간격 = 72px */}
+      {toast && (
+        <div
+          className="fixed bottom-[72px] left-1/2 -translate-x-1/2 z-50 max-w-[calc(100vw-32px)] pointer-events-none"
+          role="status"
+          aria-live="polite"
+        >
+          <Toast
+            key={toast.id}
+            id={toast.id}
+            type={toast.type}
+            message={toast.message}
+            duration={toast.duration}
+            onClose={removeToast}
+          />
         </div>
-      </div>
+      )}
     </ToastContext.Provider>
   )
 }

--- a/frontend/src/contexts/__tests__/ToastContext.test.tsx
+++ b/frontend/src/contexts/__tests__/ToastContext.test.tsx
@@ -77,7 +77,7 @@ describe('ToastContext', () => {
       })
     })
 
-    it('여러 토스트를 동시에 추가할 수 있다', async () => {
+    it('새 토스트 추가 시 기존 토스트를 교체한다 (1개만 표시)', async () => {
       const user = userEvent.setup()
       renderWithToastProvider()
 
@@ -85,7 +85,8 @@ describe('ToastContext', () => {
       await user.click(screen.getByRole('button', { name: '에러 추가' }))
 
       await waitFor(() => {
-        expect(screen.getByText('성공 메시지')).toBeInTheDocument()
+        // 마지막에 추가된 에러 토스트만 표시
+        expect(screen.queryByText('성공 메시지')).not.toBeInTheDocument()
         expect(screen.getByText('에러 메시지')).toBeInTheDocument()
       })
     })

--- a/frontend/src/hooks/__tests__/useBotLinking.test.ts
+++ b/frontend/src/hooks/__tests__/useBotLinking.test.ts
@@ -80,7 +80,7 @@ describe('useBotLinking', () => {
       await act(() => result.current.generateCode())
 
       expect(result.current.linkCode).toBeNull()
-      expect(mockAddToast).toHaveBeenCalledWith('error', '코드 발급에 실패했습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('error', '처리에 실패했어요')
     })
 
     it('unlink 성공 시 refreshUser 호출 + linkCode null 초기화', async () => {
@@ -99,7 +99,7 @@ describe('useBotLinking', () => {
 
       expect(mockRefreshUser).toHaveBeenCalled()
       expect(result.current.linkCode).toBeNull()
-      expect(mockAddToast).toHaveBeenCalledWith('success', '텔레그램 연동이 해제되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '텔레그램 연동을 해제했어요')
     })
 
     it('unlink 시 confirm 취소하면 API 호출하지 않는다', async () => {
@@ -119,7 +119,7 @@ describe('useBotLinking', () => {
       await act(() => result.current.copyCode())
 
       expect(mockWriteText).toHaveBeenCalledWith('/link TG999')
-      expect(mockAddToast).toHaveBeenCalledWith('success', '복사되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '연동 코드를 복사했어요')
     })
 
     it('linkCode 없으면 copyCode는 아무것도 하지 않는다', async () => {
@@ -148,7 +148,7 @@ describe('useBotLinking', () => {
       const { result } = renderHook(() => useBotLinking('kakao'))
       await act(() => result.current.unlink())
 
-      expect(mockAddToast).toHaveBeenCalledWith('success', '카카오톡 연동이 해제되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '카카오톡 연동을 해제했어요')
     })
 
     it('copyCode는 "연동 {code}" 형식으로 클립보드 복사', async () => {

--- a/frontend/src/hooks/__tests__/useNaturalInput.test.ts
+++ b/frontend/src/hooks/__tests__/useNaturalInput.test.ts
@@ -207,7 +207,7 @@ describe('useNaturalInput', () => {
         await result.current.handlePreview({ preventDefault: vi.fn() } as unknown as React.FormEvent)
       })
 
-      expect(mockAddToast).toHaveBeenCalledWith('error', '파싱에 실패했습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('error', '분석에 실패했어요')
     })
   })
 
@@ -409,7 +409,7 @@ describe('useNaturalInput', () => {
       })
 
       expect(createCalled).toBe(true)
-      expect(mockAddToast).toHaveBeenCalledWith('success', '거래가 저장되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '저장했어요')
       expect(result.current.previewItems).toBeNull()
       expect(result.current.naturalInput).toBe('')
     })
@@ -483,7 +483,7 @@ describe('useNaturalInput', () => {
         await result.current.handleConfirmSave()
       })
 
-      expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했어요')
     })
   })
 
@@ -529,7 +529,7 @@ describe('useNaturalInput', () => {
       })
 
       expect(incomeCreateCalled).toBe(true)
-      expect(mockAddToast).toHaveBeenCalledWith('success', '수입이 저장되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '저장했어요')
     })
   })
 
@@ -582,7 +582,7 @@ describe('useNaturalInput', () => {
       expect(result.current.previewItems![0].category_id).toBe(99)
       expect(result.current.showNewCategoryFor).toBeNull()
       expect(result.current.newCategoryName).toBe('')
-      expect(mockAddToast).toHaveBeenCalledWith('success', '"외식" 카테고리가 추가되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '카테고리를 추가했어요')
     })
 
     it('빈 이름이면 아무 일도 하지 않는다', async () => {

--- a/frontend/src/hooks/useBotLinking.ts
+++ b/frontend/src/hooks/useBotLinking.ts
@@ -9,6 +9,7 @@ import { generateTelegramLinkCode, unlinkTelegram } from '../api/telegram'
 import { generateKakaoLinkCode, unlinkKakao } from '../api/kakao'
 import { useAuth } from '../contexts/AuthContext'
 import { useToast } from './useToast'
+import { TOAST } from '../constants/toastMessages'
 import { trackEvent } from '../utils/analytics'
 
 type Platform = 'telegram' | 'kakao'
@@ -54,7 +55,7 @@ export function useBotLinking(platform: Platform) {
       setLinkCode(data)
       trackEvent(config.trackEventName)
     } catch {
-      addToast('error', '코드 발급에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
     } finally {
       setLoadingCode(false)
     }
@@ -65,11 +66,11 @@ export function useBotLinking(platform: Platform) {
     setLoadingUnlink(true)
     try {
       await config.unlinkApi()
-      addToast('success', `${config.displayName} 연동이 해제되었습니다`)
+      addToast('success', TOAST.BOT_UNLINKED(config.displayName))
       await refreshUser()
       setLinkCode(null)
     } catch {
-      addToast('error', '연동 해제에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
     } finally {
       setLoadingUnlink(false)
     }
@@ -79,9 +80,9 @@ export function useBotLinking(platform: Platform) {
     if (!linkCode) return
     try {
       await navigator.clipboard.writeText(config.copyFormat(linkCode.code))
-      addToast('success', '복사되었습니다')
+      addToast('success', TOAST.LINK_CODE_COPIED)
     } catch {
-      addToast('error', '자동 복사에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
     }
   }, [linkCode, config, addToast])
 

--- a/frontend/src/hooks/useNaturalInput.ts
+++ b/frontend/src/hooks/useNaturalInput.ts
@@ -8,6 +8,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useToast } from './useToast'
+import { TOAST } from '../constants/toastMessages'
 import { expenseApi } from '../api/expenses'
 import { incomeApi } from '../api/income'
 import { categoryApi } from '../api/categories'
@@ -30,14 +31,14 @@ const CONFIG = {
     categoryFilter: { type: 'expense' as const },
     listRoute: '/expenses',
     eventPrefix: 'expense',
-    successMessage: '거래가 저장되었습니다',
+    successMessage: TOAST.SAVED,
     noParseMessage: '지출 정보를 인식하지 못했습니다',
   },
   income: {
     categoryFilter: undefined, // 전체 불러온 뒤 income/both 필터
     listRoute: '/income',
     eventPrefix: 'income',
-    successMessage: '수입이 저장되었습니다',
+    successMessage: TOAST.SAVED,
     noParseMessage: '수입 정보를 인식하지 못했습니다',
   },
 } as const
@@ -68,7 +69,7 @@ export function useNaturalInput(type: TransactionType) {
       .getAll(config.categoryFilter)
       .then((res) => setCategories(res.data))
       .catch(() => {
-        addToast('warning', '카테고리 목록을 불러오지 못했습니다')
+        addToast('warning', TOAST.LOAD_FAILED)
       })
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -131,7 +132,7 @@ export function useNaturalInput(type: TransactionType) {
         }
       }
     } catch {
-      addToast('error', '파싱에 실패했습니다')
+      addToast('error', TOAST.PARSE_FAILED)
     } finally {
       setLoading(false)
     }
@@ -178,7 +179,7 @@ export function useNaturalInput(type: TransactionType) {
       sessionStorage.removeItem(FILTER_STORAGE_KEY)
       setTimeout(() => navigate(config.listRoute), 500)
     } catch {
-      addToast('error', '저장에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setLoading(false)
     }
@@ -225,9 +226,9 @@ export function useNaturalInput(type: TransactionType) {
       })
       setShowNewCategoryFor(null)
       setNewCategoryName('')
-      addToast('success', `"${name}" 카테고리가 추가되었습니다`)
+      addToast('success', TOAST.CATEGORY_ADDED)
     } catch {
-      addToast('error', '카테고리 생성에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setCreatingCategory(false)
     }

--- a/frontend/src/hooks/useTransactionSearch.ts
+++ b/frontend/src/hooks/useTransactionSearch.ts
@@ -9,6 +9,7 @@ import { useSearchParams } from 'react-router-dom'
 import { expenseApi } from '../api/expenses'
 import { incomeApi } from '../api/income'
 import { useToast } from './useToast'
+import { TOAST } from '../constants/toastMessages'
 import { getLocalDateString } from '../utils/format'
 import type { Expense, Income } from '../types'
 
@@ -200,7 +201,7 @@ export function useTransactionSearch({ activeHouseholdId }: UseTransactionSearch
       searchOffsetRef.current = offset + SEARCH_PAGE_SIZE
       setSearchHasMore(newItems.length >= SEARCH_PAGE_SIZE)
     } catch {
-      addToast('error', '검색에 실패했습니다')
+      addToast('error', TOAST.SEARCH_FAILED)
     } finally {
       setSearchLoading(false)
       setSearchLoadingMore(false)

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,6 +49,14 @@
     to { transform: translateX(0); opacity: 1; }
   }
 
+  /* 토스트 전용: 하단에서 위로 등장 */
+  --animate-toastIn: toastIn 0.3s ease-out;
+
+  @keyframes toastIn {
+    from { transform: translateY(16px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+  }
+
   @keyframes grape-pop {
     0% { transform: scale(0); opacity: 0; }
     60% { transform: scale(1.2); }

--- a/frontend/src/pages/AcceptInvitationPage.tsx
+++ b/frontend/src/pages/AcceptInvitationPage.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 
 export default function AcceptInvitationPage() {
   const navigate = useNavigate()
@@ -40,12 +41,12 @@ export default function AcceptInvitationPage() {
 
     try {
       const result = await acceptInvitation(token)
-      addToast('success', `${result.household_name} 가구에 가입했습니다`)
+      addToast('success', TOAST.HOUSEHOLD_JOINED(result.household_name))
       navigate('/', { replace: true })
     } catch (err) {
       console.error('초대 수락 실패:', err)
       setError('초대 수락에 실패했습니다. 초대가 만료되었거나 이미 처리되었을 수 있습니다.')
-      addToast('error', '초대 수락에 실패했습니다')
+      addToast('error', TOAST.INVITE_ACCEPT_FAILED)
     } finally {
       setIsProcessing(false)
       setAction(null)
@@ -66,12 +67,12 @@ export default function AcceptInvitationPage() {
 
     try {
       await rejectInvitation(token)
-      addToast('success', '초대를 거절했습니다')
+      addToast('success', TOAST.INVITE_REJECTED)
       navigate('/', { replace: true })
     } catch (err) {
       console.error('초대 거절 실패:', err)
       setError('초대 거절에 실패했습니다')
-      addToast('error', '초대 거절에 실패했습니다')
+      addToast('error', TOAST.INVITE_REJECT_FAILED)
     } finally {
       setIsProcessing(false)
       setAction(null)

--- a/frontend/src/pages/AccountManager.tsx
+++ b/frontend/src/pages/AccountManager.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Plus, Wallet, Trash2, ArrowLeft } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { accountApi } from '../api/accounts'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import EmptyState from '../components/EmptyState'
@@ -51,12 +52,12 @@ export default function AccountManager() {
     setSaving(true)
     try {
       await accountApi.create(form)
-      addToast('success', '계좌가 등록되었습니다')
+      addToast('success', TOAST.BANK_ACCOUNT_SAVED)
       setForm({ name: '', type: 'brokerage' })
       setShowForm(false)
       loadAccounts()
     } catch {
-      addToast('error', '저장 중 오류가 발생했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setSaving(false)
     }
@@ -66,9 +67,9 @@ export default function AccountManager() {
     try {
       await accountApi.delete(id)
       setAccounts(prev => prev.filter(a => a.id !== id))
-      addToast('success', '계좌가 삭제되었습니다')
+      addToast('success', TOAST.BANK_ACCOUNT_DELETED)
     } catch {
-      addToast('error', '삭제 중 오류가 발생했습니다')
+      addToast('error', TOAST.DELETE_FAILED)
     }
   }
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { RefreshCw, ShieldCheck } from 'lucide-react'
 import { useAuth } from '../contexts/AuthContext'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { adminApi } from '../api/admin'
 
 import LoadingSpinner from '../components/LoadingSpinner'
@@ -34,7 +35,7 @@ export default function AdminPage() {
       const res = await adminApi.getDashboardStats()
       setDashboard(res.data)
     } catch {
-      addToast('error', '데이터 로딩에 실패했습니다')
+      addToast('error', TOAST.LOAD_FAILED)
     } finally {
       setLoading(false)
       setRefreshing(false)

--- a/frontend/src/pages/AssetForm.tsx
+++ b/frontend/src/pages/AssetForm.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate, useParams, Link } from 'react-router-dom'
 import { ArrowLeft, Search, Trash2 } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { useTickerSearch } from '../hooks/useTickerSearch'
 import { assetApi } from '../api/assets'
 import { accountApi } from '../api/accounts'
@@ -102,7 +103,7 @@ export default function AssetForm() {
         else if (['stock_kr', 'stock_us', 'crypto'].includes(asset.type)) setSearchQuery(asset.name)
       })
       .catch(() => {
-        addToast('error', '자산 정보를 불러오지 못했습니다')
+        addToast('error', TOAST.ASSET_LOAD_FAILED)
         navigate('/assets')
       })
       .finally(() => setInitialLoading(false))
@@ -124,7 +125,7 @@ export default function AssetForm() {
       const res = await assetApi.parse(naturalInput)
       setPreviewItems(res.data.items)
     } catch {
-      addToast('error', '분석 중 오류가 발생했습니다')
+      addToast('error', TOAST.ASSET_PARSE_FAILED)
     } finally {
       setLoading(false)
     }
@@ -138,11 +139,11 @@ export default function AssetForm() {
       for (const item of previewItems) {
         await assetApi.create(item)
       }
-      addToast('success', `${previewItems.length}개 자산이 등록되었습니다`)
+      addToast('success', TOAST.ASSET_SAVED)
       trackEvent('asset_added')
       navigate('/assets')
     } catch {
-      addToast('error', '저장 중 오류가 발생했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setLoading(false)
     }
@@ -159,15 +160,15 @@ export default function AssetForm() {
     try {
       if (isEdit) {
         await assetApi.update(Number(id), form)
-        addToast('success', '자산이 수정되었습니다')
+        addToast('success', TOAST.ASSET_UPDATED)
       } else {
         await assetApi.create(form)
-        addToast('success', '자산이 등록되었습니다')
+        addToast('success', TOAST.ASSET_SAVED)
         trackEvent('asset_added')
       }
       navigate('/assets')
     } catch {
-      addToast('error', isEdit ? '수정 중 오류가 발생했습니다' : '저장 중 오류가 발생했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setLoading(false)
     }
@@ -178,10 +179,10 @@ export default function AssetForm() {
     setLoading(true)
     try {
       await assetApi.delete(Number(id))
-      addToast('success', '자산이 삭제되었습니다')
+      addToast('success', TOAST.ASSET_DELETED)
       navigate('/assets')
     } catch {
-      addToast('error', '삭제 중 오류가 발생했습니다')
+      addToast('error', TOAST.DELETE_FAILED)
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { supabase } from '../utils/supabase'
 import { trackEvent } from '../utils/analytics'
 
@@ -65,7 +66,7 @@ export default function AuthCallbackPage() {
       const { error: updateError } = await supabase.auth.updateUser({ password })
       if (updateError) throw updateError
 
-      addToast('success', '비밀번호가 변경되었습니다')
+      addToast('success', TOAST.PASSWORD_CHANGED)
       navigate('/', { replace: true })
     } catch (err) {
       const message = (err as Error).message

--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
 import { ArrowLeft, BarChart3, AlertTriangle, Wallet } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import budgetApi from '../api/budgets'
 import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
@@ -130,10 +131,10 @@ export default function BudgetManager() {
       const amount = localTotalBudget && num > 0 ? num : null
       const res = await budgetApi.updateTotalBudget(amount)
       setTotalBudget(res.data.total_monthly_budget)
-      addToast('success', '월 총 예산이 저장되었습니다')
+      addToast('success', TOAST.BUDGET_SAVED)
     } catch (err) {
       console.error('Failed to save total budget:', err)
-      addToast('error', '월 총 예산 저장에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setSavingTotal(false)
     }
@@ -155,12 +156,12 @@ export default function BudgetManager() {
         // 빈 값이면 기존 예산 삭제
         if (item.current_budget_id) {
           await budgetApi.deleteBudget(item.current_budget_id)
-          addToast('success', '예산이 삭제되었습니다')
+          addToast('success', TOAST.BUDGET_DELETED)
         }
       } else if (item.current_budget_id) {
         // 기존 예산 수정
         await budgetApi.updateBudget(item.current_budget_id, { amount: numAmount })
-        addToast('success', '예산이 저장되었습니다')
+        addToast('success', TOAST.BUDGET_SAVED)
       } else {
         // 새 예산 생성 — 월간, 오늘부터, 알림 80% 기본값
         await budgetApi.createBudget({
@@ -169,12 +170,12 @@ export default function BudgetManager() {
           period: 'monthly',
           start_date: new Date().toISOString().split('T')[0],
         })
-        addToast('success', '예산이 저장되었습니다')
+        addToast('success', TOAST.BUDGET_SAVED)
       }
       await loadData()
     } catch (err) {
       console.error('Failed to save budget:', err)
-      addToast('error', '예산 저장에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setSavingIds((prev) => {
         const next = new Set(prev)

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
 import { ArrowLeft, Lock, Plus } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { categoryApi } from '../api/categories'
 import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
@@ -53,7 +54,7 @@ export default function CategoryManager() {
       setCategories(res.data)
     } catch {
       setError(true)
-      addToast('error', '카테고리 목록 로딩에 실패했습니다')
+      addToast('error', TOAST.LOAD_FAILED)
     } finally {
       setLoading(false)
     }
@@ -74,14 +75,14 @@ export default function CategoryManager() {
         description: newDescription.trim() || undefined,
         is_savings: newIsSavings,
       })
-      addToast('success', '카테고리가 추가되었습니다')
+      addToast('success', TOAST.CATEGORY_ADDED)
       setNewName('')
       setNewDescription('')
       setNewIsSavings(false)
       setIsAdding(false)
       fetchCategories()
     } catch {
-      addToast('error', '카테고리 추가에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     }
   }
 
@@ -112,11 +113,11 @@ export default function CategoryManager() {
         description: editForm.description.trim() || undefined,
         is_savings: editForm.is_savings,
       })
-      addToast('success', '카테고리가 수정되었습니다')
+      addToast('success', TOAST.CATEGORY_UPDATED)
       setEditingId(null)
       fetchCategories()
     } catch {
-      addToast('error', '카테고리 수정에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     }
   }
 
@@ -126,11 +127,11 @@ export default function CategoryManager() {
   const handleDelete = async (id: number) => {
     try {
       await categoryApi.delete(id)
-      addToast('success', '카테고리가 삭제되었습니다')
+      addToast('success', TOAST.CATEGORY_DELETED)
       setDeleteTarget(null)
       fetchCategories()
     } catch {
-      addToast('error', '카테고리 삭제에 실패했습니다')
+      addToast('error', TOAST.DELETE_FAILED)
     }
   }
 
@@ -155,7 +156,7 @@ export default function CategoryManager() {
     } catch {
       // 실패 시 원래 목록 복원
       fetchCategories()
-      addToast('error', '순서 변경에 실패했습니다')
+      addToast('error', TOAST.ORDER_CHANGE_FAILED)
     } finally {
       setReordering(false)
     }

--- a/frontend/src/pages/ExpenseDetail.tsx
+++ b/frontend/src/pages/ExpenseDetail.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { expenseApi } from '../api/expenses'
 import { categoryApi } from '../api/categories'
 import RegisterRecurringModal from '../components/RegisterRecurringModal'
@@ -107,13 +108,13 @@ export default function ExpenseDetail() {
       })
       setExpense(updated.data)
       setIsEditing(false)
-      addToast('success', '저장되었습니다')
+      addToast('success', TOAST.SAVED)
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status
       if (status === 403) {
-        addToast('error', '이 항목을 수정할 권한이 없습니다')
+        addToast('error', TOAST.NO_PERMISSION)
       } else {
-        addToast('error', '저장에 실패했습니다')
+        addToast('error', TOAST.SAVE_FAILED)
       }
     }
   }
@@ -126,14 +127,14 @@ export default function ExpenseDetail() {
 
     try {
       await expenseApi.delete(expense.id)
-      addToast('success', '삭제되었습니다')
+      addToast('success', TOAST.DELETED)
       navigate('/expenses')
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status
       if (status === 403) {
-        addToast('error', '이 항목을 삭제할 권한이 없습니다')
+        addToast('error', TOAST.NO_PERMISSION)
       } else {
-        addToast('error', '삭제에 실패했습니다')
+        addToast('error', TOAST.DELETE_FAILED)
       }
     }
   }

--- a/frontend/src/pages/FeedbackPage.tsx
+++ b/frontend/src/pages/FeedbackPage.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
 import { ArrowLeft, Bug, Lightbulb, MessageSquarePlus, Send } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { feedbackApi } from '../api/feedback'
 import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
@@ -73,13 +74,13 @@ export default function FeedbackPage() {
     setSubmitting(true)
     try {
       await feedbackApi.create({ type, title: title.trim(), content: content.trim() })
-      addToast('success', '피드백이 제출되었습니다')
+      addToast('success', TOAST.FEEDBACK_SENT)
       trackEvent('feedback_submitted')
       setTitle('')
       setContent('')
       await loadData()
     } catch {
-      addToast('error', '제출에 실패했습니다')
+      addToast('error', TOAST.FEEDBACK_SUBMIT_FAILED)
     } finally {
       setSubmitting(false)
     }
@@ -90,7 +91,7 @@ export default function FeedbackPage() {
       await feedbackApi.updateStatus(id, status)
       await loadData()
     } catch {
-      addToast('error', '상태 변경에 실패했습니다')
+      addToast('error', TOAST.FEEDBACK_STATUS_FAILED)
     }
   }
 

--- a/frontend/src/pages/HouseholdDetailPage.tsx
+++ b/frontend/src/pages/HouseholdDetailPage.tsx
@@ -10,6 +10,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { useAuth } from '../contexts/AuthContext'
 import { useHouseholdRole } from '../hooks/useHouseholdRole'
 import InviteMemberModal from '../components/InviteMemberModal'
@@ -65,7 +66,7 @@ export default function HouseholdDetailPage() {
     if (id) {
       fetchHouseholdDetail(Number(id)).catch((err) => {
         console.error('가구 상세 조회 실패:', err)
-        addToast('error', '가구 정보 로딩에 실패했습니다')
+        addToast('error', TOAST.LOAD_FAILED)
       })
     }
 
@@ -89,7 +90,7 @@ export default function HouseholdDetailPage() {
    */
   useEffect(() => {
     if (error) {
-      addToast('error', '처리에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
       clearError()
     }
   }, [error, addToast, clearError])
@@ -107,9 +108,9 @@ export default function HouseholdDetailPage() {
         // 이메일 미발송 — 링크 복사 안내
         const link = `${window.location.origin}/invitations/accept?token=${result.token}`
         await navigator.clipboard.writeText(link)
-        addToast('warning', '이메일 발송에 실패하여 링크가 복사되었습니다')
+        addToast('warning', TOAST.INVITE_LINK_COPIED)
       } else {
-        addToast('success', '초대를 전송했습니다')
+        addToast('success', TOAST.INVITE_SENT)
       }
       trackEvent('member_invited')
       setShowInviteModal(false)
@@ -117,7 +118,7 @@ export default function HouseholdDetailPage() {
       await fetchHouseholdInvitations(Number(id)).catch(() => {})
     } catch (err) {
       console.error('멤버 초대 실패:', err)
-      addToast('error', '멤버 초대에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
     } finally {
       setIsInviting(false)
     }
@@ -131,10 +132,10 @@ export default function HouseholdDetailPage() {
 
     try {
       await updateMemberRole(Number(id), userId, newRole)
-      addToast('success', '역할이 변경되었습니다')
+      addToast('success', TOAST.ROLE_CHANGED)
     } catch (err) {
       console.error('역할 변경 실패:', err)
-      addToast('error', '역할 변경에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
     }
   }
 
@@ -147,10 +148,10 @@ export default function HouseholdDetailPage() {
 
     try {
       await removeMember(Number(id), userId)
-      addToast('success', '멤버를 내보냈습니다')
+      addToast('success', TOAST.MEMBER_REMOVED)
     } catch (err) {
       console.error('멤버 내보내기 실패:', err)
-      addToast('error', '멤버 내보내기에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
     }
   }
 
@@ -163,11 +164,11 @@ export default function HouseholdDetailPage() {
 
     try {
       await leaveHousehold(Number(id))
-      addToast('success', '가구에서 탈퇴했습니다')
+      addToast('success', TOAST.HOUSEHOLD_LEFT)
       navigate('/households')
     } catch (err) {
       console.error('가구 탈퇴 실패:', err)
-      addToast('error', '가구 탈퇴에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
     }
   }
 
@@ -179,10 +180,10 @@ export default function HouseholdDetailPage() {
 
     try {
       await updateHousehold(Number(id), formData)
-      addToast('success', '가구 정보가 수정되었습니다')
+      addToast('success', TOAST.HOUSEHOLD_UPDATED)
     } catch (err) {
       console.error('가구 수정 실패:', err)
-      addToast('error', '가구 수정에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     }
   }
 
@@ -195,11 +196,11 @@ export default function HouseholdDetailPage() {
 
     try {
       await deleteHousehold(Number(id))
-      addToast('success', '가구가 삭제되었습니다')
+      addToast('success', TOAST.HOUSEHOLD_DELETED)
       navigate('/households')
     } catch (err) {
       console.error('가구 삭제 실패:', err)
-      addToast('error', '가구 삭제에 실패했습니다')
+      addToast('error', TOAST.DELETE_FAILED)
     }
   }
 
@@ -213,9 +214,9 @@ export default function HouseholdDetailPage() {
 
     try {
       await cancelInvitation(Number(id), invitationId)
-      addToast('success', '초대를 취소했습니다')
+      addToast('success', TOAST.INVITE_CANCELLED)
     } catch {
-      addToast('error', '초대 취소에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
     }
   }
 
@@ -225,7 +226,7 @@ export default function HouseholdDetailPage() {
   const handleCopyInviteLink = async (token: string) => {
     const link = `${window.location.origin}/invitations/accept?token=${token}`
     await navigator.clipboard.writeText(link)
-    addToast('success', '초대 링크가 복사되었습니다')
+    addToast('success', TOAST.INVITE_LINK_COPIED)
   }
 
   /**

--- a/frontend/src/pages/HouseholdListPage.tsx
+++ b/frontend/src/pages/HouseholdListPage.tsx
@@ -11,6 +11,7 @@ import { useGoBack } from '../hooks/useGoBack'
 import { ArrowLeft, Users, Calendar } from 'lucide-react'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import CreateHouseholdModal from '../components/CreateHouseholdModal'
 import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
@@ -38,7 +39,7 @@ export default function HouseholdListPage() {
   useEffect(() => {
     fetchHouseholds().catch((err) => {
       console.error('가구 목록 조회 실패:', err)
-      addToast('error', '가구 목록 로딩에 실패했습니다')
+      addToast('error', TOAST.LOAD_FAILED)
     })
   }, [fetchHouseholds, addToast])
 
@@ -47,7 +48,7 @@ export default function HouseholdListPage() {
    */
   useEffect(() => {
     if (error) {
-      addToast('error', '처리에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
       clearError()
     }
   }, [error, addToast, clearError])
@@ -59,14 +60,14 @@ export default function HouseholdListPage() {
     setIsCreating(true)
     try {
       const newHousehold = await createHousehold(data)
-      addToast('success', '가구가 생성되었습니다')
+      addToast('success', TOAST.HOUSEHOLD_CREATED)
       trackEvent('household_created')
       setShowCreateModal(false)
       // 생성 후 상세 페이지로 이동
       navigate(`/households/${newHousehold.id}`)
     } catch (err) {
       console.error('가구 생성 실패:', err)
-      addToast('error', '가구 생성에 실패했습니다')
+      addToast('error', TOAST.HOUSEHOLD_CREATE_FAILED)
     } finally {
       setIsCreating(false)
     }

--- a/frontend/src/pages/IncomeDetail.tsx
+++ b/frontend/src/pages/IncomeDetail.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { incomeApi } from '../api/income'
 import { categoryApi } from '../api/categories'
 import RegisterRecurringModal from '../components/RegisterRecurringModal'
@@ -97,13 +98,13 @@ export default function IncomeDetail() {
       })
       setIncome(updated.data)
       setIsEditing(false)
-      addToast('success', '저장되었습니다')
+      addToast('success', TOAST.SAVED)
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status
       if (status === 403) {
-        addToast('error', '이 항목을 수정할 권한이 없습니다')
+        addToast('error', TOAST.NO_PERMISSION)
       } else {
-        addToast('error', '저장에 실패했습니다')
+        addToast('error', TOAST.SAVE_FAILED)
       }
     }
   }
@@ -113,14 +114,14 @@ export default function IncomeDetail() {
 
     try {
       await incomeApi.delete(income.id)
-      addToast('success', '삭제되었습니다')
+      addToast('success', TOAST.DELETED)
       navigate('/income')
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status
       if (status === 403) {
-        addToast('error', '이 항목을 삭제할 권한이 없습니다')
+        addToast('error', TOAST.NO_PERMISSION)
       } else {
-        addToast('error', '삭제에 실패했습니다')
+        addToast('error', TOAST.DELETE_FAILED)
       }
     }
   }

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom'
 import { Sparkles, Settings } from 'lucide-react'
 import ErrorState from '../components/ErrorState'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import EmptyState from '../components/EmptyState'
 
 // API
@@ -197,7 +198,7 @@ export default function InsightsPage() {
   // AI 분석 생성
   const handleGenerateAI = useCallback(async () => {
     if (!expenseStats && !incomeStats) {
-      addToast('error', '분석할 데이터가 없습니다')
+      addToast('error', TOAST.AI_NO_DATA)
       return
     }
 
@@ -252,9 +253,9 @@ export default function InsightsPage() {
       const result = await insightsApi.generateComprehensive(requestData)
       setStructuredInsights(result.insights)
       trackEvent('ai_analysis_requested')
-      addToast('success', 'AI 분석이 완료되었습니다')
+      addToast('success', TOAST.AI_ANALYSIS_COMPLETE)
     } catch {
-      addToast('error', 'AI 분석 생성에 실패했습니다')
+      addToast('error', TOAST.AI_ANALYSIS_FAILED)
     } finally {
       setAiLoading(false)
     }

--- a/frontend/src/pages/InvitationListPage.tsx
+++ b/frontend/src/pages/InvitationListPage.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom'
 import { ArrowLeft } from 'lucide-react'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
 import LoadingSpinner from '../components/LoadingSpinner'
@@ -105,7 +106,7 @@ export default function InvitationListPage() {
   useEffect(() => {
     fetchMyInvitations().catch((err) => {
       console.error('초대 목록 조회 실패:', err)
-      addToast('error', '초대 목록 로딩에 실패했습니다')
+      addToast('error', TOAST.INVITE_LOAD_FAILED)
     })
   }, [fetchMyInvitations, addToast])
 
@@ -114,7 +115,7 @@ export default function InvitationListPage() {
    */
   useEffect(() => {
     if (error) {
-      addToast('error', '처리에 실패했습니다')
+      addToast('error', TOAST.PROCESS_FAILED)
       clearError()
     }
   }, [error, addToast, clearError])
@@ -126,12 +127,12 @@ export default function InvitationListPage() {
     setProcessingToken(token)
     try {
       const result = await acceptInvitation(token)
-      addToast('success', `${result.household_name} 가구에 가입했습니다`)
+      addToast('success', TOAST.HOUSEHOLD_JOINED(result.household_name))
       // 가구 상세 페이지로 이동
       navigate(`/households/${result.household_id}`)
     } catch (err) {
       console.error('초대 수락 실패:', err)
-      addToast('error', '초대 수락에 실패했습니다')
+      addToast('error', TOAST.INVITE_ACCEPT_FAILED)
     } finally {
       setProcessingToken(null)
     }
@@ -146,10 +147,10 @@ export default function InvitationListPage() {
     setProcessingToken(token)
     try {
       await rejectInvitation(token)
-      addToast('success', '초대를 거절했습니다')
+      addToast('success', TOAST.INVITE_REJECTED)
     } catch (err) {
       console.error('초대 거절 실패:', err)
-      addToast('error', '초대 거절에 실패했습니다')
+      addToast('error', TOAST.INVITE_REJECT_FAILED)
     } finally {
       setProcessingToken(null)
     }

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -9,6 +9,7 @@ import { Mail } from 'lucide-react'
 import { onboardingApi } from '../api/onboarding'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { trackEvent } from '../utils/analytics'
 
 export default function OnboardingPage() {
@@ -28,11 +29,11 @@ export default function OnboardingPage() {
     try {
       await onboardingApi.createHousehold(name.trim() || undefined)
       await fetchHouseholds()
-      addToast('success', '가계부가 생성되었습니다')
+      addToast('success', TOAST.ONBOARDING_CREATED)
       trackEvent('onboarding_complete', { method: 'create' })
       navigate('/', { replace: true })
     } catch {
-      addToast('error', '가계부 생성에 실패했습니다')
+      addToast('error', TOAST.ONBOARDING_FAILED)
     } finally {
       setLoading(false)
     }
@@ -43,11 +44,11 @@ export default function OnboardingPage() {
     setAcceptingToken(token)
     try {
       await acceptInvitation(token)
-      addToast('success', `${householdName || '가계부'}에 참여했습니다`)
+      addToast('success', TOAST.HOUSEHOLD_JOINED(householdName || '가계부'))
       trackEvent('onboarding_complete', { method: 'accept_invitation' })
       navigate('/', { replace: true })
     } catch {
-      addToast('error', '초대 수락에 실패했습니다')
+      addToast('error', TOAST.INVITE_ACCEPT_FAILED)
       // 실패 시 초대 목록 새로고침 (만료 등)
       await fetchMyInvitations().catch(() => {})
     } finally {

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { ArrowLeft, CreditCard, Plus, Trash2, Pencil, ChevronUp, ChevronDown } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { paymentMethodApi } from '../api/paymentMethods'
 import { formatAmount } from '../utils/format'
@@ -72,7 +73,7 @@ export default function PaymentMethodManager() {
       usageRes.data.forEach((u) => map.set(u.id, u))
       setUsageMap(map)
     } catch {
-      addToast('error', '결제수단을 불러오지 못했습니다')
+      addToast('error', TOAST.LOAD_FAILED)
     } finally {
       setLoading(false)
     }
@@ -91,14 +92,14 @@ export default function PaymentMethodManager() {
       try {
         await paymentMethodApi.update(currentDefault.id, { is_default: false })
       } catch {
-        addToast('error', '주 결제수단 변경에 실패했습니다')
+        addToast('error', TOAST.PAYMENT_CHANGE_FAILED)
         return
       }
     }
 
     // "없음" 선택
     if (!newDefaultId) {
-      addToast('info', '주 결제수단을 해제했어요')
+      addToast('info', TOAST.PAYMENT_DEFAULT_UNSET)
       await fetchData()
       return
     }
@@ -109,10 +110,10 @@ export default function PaymentMethodManager() {
 
     try {
       await paymentMethodApi.update(target.id, { is_default: true })
-      addToast('success', `${target.name}을 주 결제수단으로 설정했어요 ✅`)
+      addToast('success', TOAST.PAYMENT_DEFAULT_SET(target.name))
       await fetchData()
     } catch {
-      addToast('error', '주 결제수단 변경에 실패했습니다')
+      addToast('error', TOAST.PAYMENT_CHANGE_FAILED)
     }
   }, [methods, fetchData, addToast])
 
@@ -130,7 +131,7 @@ export default function PaymentMethodManager() {
         monthly_target: formTarget ? Number(formTarget) : null,
         is_default: false,
       })
-      addToast('success', `"${formName.trim()}" 결제수단이 추가되었습니다`)
+      addToast('success', TOAST.PAYMENT_ADDED)
       setShowForm(false)
       setFormName('')
       setFormType('credit_card')
@@ -138,7 +139,7 @@ export default function PaymentMethodManager() {
       setShowDetailSettings(false)
       await fetchData()
     } catch {
-      addToast('error', '결제수단 추가에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setSaving(false)
     }
@@ -148,10 +149,10 @@ export default function PaymentMethodManager() {
   const handleDelete = useCallback(async (method: PaymentMethod) => {
     try {
       await paymentMethodApi.delete(method.id)
-      addToast('success', `"${method.name}" 결제수단이 삭제되었습니다`)
+      addToast('success', TOAST.PAYMENT_DELETED)
       await fetchData()
     } catch {
-      addToast('error', '결제수단 삭제에 실패했습니다')
+      addToast('error', TOAST.DELETE_FAILED)
     }
   }, [fetchData, addToast])
 
@@ -167,7 +168,7 @@ export default function PaymentMethodManager() {
     try {
       await paymentMethodApi.reorder(newMethods.map((m) => m.id))
     } catch {
-      addToast('error', '순서 변경에 실패했습니다')
+      addToast('error', TOAST.ORDER_CHANGE_FAILED)
       await fetchData()
     }
   }, [methods, fetchData, addToast])
@@ -190,11 +191,11 @@ export default function PaymentMethodManager() {
         type: editType,
         monthly_target: editTarget ? Number(editTarget) : null,
       })
-      addToast('success', `"${editName.trim()}" 결제수단이 수정되었습니다`)
+      addToast('success', TOAST.PAYMENT_UPDATED)
       setEditingMethod(null)
       await fetchData()
     } catch {
-      addToast('error', '결제수단 수정에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setEditSaving(false)
     }

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
 import { ArrowLeft, Plus, Pencil, Trash2, Pause, Play, Zap } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import { recurringApi } from '../api/recurring'
 import { categoryApi } from '../api/categories'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
@@ -129,7 +130,7 @@ export default function RecurringList() {
           category_id: formData.category_id ? Number(formData.category_id) : null,
           end_date: formData.end_date || null,
         })
-        addToast('success', '반복 거래가 수정되었습니다')
+        addToast('success', TOAST.RECURRING_UPDATED)
       } else {
         const payload: RecurringTransactionCreate = {
           type: formData.type,
@@ -154,13 +155,13 @@ export default function RecurringList() {
           payload.interval = Number(formData.interval)
         }
         await recurringApi.create(payload)
-        addToast('success', '반복 거래가 추가되었습니다')
+        addToast('success', TOAST.RECURRING_ADDED)
         trackEvent('recurring_added')
       }
       setShowModal(false)
       loadData()
     } catch {
-      addToast('error', '저장에 실패했습니다')
+      addToast('error', TOAST.SAVE_FAILED)
     } finally {
       setSubmitting(false)
     }
@@ -171,10 +172,10 @@ export default function RecurringList() {
     if (!confirm('정말 삭제하시겠습니까?')) return
     try {
       await recurringApi.delete(id)
-      addToast('success', '반복 거래가 삭제되었습니다')
+      addToast('success', TOAST.RECURRING_DELETED)
       loadData()
     } catch {
-      addToast('error', '삭제에 실패했습니다')
+      addToast('error', TOAST.DELETE_FAILED)
     }
   }
 
@@ -182,10 +183,10 @@ export default function RecurringList() {
   const handleExecute = async (r: RecurringTransaction) => {
     try {
       await recurringApi.execute(r.id)
-      addToast('success', `${r.description} 등록되었습니다`)
+      addToast('success', TOAST.RECURRING_EXECUTED)
       loadData()
     } catch {
-      addToast('error', '등록에 실패했습니다')
+      addToast('error', TOAST.RECURRING_EXECUTE_FAILED)
     }
   }
 
@@ -193,10 +194,10 @@ export default function RecurringList() {
   const toggleActive = async (r: RecurringTransaction) => {
     try {
       await recurringApi.update(r.id, { is_active: !r.is_active })
-      addToast('success', r.is_active ? '중지되었습니다' : '다시 시작되었습니다')
+      addToast('success', TOAST.STATUS_CHANGED)
       loadData()
     } catch {
-      addToast('error', '변경에 실패했습니다')
+      addToast('error', TOAST.RECURRING_TOGGLE_FAILED)
     }
   }
 

--- a/frontend/src/pages/TransactionList.tsx
+++ b/frontend/src/pages/TransactionList.tsx
@@ -10,6 +10,7 @@ import { expenseApi } from '../api/expenses'
 import { incomeApi } from '../api/income'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
+import { TOAST } from '../constants/toastMessages'
 import CategoryBottomSheet from '../components/CategoryBottomSheet'
 import PullToRefresh from '../components/PullToRefresh'
 import ErrorState from '../components/ErrorState'
@@ -135,7 +136,7 @@ export default function TransactionList() {
       }
       setSheetOpen(false)
     } catch {
-      addToast('error', '카테고리 변경에 실패했습니다')
+      addToast('error', TOAST.CATEGORY_CHANGE_FAILED)
     } finally {
       setSheetSaving(false)
     }

--- a/frontend/src/pages/__tests__/AcceptInvitationPage.test.tsx
+++ b/frontend/src/pages/__tests__/AcceptInvitationPage.test.tsx
@@ -110,7 +110,7 @@ describe('AcceptInvitationPage', () => {
       await user.click(screen.getByRole('button', { name: '초대 수락' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '테스트 가구 가구에 가입했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '테스트 가구에 참여했어요')
       })
 
       await waitFor(() => {
@@ -131,7 +131,7 @@ describe('AcceptInvitationPage', () => {
       })
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '초대 수락에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '초대 수락에 실패했어요')
       })
     })
   })
@@ -173,7 +173,7 @@ describe('AcceptInvitationPage', () => {
       await user.click(screen.getByRole('button', { name: '초대 거절' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '초대를 거절했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '초대를 거절했어요')
       })
 
       await waitFor(() => {

--- a/frontend/src/pages/__tests__/AccountManager.test.tsx
+++ b/frontend/src/pages/__tests__/AccountManager.test.tsx
@@ -162,7 +162,7 @@ describe('AccountManager', () => {
       await waitFor(() => {
         expect(mockCreate).toHaveBeenCalledWith({ name: '새 증권 계좌', type: 'brokerage' })
       })
-      expect(mockAddToast).toHaveBeenCalledWith('success', '계좌가 등록되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '계좌를 등록했어요')
     })
 
     it('취소 버튼 클릭 시 폼을 닫는다', async () => {
@@ -197,7 +197,7 @@ describe('AccountManager', () => {
         await waitFor(() => {
           expect(mockDelete).toHaveBeenCalledWith(1)
         })
-        expect(mockAddToast).toHaveBeenCalledWith('success', '계좌가 삭제되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '계좌를 삭제했어요')
       }
     })
   })

--- a/frontend/src/pages/__tests__/AssetForm.test.tsx
+++ b/frontend/src/pages/__tests__/AssetForm.test.tsx
@@ -199,7 +199,7 @@ describe('AssetForm', () => {
       await waitFor(() => {
         expect(mockAssetCreate).toHaveBeenCalled()
       })
-      expect(mockAddToast).toHaveBeenCalledWith('success', '자산이 등록되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '자산을 저장했어요')
       expect(mockNavigate).toHaveBeenCalledWith('/assets')
     })
 
@@ -293,7 +293,7 @@ describe('AssetForm', () => {
 
       await waitFor(() => {
         expect(mockAssetDelete).toHaveBeenCalledWith(1)
-        expect(mockAddToast).toHaveBeenCalledWith('success', '자산이 삭제되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '자산을 삭제했어요')
         expect(mockNavigate).toHaveBeenCalledWith('/assets')
       })
     })
@@ -332,7 +332,7 @@ describe('AssetForm', () => {
         expect(mockAssetUpdate).toHaveBeenCalledWith(1, expect.objectContaining({
           name: '긴급 자금',
         }))
-        expect(mockAddToast).toHaveBeenCalledWith('success', '자산이 수정되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '자산을 수정했어요')
       })
     })
 
@@ -348,7 +348,7 @@ describe('AssetForm', () => {
       await user.click(screen.getByRole('button', { name: /수정하기/ }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '수정 중 오류가 발생했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했어요')
       })
     })
 
@@ -357,7 +357,7 @@ describe('AssetForm', () => {
       renderEditAssetForm(999)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '자산 정보를 불러오지 못했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '자산 정보를 불러오지 못했어요')
         expect(mockNavigate).toHaveBeenCalledWith('/assets')
       })
     })
@@ -388,7 +388,7 @@ describe('AssetForm', () => {
 
       await waitFor(() => {
         expect(mockAssetCreate).toHaveBeenCalledTimes(2)
-        expect(mockAddToast).toHaveBeenCalledWith('success', '2개 자산이 등록되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '자산을 저장했어요')
         expect(mockNavigate).toHaveBeenCalledWith('/assets')
       })
     })
@@ -403,7 +403,7 @@ describe('AssetForm', () => {
       await user.click(screen.getByRole('button', { name: /분석하기/ }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '분석 중 오류가 발생했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '분석에 실패했어요')
       })
     })
   })
@@ -436,7 +436,7 @@ describe('AssetForm', () => {
       await user.click(screen.getByRole('button', { name: '저장하기' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '저장 중 오류가 발생했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했어요')
       })
     })
   })

--- a/frontend/src/pages/__tests__/BudgetManager.test.tsx
+++ b/frontend/src/pages/__tests__/BudgetManager.test.tsx
@@ -289,7 +289,7 @@ describe('BudgetManager', () => {
       await waitFor(() => {
         expect(postCalled).toBe(true)
       })
-      expect(mockAddToast).toHaveBeenCalledWith('success', '예산이 저장되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '예산을 저장했어요')
     })
 
     it('기존 예산 수정 시 PUT API를 호출한다', async () => {
@@ -330,7 +330,7 @@ describe('BudgetManager', () => {
       await waitFor(() => {
         expect(putCalled).toBe(true)
       })
-      expect(mockAddToast).toHaveBeenCalledWith('success', '예산이 저장되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '예산을 저장했어요')
     })
 
     it('입력을 비우고 저장하면 기존 예산을 삭제한다', async () => {
@@ -360,7 +360,7 @@ describe('BudgetManager', () => {
       await waitFor(() => {
         expect(deleteCalled).toBe(true)
       })
-      expect(mockAddToast).toHaveBeenCalledWith('success', '예산이 삭제되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '예산을 삭제했어요')
     })
   })
 

--- a/frontend/src/pages/__tests__/CategoryManager.test.tsx
+++ b/frontend/src/pages/__tests__/CategoryManager.test.tsx
@@ -168,7 +168,7 @@ describe('CategoryManager', () => {
       await user.click(saveButton)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '카테고리가 추가되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '카테고리를 추가했어요')
       })
     })
 
@@ -264,7 +264,7 @@ describe('CategoryManager', () => {
       await user.click(saveButton)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '카테고리가 수정되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '카테고리를 수정했어요')
       })
     })
 
@@ -355,7 +355,7 @@ describe('CategoryManager', () => {
       await user.click(modalDeleteButton)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '카테고리가 삭제되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '카테고리를 삭제했어요')
       })
     })
   })
@@ -402,7 +402,7 @@ describe('CategoryManager', () => {
 
       await waitFor(() => {
         expect(screen.getByText('문제가 발생했습니다')).toBeInTheDocument()
-        expect(mockAddToast).toHaveBeenCalledWith('error', '카테고리 목록 로딩에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '불러오지 못했어요')
       })
     })
   })
@@ -434,7 +434,7 @@ describe('CategoryManager', () => {
       await user.click(modalDeleteButton)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '카테고리 삭제에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '삭제에 실패했어요')
       })
     })
   })
@@ -583,7 +583,7 @@ describe('CategoryManager', () => {
       await user.click(screen.getByRole('button', { name: '저장' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '카테고리 추가에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했어요')
       })
     })
   })
@@ -618,7 +618,7 @@ describe('CategoryManager', () => {
       await user.click(screen.getByRole('button', { name: '저장' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '카테고리 수정에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했어요')
       })
     })
   })

--- a/frontend/src/pages/__tests__/ExpenseDetail.test.tsx
+++ b/frontend/src/pages/__tests__/ExpenseDetail.test.tsx
@@ -216,7 +216,7 @@ describe('ExpenseDetail', () => {
       await user.click(saveButton)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '저장되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '저장했어요')
       })
     })
 
@@ -311,7 +311,7 @@ describe('ExpenseDetail', () => {
       await user.click(modalDeleteButton)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '삭제되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '삭제했어요')
         expect(screen.getByText('지출 목록 페이지')).toBeInTheDocument()
       })
     })
@@ -382,7 +382,7 @@ describe('ExpenseDetail', () => {
       await user.click(submitBtn)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '반복 거래로 등록되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '정기 거래를 등록했어요')
       })
     })
   })
@@ -428,7 +428,7 @@ describe('ExpenseDetail', () => {
       await user.click(saveButton)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '이 항목을 수정할 권한이 없습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '권한이 없어요')
       })
     })
   })

--- a/frontend/src/pages/__tests__/ExpenseForm.test.tsx
+++ b/frontend/src/pages/__tests__/ExpenseForm.test.tsx
@@ -134,7 +134,7 @@ describe('ExpenseForm', () => {
       fireEvent.submit(submitBtn.closest('form')!)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', expect.stringContaining('저장되었습니다'))
+        expect(mockAddToast).toHaveBeenCalledWith('success', '저장했어요')
       })
     })
 
@@ -344,7 +344,7 @@ describe('ExpenseForm', () => {
         // 핵심 검증: date 필드에 반드시 T가 포함되어야 함
         // T가 없으면 백엔드에서 422 에러 발생 (Pydantic v2 datetime 파싱 실패)
         expect(capturedExpenseBody!['date']).toContain('T')
-        expect(mockAddToast).toHaveBeenCalledWith('success', expect.stringContaining('거래가 저장되었습니다'))
+        expect(mockAddToast).toHaveBeenCalledWith('success', '저장했어요')
       })
     })
 

--- a/frontend/src/pages/__tests__/HouseholdDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/HouseholdDetailPage.test.tsx
@@ -195,7 +195,7 @@ describe('HouseholdDetailPage', () => {
     storeState.error = '서버 에러'
     renderPage()
     expect(screen.getByText('홍길동')).toBeInTheDocument()
-    expect(addToast).toHaveBeenCalledWith('error', '처리에 실패했습니다')
+    expect(addToast).toHaveBeenCalledWith('error', '처리에 실패했어요')
     expect(clearError).toHaveBeenCalled()
   })
 
@@ -354,7 +354,7 @@ describe('HouseholdDetailPage', () => {
     await userEvent.click(submitBtn)
 
     await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith('warning', '이메일 발송에 실패하여 링크가 복사되었습니다')
+      expect(addToast).toHaveBeenCalledWith('warning', '초대 링크를 복사했어요')
     })
   })
 
@@ -386,7 +386,7 @@ describe('HouseholdDetailPage', () => {
       expect(window.confirm).toHaveBeenCalled()
       expect(mockRemoveMember).toHaveBeenCalledWith(1, 2)
     })
-    expect(addToast).toHaveBeenCalledWith('success', '멤버를 내보냈습니다')
+    expect(addToast).toHaveBeenCalledWith('success', '멤버를 내보냈어요')
   })
 
   it('내보내기 실패 시 에러 토스트를 표시한다', async () => {
@@ -396,7 +396,7 @@ describe('HouseholdDetailPage', () => {
     await userEvent.click(screen.getByText('내보내기'))
 
     await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith('error', '멤버 내보내기에 실패했습니다')
+      expect(addToast).toHaveBeenCalledWith('error', '처리에 실패했어요')
     })
   })
 
@@ -440,7 +440,7 @@ describe('HouseholdDetailPage', () => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
         expect.stringContaining('/invitations/accept?token=abc123'),
       )
-      expect(addToast).toHaveBeenCalledWith('success', '초대 링크가 복사되었습니다')
+      expect(addToast).toHaveBeenCalledWith('success', '초대 링크를 복사했어요')
     })
   })
 
@@ -460,7 +460,7 @@ describe('HouseholdDetailPage', () => {
 
     await waitFor(() => {
       expect(mockLeaveHousehold).toHaveBeenCalledWith(1)
-      expect(addToast).toHaveBeenCalledWith('success', '가구에서 탈퇴했습니다')
+      expect(addToast).toHaveBeenCalledWith('success', '가구를 나갔어요')
       expect(mockNavigate).toHaveBeenCalledWith('/households')
     })
   })
@@ -472,7 +472,7 @@ describe('HouseholdDetailPage', () => {
     await userEvent.click(screen.getByText('탈퇴'))
 
     await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith('error', '가구 탈퇴에 실패했습니다')
+      expect(addToast).toHaveBeenCalledWith('error', '처리에 실패했어요')
     })
   })
 
@@ -490,7 +490,7 @@ describe('HouseholdDetailPage', () => {
 
     await waitFor(() => {
       expect(mockDeleteHousehold).toHaveBeenCalledWith(1)
-      expect(addToast).toHaveBeenCalledWith('success', '가구가 삭제되었습니다')
+      expect(addToast).toHaveBeenCalledWith('success', '가구를 삭제했어요')
       expect(mockNavigate).toHaveBeenCalledWith('/households')
     })
   })
@@ -503,7 +503,7 @@ describe('HouseholdDetailPage', () => {
     await userEvent.click(screen.getByText('가구 삭제'))
 
     await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith('error', '가구 삭제에 실패했습니다')
+      expect(addToast).toHaveBeenCalledWith('error', '삭제에 실패했어요')
     })
   })
 
@@ -542,7 +542,7 @@ describe('HouseholdDetailPage', () => {
 
     await waitFor(() => {
       expect(mockUpdateMemberRole).toHaveBeenCalledWith(1, 2, 'admin')
-      expect(addToast).toHaveBeenCalledWith('success', '역할이 변경되었습니다')
+      expect(addToast).toHaveBeenCalledWith('success', '역할을 변경했어요')
     })
   })
 
@@ -554,7 +554,7 @@ describe('HouseholdDetailPage', () => {
     await userEvent.selectOptions(roleSelects[0], 'admin')
 
     await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith('error', '역할 변경에 실패했습니다')
+      expect(addToast).toHaveBeenCalledWith('error', '처리에 실패했어요')
     })
   })
 
@@ -606,7 +606,7 @@ describe('HouseholdDetailPage', () => {
     await userEvent.click(screen.getByText('취소'))
 
     await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith('error', '초대 취소에 실패했습니다')
+      expect(addToast).toHaveBeenCalledWith('error', '처리에 실패했어요')
     })
   })
 
@@ -628,7 +628,7 @@ describe('HouseholdDetailPage', () => {
     await userEvent.click(submitBtn)
 
     await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith('error', '멤버 초대에 실패했습니다')
+      expect(addToast).toHaveBeenCalledWith('error', '처리에 실패했어요')
     })
   })
 
@@ -652,7 +652,7 @@ describe('HouseholdDetailPage', () => {
 
     await waitFor(() => {
       expect(mockUpdateHousehold).toHaveBeenCalledWith(1, expect.objectContaining({ name: '새 이름' }))
-      expect(addToast).toHaveBeenCalledWith('success', '가구 정보가 수정되었습니다')
+      expect(addToast).toHaveBeenCalledWith('success', '가구 정보를 수정했어요')
     })
   })
 
@@ -666,7 +666,7 @@ describe('HouseholdDetailPage', () => {
     await userEvent.click(screen.getByText('저장'))
 
     await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith('error', '가구 수정에 실패했습니다')
+      expect(addToast).toHaveBeenCalledWith('error', '저장에 실패했어요')
     })
   })
 

--- a/frontend/src/pages/__tests__/HouseholdListPage.test.tsx
+++ b/frontend/src/pages/__tests__/HouseholdListPage.test.tsx
@@ -335,7 +335,7 @@ describe('HouseholdListPage', () => {
 
       await waitFor(() => {
         expect(mockCreateHousehold).toHaveBeenCalled()
-        expect(mockAddToast).toHaveBeenCalledWith('success', '가구가 생성되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '가구를 만들었어요')
         expect(mockNavigate).toHaveBeenCalledWith('/households/99')
       })
     })
@@ -359,7 +359,7 @@ describe('HouseholdListPage', () => {
       await user.click(createBtn)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '가구 생성에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '가구 생성에 실패했어요')
       })
     })
   })
@@ -374,7 +374,7 @@ describe('HouseholdListPage', () => {
 
       renderHouseholdList()
 
-      expect(mockAddToast).toHaveBeenCalledWith('error', '처리에 실패했습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('error', '처리에 실패했어요')
       expect(mockClearError).toHaveBeenCalled()
     })
   })

--- a/frontend/src/pages/__tests__/IncomeDetail.test.tsx
+++ b/frontend/src/pages/__tests__/IncomeDetail.test.tsx
@@ -127,7 +127,7 @@ describe('IncomeDetail', () => {
       await user.click(screen.getByRole('button', { name: '저장' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '저장되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '저장했어요')
       })
     })
 
@@ -288,7 +288,7 @@ describe('IncomeDetail', () => {
       await user.click(deleteButtons[deleteButtons.length - 1])
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '삭제되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '삭제했어요')
         expect(screen.getByText('수입 목록 페이지')).toBeInTheDocument()
       })
     })
@@ -336,7 +336,7 @@ describe('IncomeDetail', () => {
       await user.click(submitBtn)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '반복 거래로 등록되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '정기 거래를 등록했어요')
       })
     })
   })
@@ -380,7 +380,7 @@ describe('IncomeDetail', () => {
       await user.click(screen.getByRole('button', { name: '저장' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '이 항목을 수정할 권한이 없습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '권한이 없어요')
       })
     })
   })

--- a/frontend/src/pages/__tests__/IncomeForm.test.tsx
+++ b/frontend/src/pages/__tests__/IncomeForm.test.tsx
@@ -159,7 +159,7 @@ describe('IncomeForm', () => {
       fireEvent.submit(submitBtn.closest('form')!)
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '수입이 저장되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '저장했어요')
       })
     })
 
@@ -361,7 +361,7 @@ describe('IncomeForm', () => {
       await user.click(screen.getByText(/1건 저장하기/))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '수입이 저장되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '저장했어요')
       })
     })
   })

--- a/frontend/src/pages/__tests__/InvitationListPage.test.tsx
+++ b/frontend/src/pages/__tests__/InvitationListPage.test.tsx
@@ -270,7 +270,7 @@ describe('InvitationListPage', () => {
       await user.click(screen.getByRole('button', { name: '수락' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '테스트 가구 가구에 가입했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '테스트 가구에 참여했어요')
       })
     })
   })

--- a/frontend/src/pages/__tests__/OnboardingPage.test.tsx
+++ b/frontend/src/pages/__tests__/OnboardingPage.test.tsx
@@ -106,7 +106,7 @@ describe('OnboardingPage', () => {
       await user.click(screen.getByRole('button', { name: '새 가계부 만들기' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '가계부가 생성되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '가계부를 만들었어요')
         expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
       })
     })
@@ -119,7 +119,7 @@ describe('OnboardingPage', () => {
       await user.type(input, '엔터 테스트{Enter}')
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('success', '가계부가 생성되었습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '가계부를 만들었어요')
       })
     })
 
@@ -133,7 +133,7 @@ describe('OnboardingPage', () => {
       await user.click(screen.getByRole('button', { name: '새 가계부 만들기' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '가계부 생성에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '가계부 생성에 실패했어요')
       })
     })
   })
@@ -170,7 +170,7 @@ describe('OnboardingPage', () => {
 
       await waitFor(() => {
         expect(mockAcceptInvitation).toHaveBeenCalledWith('invite-token-abc')
-        expect(mockAddToast).toHaveBeenCalledWith('success', '부부 가계부에 참여했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('success', '부부 가계부에 참여했어요')
         expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
       })
     })
@@ -185,7 +185,7 @@ describe('OnboardingPage', () => {
       await user.click(screen.getByRole('button', { name: '참여' }))
 
       await waitFor(() => {
-        expect(mockAddToast).toHaveBeenCalledWith('error', '초대 수락에 실패했습니다')
+        expect(mockAddToast).toHaveBeenCalledWith('error', '초대 수락에 실패했어요')
       })
     })
   })

--- a/frontend/src/pages/__tests__/RecurringList.test.tsx
+++ b/frontend/src/pages/__tests__/RecurringList.test.tsx
@@ -216,7 +216,7 @@ describe('RecurringList', () => {
     await user.click(executeBtns[0])
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('success', '넷플릭스 등록되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '정기 거래를 실행했어요')
     })
   })
 
@@ -242,7 +242,7 @@ describe('RecurringList', () => {
     await user.click(pauseBtns[0])
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('success', '중지되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '상태를 변경했어요')
     })
   })
 
@@ -266,7 +266,7 @@ describe('RecurringList', () => {
     await user.click(playBtns[0])
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('success', '다시 시작되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '상태를 변경했어요')
     })
   })
 
@@ -290,7 +290,7 @@ describe('RecurringList', () => {
     await user.click(deleteBtns[0])
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('success', '반복 거래가 삭제되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '정기 거래를 삭제했어요')
     })
   })
 
@@ -312,7 +312,7 @@ describe('RecurringList', () => {
     await user.click(deleteBtns[0])
 
     // 삭제 토스트가 호출되지 않아야 함
-    expect(mockAddToast).not.toHaveBeenCalledWith('success', '반복 거래가 삭제되었습니다')
+    expect(mockAddToast).not.toHaveBeenCalledWith('success', '정기 거래를 삭제했어요')
   })
 
   // ==================== 수정 ====================
@@ -410,7 +410,7 @@ describe('RecurringList', () => {
     await user.click(executeBtns[0])
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('error', '등록에 실패했습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('error', '반복 거래 등록에 실패했어요')
     })
   })
 
@@ -434,7 +434,7 @@ describe('RecurringList', () => {
     await user.click(pauseBtns[0])
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('error', '변경에 실패했습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('error', '변경에 실패했어요')
     })
   })
 
@@ -468,7 +468,7 @@ describe('RecurringList', () => {
     await user.click(screen.getByText('추가하기'))
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('success', '반복 거래가 추가되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '정기 거래를 등록했어요')
     })
   })
 
@@ -497,7 +497,7 @@ describe('RecurringList', () => {
     await user.click(screen.getByText('수정하기'))
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('success', '반복 거래가 수정되었습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('success', '정기 거래를 수정했어요')
     })
   })
 
@@ -521,7 +521,7 @@ describe('RecurringList', () => {
     await user.click(deleteBtns[0])
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('error', '삭제에 실패했습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('error', '삭제에 실패했어요')
     })
   })
 
@@ -547,7 +547,7 @@ describe('RecurringList', () => {
     await user.click(screen.getByText('추가하기'))
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했습니다')
+      expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했어요')
     })
   })
 })


### PR DESCRIPTION
## Summary
기획서 기반 토스트 알림 전면 리디자인 (`docs/specs/2026-03-27-toast-redesign.md`)

- Pill shape + 다크 포도색 반투명 (`#1a1625/90`)
- lucide 아이콘 색상으로 타입 구분 (닫기 버튼 제거)
- 1개만 표시 (교체 방식), 하단 네비 위 72px
- 메시지 상수 모듈 (`constants/toastMessages.ts`) — 한 곳에서 관리
- 앱 전체 160개 addToast 호출 → 짧은 메시지 + "~했어요" 종결 통일

## Test plan
- [x] FE 1318 passed
- [x] 빌드 성공
- [ ] 라이트/다크 모드에서 토스트 가시성 확인
- [ ] 모바일에서 하단 네비와 안 겹치는지 확인

close #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)