### PR TITLE
feat: 검색 UX 개선 — 아이콘, 직접입력 버그, 카테고리 이모지

### DIFF
--- a/frontend/src/components/CategoryBottomSheet.tsx
+++ b/frontend/src/components/CategoryBottomSheet.tsx
@@ -96,10 +96,11 @@ export default function CategoryBottomSheet({
                 <button
                   key={cat.id}
                   onClick={() => onSelect(cat.id)}
-                  className={`w-full text-left px-3 py-2.5 rounded-lg text-sm transition-colors ${
+                  className={`w-full text-left px-3 py-2.5 rounded-lg text-sm transition-colors flex items-center gap-2 ${
                     currentCategoryId === cat.id ? activeClass : 'text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]'
                   }`}
                 >
+                  {cat.emoji && <span className="text-base leading-none">{cat.emoji}</span>}
                   {cat.name}
                 </button>
               ))}

--- a/frontend/src/components/transaction/MonthlyView.tsx
+++ b/frontend/src/components/transaction/MonthlyView.tsx
@@ -14,7 +14,7 @@ import ScheduledTransactions from '../ScheduledTransactions'
 import EmptyState from '../EmptyState'
 import WelcomeCard from '../WelcomeCard'
 import BotNudgeCard from '../BotNudgeCard'
-import { Search, ChevronDown, ChevronUp, Home } from 'lucide-react'
+import { Search, ChevronDown, ChevronUp, NotebookTabs } from 'lucide-react'
 import { formatAmount } from '../../utils/format'
 import { formatDateHeader } from '../../utils/calendar'
 import { recurringApi } from '../../api/recurring'
@@ -102,7 +102,7 @@ export default function MonthlyView({
             className="absolute left-0 top-1/2 -translate-y-1/2 p-2 rounded-xl hover:bg-[var(--surface-hover)] transition-colors z-10"
             aria-label="가계부 전환"
           >
-            <Home className="w-5 h-5 text-[var(--text-secondary)]" />
+            <NotebookTabs className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
         )}
         <PeriodNavigator

--- a/frontend/src/components/transaction/MonthlyView.tsx
+++ b/frontend/src/components/transaction/MonthlyView.tsx
@@ -99,7 +99,7 @@ export default function MonthlyView({
         {showHouseholdSwitcher && onOpenHouseholdSheet && (
           <button
             onClick={onOpenHouseholdSheet}
-            className="absolute left-0 top-1/2 -translate-y-1/2 p-2 rounded-xl hover:bg-[var(--surface-hover)] transition-colors"
+            className="absolute left-0 top-1/2 -translate-y-1/2 p-2 rounded-xl hover:bg-[var(--surface-hover)] transition-colors z-10"
             aria-label="가계부 전환"
           >
             <Home className="w-5 h-5 text-[var(--text-secondary)]" />

--- a/frontend/src/components/transaction/SearchMode.tsx
+++ b/frontend/src/components/transaction/SearchMode.tsx
@@ -250,8 +250,9 @@ export default function SearchMode({
                   <button
                     key={cat.id}
                     onClick={() => search.setSearchFilter('category', String(cat.id))}
-                    className="px-3 py-1.5 rounded-lg text-xs font-medium bg-[var(--surface-hover)] text-[var(--text-secondary)] hover:bg-grape-50 hover:text-grape-600 transition-colors"
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-[var(--surface-hover)] text-[var(--text-secondary)] hover:bg-grape-50 hover:text-grape-600 transition-colors"
                   >
+                    {cat.emoji && <span className="text-sm leading-none">{cat.emoji}</span>}
                     {cat.name}
                   </button>
                 ))}

--- a/frontend/src/hooks/__tests__/useTransactionSearch.test.ts
+++ b/frontend/src/hooks/__tests__/useTransactionSearch.test.ts
@@ -115,6 +115,31 @@ describe('useTransactionSearch', () => {
 
       expect(result.current.hasSearchFilters).toBe(true)
     })
+
+    it('custom 기간이지만 날짜 미입력이면 hasSearchFilters가 false', () => {
+      mockSearchParams.set('search', '')
+      mockSearchParams.set('period', 'custom')
+      // start_date, end_date 없음
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.hasSearchFilters).toBe(false)
+    })
+
+    it('custom 기간 + 날짜 입력 시 hasSearchFilters가 true', () => {
+      mockSearchParams.set('search', '')
+      mockSearchParams.set('period', 'custom')
+      mockSearchParams.set('start_date', '2026-01-01')
+      mockSearchParams.set('end_date', '2026-01-31')
+
+      const { result } = renderHook(() =>
+        useTransactionSearch({ activeHouseholdId: 1 })
+      )
+
+      expect(result.current.hasSearchFilters).toBe(true)
+    })
   })
 
   describe('검색 모드 진입/해제', () => {

--- a/frontend/src/hooks/useTransactionSearch.ts
+++ b/frontend/src/hooks/useTransactionSearch.ts
@@ -94,7 +94,9 @@ export function useTransactionSearch({ activeHouseholdId }: UseTransactionSearch
   const searchPeriod = (searchParams.get('period') as 'all' | '1m' | '3m' | '6m' | 'year' | 'custom') || 'all'
   const searchStartDate = searchParams.get('start_date') ?? ''
   const searchEndDate = searchParams.get('end_date') ?? ''
-  const hasSearchFilters = !!(searchCategoryId || searchPeriod !== 'all' || searchType !== 'all')
+  // custom 기간은 날짜가 실제로 입력된 경우에만 필터로 간주
+  const periodActive = searchPeriod !== 'all' && !(searchPeriod === 'custom' && !searchStartDate && !searchEndDate)
+  const hasSearchFilters = !!(searchCategoryId || periodActive || searchType !== 'all')
 
   // 검색 결과 상태
   const [searchResults, setSearchResults] = useState<UnifiedTransaction[]>([])

--- a/frontend/src/pages/__tests__/TransactionList.test.tsx
+++ b/frontend/src/pages/__tests__/TransactionList.test.tsx
@@ -273,8 +273,8 @@ describe('TransactionList', () => {
       await waitFor(() => {
         expect(screen.getByText('카테고리로 보기')).toBeInTheDocument()
         // mockCategories에 '식비', '교통'이 있음
-        expect(screen.getByRole('button', { name: '식비' })).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: '교통' })).toBeInTheDocument()
+        expect(screen.getByText('식비')).toBeInTheDocument()
+        expect(screen.getByText('교통')).toBeInTheDocument()
       })
     })
 


### PR DESCRIPTION
## Summary
- 가계부 전환 버튼 아이콘 `Home` → `NotebookTabs` (앱 테마에 맞게)
- 기간 직접 입력 선택 시 날짜 미입력 상태에서 전체 결과 노출되던 버그 수정
- 카테고리 변경 바텀시트 + 검색 카테고리 칩에 이모지 표시

## Changes
- `MonthlyView.tsx`: 가계부 전환 버튼 아이콘 변경
- `useTransactionSearch.ts`: custom 기간 + 날짜 없으면 `hasSearchFilters=false`
- `CategoryBottomSheet.tsx`: 카테고리 이름 옆 emoji 표시
- `SearchMode.tsx`: 카테고리로 보기 칩에 emoji 표시

## Test plan
- [ ] 기간 직접 입력 선택 → 날짜 없으면 결과 안 뜨고 날짜 입력 폼만 노출 확인
- [ ] 카테고리 변경 바텀시트에 이모지 표시 확인
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)