### PR TITLE
feat: 퍼블릭 랜딩 페이지 — Google OAuth 심사 (#495)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,16 +27,17 @@ const AssetForm = lazy(() => import('./pages/AssetForm'))
 const AccountManager = lazy(() => import('./pages/AccountManager'))
 const PaymentMethodManager = lazy(() => import('./pages/PaymentMethodManager'))
 const TransactionList = lazy(() => import('./pages/TransactionList'))
+const LandingPage = lazy(() => import('./pages/LandingPage'))
 const GuidePage = lazy(() => import('./pages/GuidePage'))
 const FeedbackPage = lazy(() => import('./pages/FeedbackPage'))
 const AdminPage = lazy(() => import('./pages/AdminPage'))
 const OnboardingPage = lazy(() => import('./pages/OnboardingPage'))
 
-/* /transactions → / 쿼리 보존 리다이렉트 */
+/* /transactions → /home 쿼리 보존 리다이렉트 */
 function TransactionsRedirect() {
   const [searchParams] = useSearchParams()
   const query = searchParams.toString()
-  return <Navigate to={query ? `/?${query}` : '/'} replace />
+  return <Navigate to={query ? `/home?${query}` : '/home'} replace />
 }
 
 /* 로딩 스피너 */
@@ -80,6 +81,8 @@ function App() {
     <Suspense fallback={<PageLoading />}>
       <ScrollToTop />
       <Routes>
+        {/* 퍼블릭 랜딩 페이지 — 로그인 상태면 /home으로 자동 리디렉션 (#495) */}
+        <Route path="/" element={<LandingPage />} />
         {/* podo-auth SSO 콜백 */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
@@ -90,12 +93,12 @@ function App() {
           <Route path="onboarding" element={<OnboardingPage />} />
           <Route path="/invitations/accept" element={<AcceptInvitationPage />} />
           <Route element={<Layout />}>
-            <Route path="/" element={<TransactionList />} />
+            <Route path="/home" element={<TransactionList />} />
             <Route path="/transactions" element={<TransactionsRedirect />} />
-            <Route path="/expenses" element={<Navigate to="/?filter=expense" replace />} />
+            <Route path="/expenses" element={<Navigate to="/home?filter=expense" replace />} />
             <Route path="/expenses/new" element={<ExpenseForm />} />
             <Route path="/expenses/:id" element={<ExpenseDetail />} />
-            <Route path="/income" element={<Navigate to="/?filter=income" replace />} />
+            <Route path="/income" element={<Navigate to="/home?filter=income" replace />} />
             <Route path="/income/new" element={<IncomeForm />} />
             <Route path="/income/:id" element={<IncomeDetail />} />
             <Route path="/categories" element={<CategoryManager />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -16,7 +16,7 @@ import { trackPageView } from '../utils/analytics'
 
 
 const navItems: { path: string; label: string; icon: LucideIcon }[] = [
-  { path: '/', label: '가계부', icon: Receipt },
+  { path: '/home', label: '가계부', icon: Receipt },
   { path: '/assets', label: '자산', icon: Landmark },
   { path: '/insights', label: '돌아보기', icon: TrendingUp },
   { path: '/settings', label: '더보기', icon: SettingsIcon },
@@ -51,7 +51,7 @@ export default function Layout() {
   const activeHousehold = households.find(h => h.id === activeHouseholdId)
 
   const isActive = (path: string) =>
-    path === '/' ? location.pathname === '/' : location.pathname.startsWith(path)
+    path === '/home' ? location.pathname === '/home' : location.pathname.startsWith(path)
 
   const isDev = import.meta.env.VITE_SENTRY_ENVIRONMENT === 'development'
 
@@ -110,7 +110,7 @@ export default function Layout() {
         <aside className="hidden md:flex md:sticky md:top-0 md:h-screen w-60 bg-[var(--surface)] border-r border-[var(--border-default)] p-4 flex-col">
           {/* 앱 타이틀 */}
           <div className="mb-4">
-            <Link to="/" className="text-2xl font-bold text-grape-600 flex items-center gap-2"><img src="/favicon-book-192.png" alt="" className="w-8 h-8" />포도가계부</Link>
+            <Link to="/home" className="text-2xl font-bold text-grape-600 flex items-center gap-2"><img src="/favicon-book-192.png" alt="" className="w-8 h-8" />포도가계부</Link>
           </div>
 
           {/* 가구 선택 드롭다운 */}

--- a/frontend/src/components/__tests__/Layout.test.tsx
+++ b/frontend/src/components/__tests__/Layout.test.tsx
@@ -46,7 +46,7 @@ vi.mock('../../stores/useHouseholdStore', () => ({
 /**
  * Layout 컴포넌트를 MemoryRouter로 감싸서 렌더링하는 헬퍼 함수
  */
-function renderLayout(initialPath = '/') {
+function renderLayout(initialPath = '/home') {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Layout />
@@ -84,7 +84,7 @@ describe('Layout', () => {
     })
 
     it('현재 경로에 해당하는 네비게이션 항목에 aria-current를 설정한다', () => {
-      renderLayout('/')
+      renderLayout('/home')
       const transactionLinks = screen.getAllByRole('link', { name: '가계부' })
       transactionLinks.forEach(link => {
         expect(link).toHaveAttribute('aria-current', 'page')
@@ -92,7 +92,7 @@ describe('Layout', () => {
     })
 
     it('다른 경로의 네비게이션 항목에는 aria-current가 없다', () => {
-      renderLayout('/')
+      renderLayout('/home')
       const reportLinks = screen.getAllByRole('link', { name: /돌아보기/i })
       reportLinks.forEach(link => {
         expect(link).not.toHaveAttribute('aria-current')

--- a/frontend/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/__tests__/ProtectedRoute.test.tsx
@@ -37,13 +37,13 @@ vi.mock('../../stores/useHouseholdStore', () => ({
   ),
 }))
 
-function renderWithRouter(initialPath = '/') {
+function renderWithRouter(initialPath = '/home') {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="/login" element={<div data-testid="login-page">로그인</div>} />
         <Route element={<ProtectedRoute />}>
-          <Route path="/" element={<div data-testid="home-page">홈</div>} />
+          <Route path="/home" element={<div data-testid="home-page">홈</div>} />
         </Route>
       </Routes>
     </MemoryRouter>
@@ -61,7 +61,7 @@ describe('ProtectedRoute', () => {
     mockAuth.isAuthenticated = false
     mockAuth.loading = false
 
-    renderWithRouter('/')
+    renderWithRouter('/home')
 
     await waitFor(() => {
       expect(screen.getByTestId('login-page')).toBeInTheDocument()
@@ -72,7 +72,7 @@ describe('ProtectedRoute', () => {
     mockAuth.isAuthenticated = true
     mockAuth.loading = false
 
-    renderWithRouter('/')
+    renderWithRouter('/home')
 
     await waitFor(() => {
       expect(screen.getByTestId('home-page')).toBeInTheDocument()
@@ -83,7 +83,7 @@ describe('ProtectedRoute', () => {
     mockAuth.isAuthenticated = false
     mockAuth.loading = true
 
-    renderWithRouter('/')
+    renderWithRouter('/home')
 
     // 로딩 스피너 (포도 로고 이미지)
     expect(screen.getByAltText('포도가계부')).toBeInTheDocument()

--- a/frontend/src/components/settings/__tests__/ChangelogSection.test.tsx
+++ b/frontend/src/components/settings/__tests__/ChangelogSection.test.tsx
@@ -77,7 +77,8 @@ describe('ChangelogSection 컴포넌트', () => {
   it('날짜를 표시한다', () => {
     renderChangelog()
     changelogs.forEach((log) => {
-      expect(screen.getByText(log.date)).toBeInTheDocument()
+      const elements = screen.getAllByText(log.date)
+      expect(elements.length).toBeGreaterThan(0)
     })
   })
 })

--- a/frontend/src/components/transaction/__tests__/MonthlyView.test.tsx
+++ b/frontend/src/components/transaction/__tests__/MonthlyView.test.tsx
@@ -38,7 +38,7 @@ vi.mock('../../../contexts/AuthContext', () => ({
   }),
 }))
 
-function renderPage(initialRoute = '/') {
+function renderPage(initialRoute = '/home') {
   return render(
     <MemoryRouter initialEntries={[initialRoute]}>
       <TransactionList />

--- a/frontend/src/data/changelogs.ts
+++ b/frontend/src/data/changelogs.ts
@@ -18,6 +18,14 @@ export interface Changelog {
 
 export const changelogs: Changelog[] = [
   {
+    version: '0.13.0',
+    date: '2026-03-27',
+    title: '퍼블릭 랜딩 페이지',
+    items: [
+      { tag: '신규', text: '앱 소개 랜딩 페이지 추가 — 비로그인 사용자에게 기능 안내' },
+    ],
+  },
+  {
     version: '0.12.0',
     date: '2026-03-27',
     title: '결제수단 UX 개선',

--- a/frontend/src/hooks/__tests__/useGoBack.test.ts
+++ b/frontend/src/hooks/__tests__/useGoBack.test.ts
@@ -39,7 +39,7 @@ describe('useGoBack', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/settings')
   })
 
-  it('fallback 기본값은 /', () => {
+  it('fallback 기본값은 /home', () => {
     Object.defineProperty(window, 'history', {
       value: { length: 1 },
       writable: true,
@@ -48,6 +48,6 @@ describe('useGoBack', () => {
     const { result } = renderHook(() => useGoBack())
     act(() => result.current())
 
-    expect(mockNavigate).toHaveBeenCalledWith('/')
+    expect(mockNavigate).toHaveBeenCalledWith('/home')
   })
 })

--- a/frontend/src/hooks/useGoBack.ts
+++ b/frontend/src/hooks/useGoBack.ts
@@ -7,7 +7,7 @@
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-export function useGoBack(fallback: string = '/') {
+export function useGoBack(fallback: string = '/home') {
   const navigate = useNavigate()
 
   return useCallback(() => {

--- a/frontend/src/pages/AcceptInvitationPage.tsx
+++ b/frontend/src/pages/AcceptInvitationPage.tsx
@@ -42,7 +42,7 @@ export default function AcceptInvitationPage() {
     try {
       const result = await acceptInvitation(token)
       addToast('success', TOAST.HOUSEHOLD_JOINED(result.household_name))
-      navigate('/', { replace: true })
+      navigate('/home', { replace: true })
     } catch (err) {
       console.error('초대 수락 실패:', err)
       setError('초대 수락에 실패했습니다. 초대가 만료되었거나 이미 처리되었을 수 있습니다.')
@@ -68,7 +68,7 @@ export default function AcceptInvitationPage() {
     try {
       await rejectInvitation(token)
       addToast('success', TOAST.INVITE_REJECTED)
-      navigate('/', { replace: true })
+      navigate('/home', { replace: true })
     } catch (err) {
       console.error('초대 거절 실패:', err)
       setError('초대 거절에 실패했습니다')
@@ -88,7 +88,7 @@ export default function AcceptInvitationPage() {
           <h1 className="text-xl font-bold text-[var(--text-primary)]">유효하지 않은 초대 링크입니다</h1>
           <p className="text-sm text-[var(--text-tertiary)]">초대 링크가 올바르지 않습니다. 초대를 보낸 사람에게 다시 요청해주세요.</p>
           <button
-            onClick={() => navigate('/')}
+            onClick={() => navigate('/home')}
             className="px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700"
           >
             홈으로
@@ -107,7 +107,7 @@ export default function AcceptInvitationPage() {
           <h1 className="text-xl font-bold text-[var(--text-primary)]">초대 처리에 실패했습니다</h1>
           <p className="text-sm text-[var(--text-tertiary)]">{error}</p>
           <button
-            onClick={() => navigate('/')}
+            onClick={() => navigate('/home')}
             className="px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700"
           >
             홈으로
@@ -165,7 +165,7 @@ export default function AcceptInvitationPage() {
           </button>
 
           <button
-            onClick={() => navigate('/')}
+            onClick={() => navigate('/home')}
             disabled={isProcessing}
             className="w-full px-4 py-3 text-sm font-medium text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -46,7 +46,7 @@ export default function AuthCallbackPage() {
   useEffect(() => {
     if (isAuthenticated && !isRecovery) {
       trackEvent('login')
-      const intendedPath = sessionStorage.getItem('intended_path') || '/'
+      const intendedPath = sessionStorage.getItem('intended_path') || '/home'
       sessionStorage.removeItem('intended_path')
       navigate(intendedPath, { replace: true })
     }
@@ -67,7 +67,7 @@ export default function AuthCallbackPage() {
       if (updateError) throw updateError
 
       addToast('success', TOAST.PASSWORD_CHANGED)
-      navigate('/', { replace: true })
+      navigate('/home', { replace: true })
     } catch (err) {
       const message = (err as Error).message
       if (message.includes('should be at least')) {

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -318,7 +318,7 @@ export default function InsightsPage() {
         <EmptyState
           title="이번 달 거래 내역이 없습니다"
           description="가계부에 수입이나 지출을 기록하면 리포트가 생성됩니다"
-          action={{ label: '가계부로 이동', onClick: () => navigate('/') }}
+          action={{ label: '가계부로 이동', onClick: () => navigate('/home') }}
         />
       )}
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,125 @@
+/**
+ * @file LandingPage.tsx
+ * @description 퍼블릭 랜딩 페이지 — Google OAuth 심사 충족 (#495)
+ *
+ * 미인증 사용자에게 앱 소개를 보여주는 퍼블릭 페이지.
+ * 이미 로그인된 상태면 /home으로 자동 리디렉션.
+ * Grape 디자인 시스템 + 모바일 퍼스트 반응형.
+ */
+
+import { useEffect } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+const FEATURES = [
+  {
+    icon: '\uD83D\uDDE3\uFE0F',
+    title: '자연어 입력',
+    description: '"점심 김치찌개 8000원" 한 줄이면 끝',
+  },
+  {
+    icon: '\uD83E\uDD16',
+    title: 'AI 자동 분류',
+    description: '카테고리, 날짜를 자동으로 인식',
+  },
+  {
+    icon: '\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67',
+    title: '공유 가계부',
+    description: '가족과 함께 기록하고 관리',
+  },
+  {
+    icon: '\uD83D\uDCCA',
+    title: '리포트',
+    description: '월간 소비 패턴과 AI 인사이트',
+  },
+] as const
+
+export default function LandingPage() {
+  const { isAuthenticated, loading } = useAuth()
+  const navigate = useNavigate()
+
+  /* 이미 로그인 상태면 /home으로 리디렉션 */
+  useEffect(() => {
+    if (!loading && isAuthenticated) {
+      navigate('/home', { replace: true })
+    }
+  }, [isAuthenticated, loading, navigate])
+
+  /* 인증 체크 중에는 아무것도 렌더링하지 않음 (깜빡임 방지) */
+  if (loading || isAuthenticated) {
+    return null
+  }
+
+  return (
+    <div className="min-h-screen bg-cream dark:bg-warm-900 flex flex-col">
+      {/* 헤더 */}
+      <header className="flex items-center justify-between px-4 py-3 md:px-8 md:py-4">
+        <div className="flex items-center gap-2">
+          <img src="/favicon-book-192.png" alt="" className="w-8 h-8" />
+          <span className="text-lg font-bold text-grape-600">포도가계부</span>
+        </div>
+        <Link
+          to="/login"
+          className="px-4 py-2 text-sm font-medium text-grape-600 border border-grape-300 rounded-lg hover:bg-grape-50 dark:hover:bg-grape-900/20 transition-colors"
+        >
+          로그인
+        </Link>
+      </header>
+
+      {/* 히어로 섹션 */}
+      <section className="flex-1 flex flex-col items-center justify-center text-center px-4 py-16 md:py-24">
+        <img
+          src="/logo-transparent-192.png"
+          alt="포도가계부"
+          className="w-20 h-20 md:w-24 md:h-24 mb-6"
+        />
+        <h1 className="text-2xl md:text-4xl font-bold text-[var(--text-primary)] mb-3 leading-snug">
+          포도알처럼 하나씩,
+          <br />
+          알찬 가계부
+        </h1>
+        <p className="text-sm md:text-base text-[var(--text-tertiary)] mb-8 max-w-md">
+          자연어로 말하면 AI가 알아서 분류하는 가계부
+        </p>
+        <Link
+          to="/login"
+          className="px-8 py-3 bg-grape-600 text-white text-sm md:text-base font-semibold rounded-xl hover:bg-grape-700 active:scale-[0.98] transition-all shadow-sm"
+        >
+          시작하기
+        </Link>
+      </section>
+
+      {/* 기능 소개 섹션 */}
+      <section className="px-4 pb-16 md:px-8 md:pb-24">
+        <div className="max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6">
+          {FEATURES.map((feature) => (
+            <div
+              key={feature.title}
+              className="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)] p-5 md:p-6"
+            >
+              <div className="text-3xl mb-3">{feature.icon}</div>
+              <h3 className="text-base font-semibold text-[var(--text-primary)] mb-1">
+                {feature.title}
+              </h3>
+              <p className="text-sm text-[var(--text-tertiary)]">
+                {feature.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* 푸터 */}
+      <footer className="border-t border-[var(--border-default)] px-4 py-6 md:px-8">
+        <div className="max-w-3xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-3 text-xs text-[var(--text-muted)]">
+          <div className="flex items-center gap-3">
+            <Link to="/privacy" className="hover:underline">개인정보처리방침</Link>
+            <span>|</span>
+            <Link to="/terms" className="hover:underline">이용약관</Link>
+          </div>
+          <span>&copy; 2026 포도가계부</span>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -66,7 +66,7 @@ export default function LoginPage() {
       localStorage.setItem(LAST_LOGIN_KEY, 'email')
 
       // 로그인 성공 → intended path로 이동
-      const intendedPath = sessionStorage.getItem('intended_path') || '/'
+      const intendedPath = sessionStorage.getItem('intended_path') || '/home'
       sessionStorage.removeItem('intended_path')
       navigate(intendedPath, { replace: true })
     } catch (err) {

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -11,7 +11,7 @@ export default function NotFoundPage() {
           페이지를 찾을 수 없습니다
         </p>
         <Link
-          to="/"
+          to="/home"
           className="inline-flex items-center gap-2 bg-grape-600 text-white px-6 py-3 rounded-xl font-semibold hover:bg-grape-700 active:scale-[0.98] transition-all"
         >
           <Home className="w-5 h-5" />

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -31,7 +31,7 @@ export default function OnboardingPage() {
       await fetchHouseholds()
       addToast('success', TOAST.ONBOARDING_CREATED)
       trackEvent('onboarding_complete', { method: 'create' })
-      navigate('/', { replace: true })
+      navigate('/home', { replace: true })
     } catch {
       addToast('error', TOAST.ONBOARDING_FAILED)
     } finally {
@@ -46,7 +46,7 @@ export default function OnboardingPage() {
       await acceptInvitation(token)
       addToast('success', TOAST.HOUSEHOLD_JOINED(householdName || '가계부'))
       trackEvent('onboarding_complete', { method: 'accept_invitation' })
-      navigate('/', { replace: true })
+      navigate('/home', { replace: true })
     } catch {
       addToast('error', TOAST.INVITE_ACCEPT_FAILED)
       // 실패 시 초대 목록 새로고침 (만료 등)

--- a/frontend/src/pages/__tests__/AcceptInvitationPage.test.tsx
+++ b/frontend/src/pages/__tests__/AcceptInvitationPage.test.tsx
@@ -43,7 +43,7 @@ function renderWithToken(token?: string) {
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/invitations/accept" element={<AcceptInvitationPage />} />
-        <Route path="/" element={<div>홈 페이지</div>} />
+        <Route path="/home" element={<div>홈 페이지</div>} />
       </Routes>
     </MemoryRouter>
   )

--- a/frontend/src/pages/__tests__/AuthCallbackPage.test.tsx
+++ b/frontend/src/pages/__tests__/AuthCallbackPage.test.tsx
@@ -50,7 +50,7 @@ function renderCallbackPage(initialPath = '/auth/callback') {
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
-        <Route path="/" element={<div data-testid="home">홈</div>} />
+        <Route path="/home" element={<div data-testid="home">홈</div>} />
       </Routes>
     </MemoryRouter>
   )

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -172,7 +172,7 @@ describe('LoginPage', () => {
           email: 'test@test.com',
           password: 'password123',  // pragma: allowlist secret
         })
-        expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+        expect(mockNavigate).toHaveBeenCalledWith('/home', { replace: true })
       })
     })
 
@@ -275,7 +275,7 @@ describe('LoginPage', () => {
           password: 'password123',
           options: { data: { name: '홍길동' } },
         })
-        expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+        expect(mockNavigate).toHaveBeenCalledWith('/home', { replace: true })
       })
     })
 

--- a/frontend/src/pages/__tests__/OnboardingPage.test.tsx
+++ b/frontend/src/pages/__tests__/OnboardingPage.test.tsx
@@ -107,7 +107,7 @@ describe('OnboardingPage', () => {
 
       await waitFor(() => {
         expect(mockAddToast).toHaveBeenCalledWith('success', '가계부를 만들었어요')
-        expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+        expect(mockNavigate).toHaveBeenCalledWith('/home', { replace: true })
       })
     })
 
@@ -171,7 +171,7 @@ describe('OnboardingPage', () => {
       await waitFor(() => {
         expect(mockAcceptInvitation).toHaveBeenCalledWith('invite-token-abc')
         expect(mockAddToast).toHaveBeenCalledWith('success', '부부 가계부에 참여했어요')
-        expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true })
+        expect(mockNavigate).toHaveBeenCalledWith('/home', { replace: true })
       })
     })
 

--- a/frontend/src/pages/__tests__/TransactionList.test.tsx
+++ b/frontend/src/pages/__tests__/TransactionList.test.tsx
@@ -39,7 +39,7 @@ vi.mock('../../contexts/AuthContext', () => ({
 }))
 
 
-function renderPage(initialRoute = '/') {
+function renderPage(initialRoute = '/home') {
   return render(
     <MemoryRouter initialEntries={[initialRoute]}>
       <TransactionList />


### PR DESCRIPTION
## Summary

Google OAuth 심사 요구사항: "로그인 없이 앱 정보를 볼 수 있어야 함"

### 변경
- `/` → LandingPage (퍼블릭, 앱 소개)
- `/home` → TransactionList (기존 `/` 대체)
- 이미 로그인 → `/` 접속 시 `/home` 자동 리디렉션
- 기존 URL 전부 유지

### 랜딩 페이지 구성
- 히어로: 앱 이름 + 설명 + [시작하기] CTA
- 기능 카드: 자연어 입력, AI 분류, 공유 가계부, 리포트
- 푸터: 개인정보처리방침 + 이용약관

## Test plan

- [x] 1318 tests passed
- [x] lint 0 에러, build 성공
- [ ] CI 통과

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)