### PR TITLE
feat: 가구 전환 UI 개선 — 상단 아이콘 + 바텀시트

### DIFF
--- a/frontend/src/components/FloatingTabBar.tsx
+++ b/frontend/src/components/FloatingTabBar.tsx
@@ -21,12 +21,13 @@ interface FloatingTabBarProps {
   onInputOpen: () => void
   /** 읽지 않은 changelog 있을 때 true */
   hasUnreadChangelog?: boolean
+  /** 미확인 초대 있을 때 true — 설정 탭에 배지 표시 */
+  hasPendingInvitation?: boolean
   /** QuickInput 활성 시 true — 탭바를 페이드아웃하여 입력창과 겹치지 않게 함 */
   isHidden?: boolean
 }
 
-
-export default function FloatingTabBar({ onInputOpen, hasUnreadChangelog, isHidden }: FloatingTabBarProps) {
+export default function FloatingTabBar({ onInputOpen, hasUnreadChangelog, hasPendingInvitation, isHidden }: FloatingTabBarProps) {
   const { pathname } = useLocation()
 
   const isActive = (path: string) => pathname === path || pathname.startsWith(path + '/')
@@ -65,7 +66,7 @@ export default function FloatingTabBar({ onInputOpen, hasUnreadChangelog, isHidd
             >
               <span className="relative">
                 <Icon className={`w-5 h-5 floating-island-icon ${active ? 'stroke-[2.5]' : ''}`} />
-                {item.path === '/settings' && hasUnreadChangelog && (
+                {item.path === '/settings' && (hasUnreadChangelog || hasPendingInvitation) && (
                   <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-500 rounded-full" />
                 )}
               </span>

--- a/frontend/src/components/HouseholdBottomSheet.tsx
+++ b/frontend/src/components/HouseholdBottomSheet.tsx
@@ -3,7 +3,7 @@
  * @description 가구 전환 바텀시트 — 복수 가구 소속 계정에서 활성 가구를 선택
  */
 
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { X, Home, Check } from 'lucide-react'
 import type { Household } from '../types'
 
@@ -22,8 +22,6 @@ export default function HouseholdBottomSheet({
   activeHouseholdId,
   onSelect,
 }: HouseholdBottomSheetProps) {
-  const sheetRef = useRef<HTMLDivElement>(null)
-
   useEffect(() => {
     if (!isOpen) return
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -49,7 +47,6 @@ export default function HouseholdBottomSheet({
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div className="absolute inset-0 bg-black/40 transition-opacity" onClick={onClose} />
       <div
-        ref={sheetRef}
         className="relative w-full md:max-w-sm bg-[var(--surface-card)] rounded-t-2xl md:rounded-2xl flex flex-col animate-sheet-up md:animate-none"
       >
         {/* 헤더 */}
@@ -61,7 +58,7 @@ export default function HouseholdBottomSheet({
         </div>
 
         {/* 가구 목록 */}
-        <div className="overflow-y-auto p-2 pb-safe">
+        <div className="overflow-y-auto p-2" style={{ paddingBottom: 'max(8px, env(safe-area-inset-bottom))' }}>
           {households.map(h => {
             const isActive = h.id === activeHouseholdId
             return (

--- a/frontend/src/components/HouseholdBottomSheet.tsx
+++ b/frontend/src/components/HouseholdBottomSheet.tsx
@@ -1,0 +1,91 @@
+/**
+ * @file HouseholdBottomSheet.tsx
+ * @description 가구 전환 바텀시트 — 복수 가구 소속 계정에서 활성 가구를 선택
+ */
+
+import { useEffect, useRef } from 'react'
+import { X, Home, Check } from 'lucide-react'
+import type { Household } from '../types'
+
+interface HouseholdBottomSheetProps {
+  isOpen: boolean
+  onClose: () => void
+  households: Household[]
+  activeHouseholdId: number | null
+  onSelect: (householdId: number) => void
+}
+
+export default function HouseholdBottomSheet({
+  isOpen,
+  onClose,
+  households,
+  activeHouseholdId,
+  onSelect,
+}: HouseholdBottomSheetProps) {
+  const sheetRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden'
+    }
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center" role="dialog" aria-modal="true" aria-label="가계부 선택">
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div className="absolute inset-0 bg-black/40 transition-opacity" onClick={onClose} />
+      <div
+        ref={sheetRef}
+        className="relative w-full md:max-w-sm bg-[var(--surface-card)] rounded-t-2xl md:rounded-2xl flex flex-col animate-sheet-up md:animate-none"
+      >
+        {/* 헤더 */}
+        <div className="flex items-center justify-between px-4 pt-4 pb-2 border-b border-[var(--border-subtle)]">
+          <h3 className="text-sm font-semibold text-[var(--text-primary)]">가계부 선택</h3>
+          <button onClick={onClose} className="p-1 rounded-lg hover:bg-[var(--surface-hover)]" aria-label="닫기">
+            <X className="w-4 h-4 text-[var(--text-muted)]" />
+          </button>
+        </div>
+
+        {/* 가구 목록 */}
+        <div className="overflow-y-auto p-2 pb-safe">
+          {households.map(h => {
+            const isActive = h.id === activeHouseholdId
+            return (
+              <button
+                key={h.id}
+                onClick={() => { onSelect(h.id); onClose() }}
+                className={`w-full flex items-center gap-3 px-3 py-3 rounded-xl text-sm transition-colors ${
+                  isActive
+                    ? 'bg-grape-50 text-grape-600'
+                    : 'text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]'
+                }`}
+              >
+                <div className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${
+                  isActive ? 'bg-grape-100' : 'bg-[var(--surface-hover)]'
+                }`}>
+                  <Home className="w-4 h-4" />
+                </div>
+                <span className="flex-1 text-left font-medium truncate">{h.name}</span>
+                {isActive && <Check className="w-4 h-4 shrink-0" />}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -14,9 +14,10 @@ import { trackPageView } from '../utils/analytics'
 import { NAV_ITEMS } from '../constants/navItems'
 
 export default function Layout() {
-  const [householdDropdownOpen, setHouseholdDropdownOpen] = useState(false)
   const [isInputMode, setIsInputMode] = useState(false)
   const [toastData, setToastData] = useState<ActionToastData | null>(null)
+  // 데스크톱 사이드바 가구 드롭다운 상태
+  const [householdDropdownOpen, setHouseholdDropdownOpen] = useState(false)
   // iOS Safari에서 키보드를 사용자 제스처 컨텍스트에서 띄우려면 동기적으로 focus() 호출 필요
   const quickInputRef = useRef<QuickInputHandle>(null)
   const location = useLocation()

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -68,46 +68,6 @@ export default function Layout() {
         </div>
       )}
 
-      {/* 모바일 전용 미니 헤더 — 가구 전환/초대 배지가 있을 때만 표시 */}
-      {(pendingInvitationCount > 0 || households.length > 1) && (
-        <header className="md:hidden bg-[var(--surface-card)] border-b border-[var(--border-default)] sticky top-0 z-30 h-12 flex items-center justify-end px-4 gap-3">
-          {households.length > 1 && (
-            <div className="relative">
-              <button
-                onClick={e => { e.stopPropagation(); setHouseholdDropdownOpen(!householdDropdownOpen) }}
-                className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs bg-grape-50 hover:bg-grape-100 text-grape-600 transition-colors"
-              >
-                <Home className="w-3.5 h-3.5" />
-                <span className="font-medium truncate max-w-[100px]">{activeHousehold?.name ?? '가구'}</span>
-                <ChevronDown className="w-3 h-3 text-[var(--text-muted)]" />
-              </button>
-              {householdDropdownOpen && (
-                <div className="absolute right-0 top-full mt-1 bg-[var(--surface-card)] border border-[var(--border-default)] rounded-lg shadow-lg z-50 py-1 min-w-[140px]">
-                  {households.map(h => (
-                    <button
-                      key={h.id}
-                      onClick={() => { setActiveHouseholdId(h.id); setHouseholdDropdownOpen(false) }}
-                      className={`w-full text-left px-3 py-2 text-sm hover:bg-[var(--surface-hover)] transition-colors truncate ${
-                        h.id === activeHouseholdId ? 'text-grape-600 font-medium bg-grape-50' : 'text-[var(--text-secondary)]'
-                      }`}
-                    >
-                      {h.name}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-          {pendingInvitationCount > 0 && (
-            <Link to="/invitations" className="relative p-1.5">
-              <Mail className="w-5 h-5 text-[var(--text-tertiary)]" />
-              <span className="absolute -top-0.5 -right-0.5 bg-red-500 text-white text-[10px] px-1 py-0.5 rounded-full min-w-[16px] text-center leading-none">
-                {pendingInvitationCount}
-              </span>
-            </Link>
-          )}
-        </header>
-      )}
 
       <div className="flex">
         {/* 데스크톱 사이드바 (md 이상에서만 표시) */}
@@ -224,6 +184,7 @@ export default function Layout() {
           }
         }}
         hasUnreadChangelog={hasUnreadChangelog}
+        hasPendingInvitation={pendingInvitationCount > 0}
         isHidden={isInputMode}
       />
       <QuickInput

--- a/frontend/src/components/__tests__/HouseholdBottomSheet.test.tsx
+++ b/frontend/src/components/__tests__/HouseholdBottomSheet.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @file HouseholdBottomSheet.test.tsx
+ * @description HouseholdBottomSheet 컴포넌트 테스트
+ * 열기/닫기, 가구 선택, 키보드 접근성을 검증한다.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import HouseholdBottomSheet from '../HouseholdBottomSheet'
+
+const mockHouseholds = [
+  { id: 1, name: '우리집', description: null, currency: 'KRW', my_role: 'owner' as const, member_count: 1, created_at: '' },
+  { id: 2, name: '부모님댁', description: null, currency: 'KRW', my_role: 'member' as const, member_count: 2, created_at: '' },
+]
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  households: mockHouseholds,
+  activeHouseholdId: 1,
+  onSelect: vi.fn(),
+}
+
+function renderSheet(props = {}) {
+  return render(<HouseholdBottomSheet {...defaultProps} {...props} />)
+}
+
+describe('HouseholdBottomSheet', () => {
+  describe('기본 렌더링', () => {
+    it('isOpen=true 일 때 시트를 표시한다', () => {
+      renderSheet()
+      expect(screen.getByRole('dialog', { name: '가계부 선택' })).toBeInTheDocument()
+    })
+
+    it('isOpen=false 일 때 아무것도 렌더링하지 않는다', () => {
+      renderSheet({ isOpen: false })
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('모든 가구 이름을 표시한다', () => {
+      renderSheet()
+      expect(screen.getByText('우리집')).toBeInTheDocument()
+      expect(screen.getByText('부모님댁')).toBeInTheDocument()
+    })
+
+    it('활성 가구에 체크 아이콘을 표시한다', () => {
+      renderSheet()
+      // 우리집(활성)에 체크, 부모님댁에는 없음
+      const buttons = screen.getAllByRole('button').filter(b => b.textContent?.includes('우리집'))
+      expect(buttons[0]).toBeInTheDocument()
+    })
+  })
+
+  describe('가구 선택', () => {
+    it('가구 클릭 시 onSelect와 onClose를 호출한다', async () => {
+      const user = userEvent.setup()
+      const onSelect = vi.fn()
+      const onClose = vi.fn()
+      renderSheet({ onSelect, onClose })
+
+      await user.click(screen.getByText('부모님댁'))
+
+      expect(onSelect).toHaveBeenCalledWith(2)
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  describe('닫기', () => {
+    it('Escape 키 입력 시 onClose를 호출한다', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      renderSheet({ onClose })
+
+      await user.keyboard('{Escape}')
+
+      expect(onClose).toHaveBeenCalled()
+    })
+
+    it('닫기 버튼 클릭 시 onClose를 호출한다', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      renderSheet({ onClose })
+
+      await user.click(screen.getByLabelText('닫기'))
+
+      expect(onClose).toHaveBeenCalled()
+    })
+
+    it('오버레이 클릭 시 onClose를 호출한다', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      renderSheet({ onClose })
+
+      // dialog 역할 요소의 부모(오버레이)를 클릭
+      const dialog = screen.getByRole('dialog')
+      await user.click(dialog.parentElement!.querySelector('.absolute.inset-0')!)
+
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/components/transaction/MonthlyView.tsx
+++ b/frontend/src/components/transaction/MonthlyView.tsx
@@ -14,7 +14,7 @@ import ScheduledTransactions from '../ScheduledTransactions'
 import EmptyState from '../EmptyState'
 import WelcomeCard from '../WelcomeCard'
 import BotNudgeCard from '../BotNudgeCard'
-import { Search, ChevronDown, ChevronUp } from 'lucide-react'
+import { Search, ChevronDown, ChevronUp, Home } from 'lucide-react'
 import { formatAmount } from '../../utils/format'
 import { formatDateHeader } from '../../utils/calendar'
 import { recurringApi } from '../../api/recurring'
@@ -38,6 +38,9 @@ interface MonthlyViewProps {
   memberMap: Map<number, string> | null
   /** 월 총 예산 (undefined = 로딩 중, null = 미설정, number = 설정됨) */
   totalBudget: number | null | undefined
+  /** 복수 가구 소속일 때 true — 가구 전환 아이콘 노출 */
+  showHouseholdSwitcher?: boolean
+  onOpenHouseholdSheet?: () => void
 }
 
 export default function MonthlyView({
@@ -52,6 +55,8 @@ export default function MonthlyView({
   onBotNudgeDismiss,
   memberMap,
   totalBudget,
+  showHouseholdSwitcher,
+  onOpenHouseholdSheet,
 }: MonthlyViewProps) {
   const { addToast } = useToast()
 
@@ -89,8 +94,17 @@ export default function MonthlyView({
 
   return (
     <>
-      {/* 월 네비게이션 + 검색 버튼 */}
+      {/* 월 네비게이션 + 좌측 가구 전환 + 우측 검색 버튼 */}
       <div className="relative">
+        {showHouseholdSwitcher && (
+          <button
+            onClick={onOpenHouseholdSheet}
+            className="absolute left-0 top-1/2 -translate-y-1/2 p-2 rounded-xl hover:bg-[var(--surface-hover)] transition-colors"
+            aria-label="가계부 전환"
+          >
+            <Home className="w-5 h-5 text-[var(--text-secondary)]" />
+          </button>
+        )}
         <PeriodNavigator
           label={monthly.monthLabel}
           onPrev={() => monthly.navigateMonth(-1)}

--- a/frontend/src/components/transaction/MonthlyView.tsx
+++ b/frontend/src/components/transaction/MonthlyView.tsx
@@ -96,7 +96,7 @@ export default function MonthlyView({
     <>
       {/* 월 네비게이션 + 좌측 가구 전환 + 우측 검색 버튼 */}
       <div className="relative">
-        {showHouseholdSwitcher && (
+        {showHouseholdSwitcher && onOpenHouseholdSheet && (
           <button
             onClick={onOpenHouseholdSheet}
             className="absolute left-0 top-1/2 -translate-y-1/2 p-2 rounded-xl hover:bg-[var(--surface-hover)] transition-colors"

--- a/frontend/src/components/transaction/__tests__/MonthlyView.test.tsx
+++ b/frontend/src/components/transaction/__tests__/MonthlyView.test.tsx
@@ -30,6 +30,8 @@ vi.mock('../../../stores/useHouseholdStore', () => ({
   useHouseholdStore: (selector: (s: Record<string, unknown>) => unknown) =>
     selector({
       activeHouseholdId: 1,
+      households: [{ id: 1, name: '우리집' }],
+      setActiveHouseholdId: vi.fn(),
       currentHousehold: null,
       fetchHouseholdDetail: vi.fn(),
     }),

--- a/frontend/src/pages/TransactionList.tsx
+++ b/frontend/src/pages/TransactionList.tsx
@@ -13,6 +13,7 @@ import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
 import { TOAST } from '../constants/toastMessages'
 import CategoryBottomSheet from '../components/CategoryBottomSheet'
+import HouseholdBottomSheet from '../components/HouseholdBottomSheet'
 import PullToRefresh from '../components/PullToRefresh'
 import ErrorState from '../components/ErrorState'
 import { useAuth } from '../contexts/AuthContext'
@@ -24,6 +25,8 @@ import MonthlyView from '../components/transaction/MonthlyView'
 
 export default function TransactionList() {
   const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
+  const households = useHouseholdStore((s) => s.households)
+  const setActiveHouseholdId = useHouseholdStore((s) => s.setActiveHouseholdId)
   const currentHousehold = useHouseholdStore((s) => s.currentHousehold)
   const fetchHouseholdDetail = useHouseholdStore((s) => s.fetchHouseholdDetail)
   const { addToast } = useToast()
@@ -103,6 +106,9 @@ export default function TransactionList() {
       )
     }
   }, [welcomeDismissed, monthly.loading, monthly.expenses.length, monthly.incomes.length])
+
+  // 가구 전환 바텀시트 상태
+  const [householdSheetOpen, setHouseholdSheetOpen] = useState(false)
 
   // 카테고리 바텀시트 상태
   const [sheetOpen, setSheetOpen] = useState(false)
@@ -218,8 +224,19 @@ export default function TransactionList() {
           onBotNudgeDismiss={handleBotNudgeDismiss}
           memberMap={memberMap}
           totalBudget={totalBudget}
+          showHouseholdSwitcher={households.length > 1}
+          onOpenHouseholdSheet={() => setHouseholdSheetOpen(true)}
         />
       )}
+
+      {/* 가구 전환 바텀시트 */}
+      <HouseholdBottomSheet
+        isOpen={householdSheetOpen}
+        onClose={() => setHouseholdSheetOpen(false)}
+        households={households}
+        activeHouseholdId={activeHouseholdId}
+        onSelect={setActiveHouseholdId}
+      />
 
       {/* 카테고리 바텀시트 */}
       <CategoryBottomSheet

--- a/frontend/src/pages/__tests__/TransactionList.test.tsx
+++ b/frontend/src/pages/__tests__/TransactionList.test.tsx
@@ -30,6 +30,8 @@ vi.mock('../../stores/useHouseholdStore', () => ({
   useHouseholdStore: (selector: (s: Record<string, unknown>) => unknown) =>
     selector({
       activeHouseholdId: 1,
+      households: [{ id: 1, name: '우리집' }],
+      setActiveHouseholdId: vi.fn(),
       currentHousehold: null,
       fetchHouseholdDetail: vi.fn(),
     }),


### PR DESCRIPTION
## Summary
- 모바일 sticky 헤더(가구 드롭다운) 제거 → 콘텐츠 영역 48px 확보
- 복수 가구 계정에서만 가계부 화면 PeriodNavigator 행 왼쪽에 Home 아이콘 노출
- 탭하면 바텀시트로 가구 선택 (CategoryBottomSheet와 동일 패턴)
- 초대 알림은 설정 탭 배지로 통합

## Changes
- `HouseholdBottomSheet.tsx` 신규
- `MonthlyView.tsx`: `showHouseholdSwitcher` / `onOpenHouseholdSheet` props 추가
- `TransactionList.tsx`: 가구 스토어 구독 + 바텀시트 상태 관리
- `FloatingTabBar.tsx`: `hasPendingInvitation` prop → 설정 탭 배지
- `Layout.tsx`: 모바일 sticky 헤더 제거

## Test plan
- [ ] 단일 가구 계정: 가계부 화면에 Home 아이콘 없음 확인
- [ ] 복수 가구 계정: Home 아이콘 표시 → 탭 → 바텀시트 열림 확인
- [ ] 바텀시트에서 가구 선택 → 데이터 전환 확인
- [ ] 초대 알림 있을 때 설정 탭에 빨간 배지 표시 확인
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)