### PR TITLE
fix: 홈 히어로 개선 + 자산탭 패딩 + PWA 캐시 버스팅

### DIFF
--- a/frontend/src/components/transaction/MonthlyView.tsx
+++ b/frontend/src/components/transaction/MonthlyView.tsx
@@ -36,6 +36,8 @@ interface MonthlyViewProps {
   onBotNudgeDismiss: () => void
   /** 멀티멤버 가구의 user_id → username 매핑 (단독 가구는 null) */
   memberMap: Map<number, string> | null
+  /** 월 총 예산 (null이면 미설정) */
+  totalBudget: number | null
 }
 
 export default function MonthlyView({
@@ -49,6 +51,7 @@ export default function MonthlyView({
   botNudgeDismissed,
   onBotNudgeDismiss,
   memberMap,
+  totalBudget,
 }: MonthlyViewProps) {
   const { addToast } = useToast()
 
@@ -102,35 +105,14 @@ export default function MonthlyView({
       <HeroSummary
         label={`${monthly.currentMonth + 1}월 지출`}
         amount={monthly.totalExpense}
-        sublabel={`수입 ${formatAmount(monthly.totalIncome)} · 잔액 ${formatAmount(monthly.totalIncome - monthly.totalExpense)}`}
+        sublabel={
+          totalBudget != null && totalBudget > 0
+            ? `예산 대비 ${Math.round((monthly.totalExpense / totalBudget) * 100)}%`
+            : monthly.totalIncome > 0
+              ? `수입 대비 ${Math.round((monthly.totalExpense / monthly.totalIncome) * 100)}%`
+              : undefined
+        }
       />
-
-      {/* 요약 + 필터 */}
-      <div className="flex items-center justify-center gap-6">
-        <button
-          onClick={() => monthly.toggleFilter('expense')}
-          className={`text-center transition-opacity ${
-            monthly.filter === 'income' ? 'opacity-40' : ''
-          }`}
-        >
-          <div className="text-xs text-[var(--text-tertiary)]">지출</div>
-          <div className={`text-base font-bold ${monthly.filter !== 'income' ? 'text-grape-600' : 'text-[var(--text-muted)]'}`}>
-            {formatAmount(monthly.totalExpense)}
-          </div>
-        </button>
-        <div className="w-px h-8 bg-[var(--border-default)]" />
-        <button
-          onClick={() => monthly.toggleFilter('income')}
-          className={`text-center transition-opacity ${
-            monthly.filter === 'expense' ? 'opacity-40' : ''
-          }`}
-        >
-          <div className="text-xs text-[var(--text-tertiary)]">수입</div>
-          <div className={`text-base font-bold ${monthly.filter !== 'expense' ? 'text-leaf-600' : 'text-[var(--text-muted)]'}`}>
-            {formatAmount(monthly.totalIncome)}
-          </div>
-        </button>
-      </div>
 
       {/* 온보딩 웰컴 카드 */}
       {!welcomeDismissed && !monthly.loading && (
@@ -174,6 +156,33 @@ export default function MonthlyView({
           </button>
         </div>
       )}
+
+      {/* 세그먼트 필터 — 캘린더 아래, 리스트 바로 위 */}
+      <div className="flex items-center bg-[var(--surface-elevated)] rounded-lg p-1">
+        {(['all', 'expense', 'income'] as const).map((type) => {
+          const label = type === 'all' ? '전체' : type === 'expense' ? '지출' : '수입'
+          const isActive = type === 'all' ? monthly.filter === 'all' : monthly.filter === type
+          return (
+            <button
+              key={type}
+              onClick={() => {
+                if (type === 'all') {
+                  if (monthly.filter !== 'all') monthly.toggleFilter(monthly.filter as 'expense' | 'income')
+                } else {
+                  monthly.toggleFilter(type)
+                }
+              }}
+              className={`flex-1 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                isActive
+                  ? 'bg-[var(--surface-card)] text-[var(--text-primary)] shadow-sm'
+                  : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+              }`}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </div>
 
       {/* 예정 거래 섹션 — 캘린더 아래, 거래 리스트 위 */}
       <ScheduledTransactions

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -416,6 +416,13 @@ export const handlers = [
   }),
 
   /**
+   * GET /api/budgets/total-budget - 월 총 예산 조회
+   */
+  http.get(`${BASE_URL}/budgets/total-budget`, () => {
+    return HttpResponse.json({ total_monthly_budget: null })
+  }),
+
+  /**
    * GET /api/budgets/monthly-stats - 월별 예산 대비 지출 통계
    */
   http.get(`${BASE_URL}/budgets/monthly-stats`, () => {

--- a/frontend/src/pages/AssetDashboard.tsx
+++ b/frontend/src/pages/AssetDashboard.tsx
@@ -23,7 +23,7 @@ import type { Asset, AssetSummary, AssetSnapshot, AssetGoal, MonthlySavings, Ass
 /** 자산 대시보드 로딩 스켈레톤 */
 function AssetDashboardSkeleton() {
   return (
-    <div className="space-y-4 px-4 py-6">
+    <div className="space-y-4 py-6">
       {/* 순자산 히어로 골격 */}
       <div className="card-surface p-6 space-y-3">
         <Skeleton className="h-4 w-24" />
@@ -151,7 +151,7 @@ export default function AssetDashboard() {
   // 빈 상태 — 온보딩
   if (assets.length === 0) {
     return (
-      <div className="px-4 py-6">
+      <div className="py-6">
         <AssetOnboarding onAdd={handleAddAsset} />
       </div>
     )
@@ -183,7 +183,7 @@ export default function AssetDashboard() {
     : null
 
   return (
-    <div className="space-y-4 px-4 py-6 animate-page-in animate-stagger">
+    <div className="space-y-4 py-6 animate-page-in animate-stagger">
       <NetWorthHero
         netWorth={netWorth}
         totalAssets={totalAssets}

--- a/frontend/src/pages/TransactionList.tsx
+++ b/frontend/src/pages/TransactionList.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react'
 import { expenseApi } from '../api/expenses'
 import { incomeApi } from '../api/income'
+import budgetApi from '../api/budgets'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
 import { TOAST } from '../constants/toastMessages'
@@ -57,6 +58,15 @@ export default function TransactionList() {
     localStorage.getItem('podo-welcome-dismissed') === 'true'
   )
   const [totalTransactionCount, setTotalTransactionCount] = useState(0)
+
+  // 월 총 예산
+  const [totalBudget, setTotalBudget] = useState<number | null>(null)
+  useEffect(() => {
+    if (!activeHouseholdId) return
+    budgetApi.getTotalBudget()
+      .then(res => setTotalBudget(res.data.total_monthly_budget))
+      .catch(() => setTotalBudget(null))
+  }, [activeHouseholdId])
 
   // 봇 넛지 카드 상태
   const isBotLinked = !!user?.is_telegram_linked || !!user?.is_kakao_linked
@@ -207,6 +217,7 @@ export default function TransactionList() {
           botNudgeDismissed={botNudgeDismissed}
           onBotNudgeDismiss={handleBotNudgeDismiss}
           memberMap={memberMap}
+          totalBudget={totalBudget}
         />
       )}
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
       },
       workbox: {
         // 캐시 이름 버전 업 → 구 SW 캐시 강제 제거 (API 캐시 제거 포함)
-        cacheId: 'podo-budget-v14',
+        cacheId: 'podo-budget-v15',
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
         // 새 SW가 즉시 활성화되도록 설정 (기본: 모든 탭 닫힐 때까지 대기)
         skipWaiting: true,


### PR DESCRIPTION
## Summary

- **홈 히어로 sublabel**: 수입/잔액 텍스트 → 예산 대비 % (없으면 수입 대비 %)
- **홈 필터**: 금액 포함 토글 버튼 제거 → 텍스트 세그먼트 컨트롤 (캘린더 아래)
- **자산탭**: Layout p-4와 이중 적용되던 px-4 제거 (카드 너비 정상화)
- **PWA**: cacheId v14 → v15 (HIG 대규모 변경 후 서비스 워커 캐시 충돌 방지)

## Test plan

- [x] 전체 테스트 1365개 PASS
- [x] 빌드 성공
- [ ] 모바일에서 돌아보기/자산탭 에러 재현 확인 (캐시 버스팅 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)