### PR TITLE
feat: 검색 기간 직접 입력

### DIFF
--- a/frontend/src/components/transaction/SearchMode.tsx
+++ b/frontend/src/components/transaction/SearchMode.tsx
@@ -6,7 +6,7 @@
 
 /* eslint-disable react-hooks/refs -- search 훅이 반환하는 객체 내 refs와 값을 함께 사용하므로 린터 오탐 발생 */
 
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Search, X } from 'lucide-react'
 import EmptyState from '../EmptyState'
 import TransactionItem from '../TransactionItem'
@@ -43,6 +43,23 @@ export default function SearchMode({
     }
     return '카테고리'
   }, [search.searchCategoryId, monthly.categoryMap])
+
+  // 기간 직접 입력 — 로컬 상태 (URL에는 적용 버튼 클릭 시 반영)
+  const [localStart, setLocalStart] = useState(search.searchStartDate)
+  const [localEnd, setLocalEnd] = useState(search.searchEndDate)
+
+  // 기간 칩 라벨
+  const periodChipLabel = useMemo(() => {
+    if (search.searchPeriod === 'custom') {
+      if (search.searchStartDate || search.searchEndDate) {
+        // YYYY-MM-DD → MM.DD 형식으로 축약
+        const fmt = (d: string) => d ? d.slice(5).replace('-', '.') : '?'
+        return `${fmt(search.searchStartDate)} ~ ${fmt(search.searchEndDate)}`
+      }
+      return '직접 입력'
+    }
+    return { all: '기간: 전체', '1m': '최근 1개월', '3m': '최근 3개월', '6m': '최근 6개월', year: '올해' }[search.searchPeriod] ?? '기간'
+  }, [search.searchPeriod, search.searchStartDate, search.searchEndDate])
 
   return (
     <>
@@ -134,7 +151,7 @@ export default function SearchMode({
                 : 'bg-[var(--surface-hover)] text-[var(--text-secondary)]'
             }`}
           >
-            {{ all: '기간: 전체', '1m': '최근 1개월', '3m': '최근 3개월', '6m': '최근 6개월', year: '올해' }[search.searchPeriod]}
+            {periodChipLabel}
           </button>
           {search.openFilter === 'period' && (
             <div className="absolute top-full left-0 mt-1 bg-[var(--surface-card)] rounded-xl shadow-lg border border-[var(--border-default)] py-1 z-20 min-w-[130px]">
@@ -144,6 +161,7 @@ export default function SearchMode({
                 { value: '3m', label: '최근 3개월' },
                 { value: '6m', label: '최근 6개월' },
                 { value: 'year', label: '올해' },
+                { value: 'custom', label: '직접 입력' },
               ].map(opt => (
                 <button
                   key={opt.value}
@@ -159,6 +177,39 @@ export default function SearchMode({
           )}
         </div>
       </div>
+
+      {/* 직접 입력 — custom 선택 시 날짜 범위 인풋 노출 */}
+      {search.searchPeriod === 'custom' && (
+        <div className="flex items-center gap-2">
+          <label htmlFor="search-start-date" className="sr-only">시작일</label>
+          <input
+            id="search-start-date"
+            aria-label="시작일"
+            type="date"
+            value={localStart}
+            max={localEnd || undefined}
+            onChange={(e) => setLocalStart(e.target.value)}
+            className="flex-1 px-3 py-2 rounded-xl border border-[var(--border-default)] bg-[var(--surface-card)] text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-grape-300"
+          />
+          <span className="text-[var(--text-muted)] text-sm shrink-0">~</span>
+          <label htmlFor="search-end-date" className="sr-only">종료일</label>
+          <input
+            id="search-end-date"
+            aria-label="종료일"
+            type="date"
+            value={localEnd}
+            min={localStart || undefined}
+            onChange={(e) => setLocalEnd(e.target.value)}
+            className="flex-1 px-3 py-2 rounded-xl border border-[var(--border-default)] bg-[var(--surface-card)] text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-grape-300"
+          />
+          <button
+            onClick={() => search.setCustomDateRange(localStart, localEnd)}
+            className="px-3 py-2 rounded-xl bg-grape-600 text-white text-sm font-medium hover:bg-grape-700 transition-colors shrink-0"
+          >
+            적용
+          </button>
+        </div>
+      )}
 
       {/* 빈 검색어: 최근 검색 + 카테고리 바로가기 */}
       {!search.searchQuery && !search.hasSearchFilters && (

--- a/frontend/src/components/transaction/__tests__/SearchModeDateRange.test.tsx
+++ b/frontend/src/components/transaction/__tests__/SearchModeDateRange.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * @file SearchModeDateRange.test.tsx
+ * @description SearchMode 기간 직접 입력(custom date range) 기능 테스트
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SearchMode from '../SearchMode'
+import type { useTransactionSearch } from '../../../hooks/useTransactionSearch'
+import type { useMonthlyTransactions } from '../../../hooks/useMonthlyTransactions'
+
+// SearchMode가 받는 search prop의 최소 mock 객체
+function makeSearchMock(overrides: Partial<ReturnType<typeof useTransactionSearch>> = {}): ReturnType<typeof useTransactionSearch> {
+  return {
+    searchQuery: '',
+    isSearchMode: true,
+    searchType: 'all',
+    searchCategoryId: null,
+    searchPeriod: 'all',
+    searchStartDate: '',
+    searchEndDate: '',
+    hasSearchFilters: false,
+    searchResults: [],
+    searchSummary: null,
+    searchLoading: false,
+    searchGrouped: new Map(),
+    searchHasMore: false,
+    searchLoadingMore: false,
+    loadMoreRef: { current: null },
+    searchInputRef: { current: null },
+    recentSearches: [],
+    setRecentSearches: vi.fn(),
+    openFilter: null,
+    setOpenFilter: vi.fn(),
+    setParams: vi.fn(),
+    enterSearchMode: vi.fn(),
+    exitSearchMode: vi.fn(),
+    submitSearch: vi.fn(),
+    setSearchFilter: vi.fn(),
+    setCustomDateRange: vi.fn(),
+    fetchSearchResults: vi.fn(),
+    ...overrides,
+  }
+}
+
+function makeMonthlyMock(): Partial<ReturnType<typeof useMonthlyTransactions>> {
+  return {
+    categoryMap: new Map(),
+    categories: [],
+  }
+}
+
+const defaultProps = {
+  categoryClickHandlers: new Map(),
+  onOpenFilterCategorySheet: vi.fn(),
+  onClearFilterCategory: vi.fn(),
+  searchCategoryActive: false,
+  memberMap: null,
+}
+
+describe('SearchMode — 기간 직접 입력', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('기간 칩 드롭다운에 "직접 입력" 옵션이 있다', () => {
+    const search = makeSearchMock({ openFilter: 'period' })
+    render(
+      <SearchMode
+        search={search}
+        monthly={makeMonthlyMock() as ReturnType<typeof useMonthlyTransactions>}
+        {...defaultProps}
+      />
+    )
+    expect(screen.getByRole('button', { name: '직접 입력' })).toBeInTheDocument()
+  })
+
+  it('"직접 입력" 선택 시 setSearchFilter("period", "custom") 호출된다', async () => {
+    const user = userEvent.setup()
+    const search = makeSearchMock({ openFilter: 'period' })
+    render(
+      <SearchMode
+        search={search}
+        monthly={makeMonthlyMock() as ReturnType<typeof useMonthlyTransactions>}
+        {...defaultProps}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: '직접 입력' }))
+    expect(search.setSearchFilter).toHaveBeenCalledWith('period', 'custom')
+  })
+
+  it('searchPeriod가 custom이면 날짜 범위 인풋이 표시된다', () => {
+    const search = makeSearchMock({ searchPeriod: 'custom', searchStartDate: '', searchEndDate: '' })
+    render(
+      <SearchMode
+        search={search}
+        monthly={makeMonthlyMock() as ReturnType<typeof useMonthlyTransactions>}
+        {...defaultProps}
+      />
+    )
+    expect(screen.getByLabelText('시작일')).toBeInTheDocument()
+    expect(screen.getByLabelText('종료일')).toBeInTheDocument()
+  })
+
+  it('날짜 입력 후 적용 버튼 클릭 시 setCustomDateRange 호출된다', async () => {
+    const user = userEvent.setup()
+    const search = makeSearchMock({ searchPeriod: 'custom', searchStartDate: '', searchEndDate: '' })
+    render(
+      <SearchMode
+        search={search}
+        monthly={makeMonthlyMock() as ReturnType<typeof useMonthlyTransactions>}
+        {...defaultProps}
+      />
+    )
+    await user.type(screen.getByLabelText('시작일'), '2026-03-01')
+    await user.type(screen.getByLabelText('종료일'), '2026-03-31')
+    await user.click(screen.getByRole('button', { name: '적용' }))
+    expect(search.setCustomDateRange).toHaveBeenCalledWith('2026-03-01', '2026-03-31')
+  })
+
+  it('custom 기간 선택 + 날짜 있을 때 칩이 날짜 범위 텍스트를 표시한다', () => {
+    const search = makeSearchMock({
+      searchPeriod: 'custom',
+      searchStartDate: '2026-03-01',
+      searchEndDate: '2026-03-31',
+      hasSearchFilters: true,
+    })
+    render(
+      <SearchMode
+        search={search}
+        monthly={makeMonthlyMock() as ReturnType<typeof useMonthlyTransactions>}
+        {...defaultProps}
+      />
+    )
+    expect(screen.getByText('03.01 ~ 03.31')).toBeInTheDocument()
+  })
+
+  it('custom 기간이지만 날짜 미입력 시 칩이 "직접 입력" 텍스트를 표시한다', () => {
+    const search = makeSearchMock({ searchPeriod: 'custom', searchStartDate: '', searchEndDate: '' })
+    render(
+      <SearchMode
+        search={search}
+        monthly={makeMonthlyMock() as ReturnType<typeof useMonthlyTransactions>}
+        {...defaultProps}
+      />
+    )
+    // 칩 버튼(기간 토글)에 "직접 입력" 텍스트
+    expect(screen.getByRole('button', { name: /직접 입력/ })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/hooks/useTransactionSearch.ts
+++ b/frontend/src/hooks/useTransactionSearch.ts
@@ -53,7 +53,17 @@ export function removeRecentSearch(query: string): void {
 }
 
 /** 기간 프리셋 → 날짜 범위 계산 */
-function getSearchDateRange(period: string): { start_date?: string; end_date?: string } {
+function getSearchDateRange(
+  period: string,
+  startDate?: string,
+  endDate?: string,
+): { start_date?: string; end_date?: string } {
+  if (period === 'custom') {
+    return {
+      ...(startDate && { start_date: startDate }),
+      ...(endDate && { end_date: endDate }),
+    }
+  }
   if (period === 'all') return {}
   const now = new Date()
   const end = getLocalDateString(now)
@@ -81,7 +91,9 @@ export function useTransactionSearch({ activeHouseholdId }: UseTransactionSearch
   const isSearchMode = searchParams.has('search')
   const searchType = (searchParams.get('type') as 'all' | 'expense' | 'income') || 'all'
   const searchCategoryId = searchParams.get('category') ? Number(searchParams.get('category')) : null
-  const searchPeriod = (searchParams.get('period') as 'all' | '1m' | '3m' | '6m' | 'year') || 'all'
+  const searchPeriod = (searchParams.get('period') as 'all' | '1m' | '3m' | '6m' | 'year' | 'custom') || 'all'
+  const searchStartDate = searchParams.get('start_date') ?? ''
+  const searchEndDate = searchParams.get('end_date') ?? ''
   const hasSearchFilters = !!(searchCategoryId || searchPeriod !== 'all' || searchType !== 'all')
 
   // 검색 결과 상태
@@ -121,7 +133,17 @@ export function useTransactionSearch({ activeHouseholdId }: UseTransactionSearch
 
   // 검색 모드 해제 → 월 뷰 복귀
   const exitSearchMode = useCallback(() => {
-    setParams({ search: null, type: null, category: null, period: null, member: null })
+    setParams({ search: null, type: null, category: null, period: null, member: null, start_date: null, end_date: null })
+    setOpenFilter(null)
+  }, [setParams])
+
+  // 직접 입력 날짜 범위 적용
+  const setCustomDateRange = useCallback((startDate: string, endDate: string) => {
+    setParams({
+      period: 'custom',
+      start_date: startDate || null,
+      end_date: endDate || null,
+    })
     setOpenFilter(null)
   }, [setParams])
 
@@ -154,7 +176,7 @@ export function useTransactionSearch({ activeHouseholdId }: UseTransactionSearch
 
     try {
       const offset = append ? searchOffsetRef.current : 0
-      const dateRange = getSearchDateRange(searchPeriod)
+      const dateRange = getSearchDateRange(searchPeriod, searchStartDate, searchEndDate)
       const baseParams = {
         query: searchQuery || undefined,
         skip: offset,
@@ -209,7 +231,7 @@ export function useTransactionSearch({ activeHouseholdId }: UseTransactionSearch
       setSearchLoadingMore(false)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- addToast는 안정적 참조
-  }, [searchQuery, activeHouseholdId, searchType, searchCategoryId, searchPeriod])
+  }, [searchQuery, activeHouseholdId, searchType, searchCategoryId, searchPeriod, searchStartDate, searchEndDate])
 
   // 검색어 또는 필터 변경 시 검색 실행
   useEffect(() => {
@@ -225,7 +247,7 @@ export function useTransactionSearch({ activeHouseholdId }: UseTransactionSearch
       setSearchSummary(null)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchSearchResults 내부에서 동일 state 참조
-  }, [isSearchMode, searchQuery, searchType, searchCategoryId, searchPeriod])
+  }, [isSearchMode, searchQuery, searchType, searchCategoryId, searchPeriod, searchStartDate, searchEndDate])
 
   // 검색 모드 진입 시 인풋 포커스
   useEffect(() => {
@@ -278,6 +300,8 @@ export function useTransactionSearch({ activeHouseholdId }: UseTransactionSearch
     searchType,
     searchCategoryId,
     searchPeriod,
+    searchStartDate,
+    searchEndDate,
     hasSearchFilters,
 
     // 검색 결과
@@ -306,6 +330,7 @@ export function useTransactionSearch({ activeHouseholdId }: UseTransactionSearch
     exitSearchMode,
     submitSearch,
     setSearchFilter,
+    setCustomDateRange,
     fetchSearchResults,
   }
 }


### PR DESCRIPTION
## Summary
- 기간 필터에 '직접 입력' 옵션 추가 — 시작일/종료일을 직접 지정해 검색 가능
- 날짜 선택 후 적용 버튼으로 URL 파라미터 반영, 칩에 `MM.DD ~ MM.DD` 형식 표시
- 기존 프리셋(1·3·6개월/올해)은 그대로 유지

## Changes
- `useTransactionSearch.ts`: `'custom'` period 타입, `start_date`/`end_date` URL 파라미터, `setCustomDateRange` 액션
- `SearchMode.tsx`: 드롭다운에 '직접 입력' 항목, 날짜 인풋 + 적용 버튼 인라인 노출
- 테스트 6개 추가 (SearchModeDateRange)

## Test plan
- [ ] 기간 칩 드롭다운 → '직접 입력' 선택 시 날짜 인풋 노출 확인
- [ ] 시작일/종료일 선택 → 적용 클릭 → 검색 결과 갱신 확인
- [ ] 칩에 `MM.DD ~ MM.DD` 형식 표시 확인
- [ ] 검색 모드 닫기 시 날짜 파라미터 초기화 확인
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)