### PR TITLE
hotfix: 랜딩페이지 다크모드 비활성화

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -20,6 +20,22 @@ export default function LandingPage() {
     }
   }, [isAuthenticated, loading, navigate])
 
+  // 랜딩페이지는 항상 라이트 모드
+  useEffect(() => {
+    const html = document.documentElement
+    const wasDark = html.classList.contains('dark')
+    if (wasDark) {
+      html.classList.remove('dark')
+      html.style.backgroundColor = '#fefce8'
+    }
+    return () => {
+      if (wasDark) {
+        html.classList.add('dark')
+        html.style.backgroundColor = '#1a1625'
+      }
+    }
+  }, [])
+
   if (loading || isAuthenticated) {
     return null
   }


### PR DESCRIPTION
랜딩페이지 진입 시 dark 클래스 제거, 떠날 때 복원. 랜딩은 항상 라이트 모드 고정.