### PR TITLE
hotfix: Alembic 마이그레이션 async event loop 충돌 수정

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -113,7 +113,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
         # MIGRATION_DATABASE_URL(Direct connection) 우선, 없으면 DATABASE_URL
         migration_url = settings.MIGRATION_DATABASE_URL or settings.DATABASE_URL
-        connect_args: dict[str, int] = {} if settings.MIGRATION_DATABASE_URL else {"prepared_statement_cache_size": 0, "statement_cache_size": 0}
+        # pgbouncer(transaction pooler) 경유 시 prepared statement 캐시 비활성화
+        # SQLite(E2E/테스트)에서는 지원하지 않는 옵션이므로 PostgreSQL만 적용
+        use_pg_pooler_args = not settings.MIGRATION_DATABASE_URL and "postgresql" in migration_url
+        connect_args: dict[str, int] = {"prepared_statement_cache_size": 0, "statement_cache_size": 0} if use_pg_pooler_args else {}
 
         engine = create_async_engine(migration_url, poolclass=pool.NullPool, connect_args=connect_args)
 


### PR DESCRIPTION
## Summary
- lifespan(async context) 안에서 `alembic_command.upgrade()`가 내부적으로 `asyncio.run()` 호출 → nested event loop 충돌
- 코루틴이 await 되지 않아 마이그레이션이 조용히 실패, 새 컬럼(`original_amount`) 미생성으로 자산 탭 DB 에러 발생
- SQLAlchemy async engine으로 직접 마이그레이션 실행하도록 변경, 메모리 최적화 유지

## Root Cause
```
RuntimeWarning: coroutine 'run_async_migrations' was never awaited
```
`alembic_command.upgrade()` → `env.py:run_migrations_online()` → `asyncio.run(run_async_migrations())` — 이미 돌고 있는 event loop 안에서 `asyncio.run()` 호출 불가

## Fix
alembic Python API를 우회하고 `create_async_engine` + `connection.run_sync(do_run_migrations)`로 직접 실행

## Test plan
- [x] 백엔드 테스트 1664 passed
- [ ] 운영 배포 후 fly logs에서 "Alembic 마이그레이션 완료" 로그 확인

close #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)