### PR TITLE
fix: 필터 드롭다운 자동 닫힘 + 바텀시트 스크롤 체이닝 방지

### DIFF
--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -14,6 +14,12 @@
 - release/x.x.x: 릴리즈 안정화 (develop에서 분기 → main 머지)
 - hotfix/xxx: 운영 긴급 수정 (main에서 분기 → main 머지)
 
+## PR 머지 전략
+- feature/fix → develop: **Squash merge** (커밋 히스토리 정리)
+- release → main: **Merge commit** (공통 조상 유지 → 다음 release 충돌 방지)
+- hotfix → main: **Merge commit** (같은 이유)
+- squash 머지는 커밋 SHA를 새로 만들어 히스토리 연결을 끊기 때문에, main 대상 PR은 반드시 merge commit 사용
+
 ## 버전 관리
 - SemVer (x.y.z) 기반, 현재 0.x.x (정식 출시 전)
 - release → main 머지 시: minor bump (0.6.0 → 0.7.0) — 자동
@@ -60,7 +66,7 @@
 3. dev 테스트     release push → dev 환경 자동 배포
 
 4. main 머지      gh pr create --base main
-                  CI 통과 후 머지
+                  CI 통과 후 **merge commit으로 머지** (squash 아님!)
 
 5. 자동 처리      운영 배포 + vX.X.X 태그 + develop 역머지 PR (모두 자동)
 
@@ -76,7 +82,7 @@
 2. 수정 + 테스트
 
 3. main 머지      gh pr create --base main
-                  CI 통과 후 머지
+                  CI 통과 후 **merge commit으로 머지** (squash 아님!)
 
 4. 자동 처리      운영 배포 + vX.X.Z 태그 + develop 역머지 PR (모두 자동)
 

--- a/frontend/src/components/CategoryBottomSheet.tsx
+++ b/frontend/src/components/CategoryBottomSheet.tsx
@@ -61,7 +61,7 @@ export default function CategoryBottomSheet({
     : 'bg-grape-50 text-grape-600 font-medium'
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center" role="dialog" aria-modal="true" aria-label={title}>
+    <div className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center overscroll-contain touch-none" role="dialog" aria-modal="true" aria-label={title}>
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- 모달 배경 오버레이: Escape 키로 닫기 지원됨 */}
       <div
         className="absolute inset-0 bg-black/40 transition-opacity"
@@ -69,7 +69,7 @@ export default function CategoryBottomSheet({
       />
       <div
         ref={sheetRef}
-        className="relative w-full md:max-w-sm bg-[var(--surface-card)] rounded-t-2xl md:rounded-2xl max-h-[60vh] flex flex-col animate-sheet-up md:animate-none"
+        className="relative w-full md:max-w-sm bg-[var(--surface-card)] rounded-t-2xl md:rounded-2xl max-h-[60vh] flex flex-col animate-sheet-up md:animate-none touch-auto"
       >
         <div className="flex items-center justify-between px-4 pt-4 pb-2 border-b border-[var(--border-subtle)]">
           <h3 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h3>
@@ -77,7 +77,7 @@ export default function CategoryBottomSheet({
             <X className="w-4 h-4 text-[var(--text-muted)]" />
           </button>
         </div>
-        <div className="overflow-y-auto p-2">
+        <div className="overflow-y-auto overscroll-contain p-2">
           {saving ? (
             <div className="flex items-center justify-center py-8">
               <div className="animate-spin rounded-full border-b-2 border-warm-400 w-5 h-5" />

--- a/frontend/src/components/HouseholdBottomSheet.tsx
+++ b/frontend/src/components/HouseholdBottomSheet.tsx
@@ -43,11 +43,11 @@ export default function HouseholdBottomSheet({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center" role="dialog" aria-modal="true" aria-label="가계부 선택">
+    <div className="fixed inset-0 z-50 flex items-end md:items-center md:justify-center overscroll-contain touch-none" role="dialog" aria-modal="true" aria-label="가계부 선택">
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div className="absolute inset-0 bg-black/40 transition-opacity" onClick={onClose} />
       <div
-        className="relative w-full md:max-w-sm bg-[var(--surface-card)] rounded-t-2xl md:rounded-2xl flex flex-col animate-sheet-up md:animate-none"
+        className="relative w-full md:max-w-sm bg-[var(--surface-card)] rounded-t-2xl md:rounded-2xl flex flex-col animate-sheet-up md:animate-none touch-auto"
       >
         {/* 헤더 */}
         <div className="flex items-center justify-between px-4 pt-4 pb-2 border-b border-[var(--border-subtle)]">
@@ -58,7 +58,7 @@ export default function HouseholdBottomSheet({
         </div>
 
         {/* 가구 목록 */}
-        <div className="overflow-y-auto p-2" style={{ paddingBottom: 'max(8px, env(safe-area-inset-bottom))' }}>
+        <div className="overflow-y-auto overscroll-contain p-2" style={{ paddingBottom: 'max(8px, env(safe-area-inset-bottom))' }}>
           {households.map(h => {
             const isActive = h.id === activeHouseholdId
             return (

--- a/frontend/src/components/transaction/SearchMode.tsx
+++ b/frontend/src/components/transaction/SearchMode.tsx
@@ -139,7 +139,7 @@ export default function SearchMode({
               ].map(opt => (
                 <button
                   key={opt.value}
-                  onClick={() => search.setSearchFilter('type', opt.value === 'all' ? null : opt.value)}
+                  onClick={() => { search.setSearchFilter('type', opt.value === 'all' ? null : opt.value); search.setOpenFilter(null); }}
                   className={`w-full text-left px-4 py-2 text-sm hover:bg-[var(--surface-hover)] ${
                     search.searchType === opt.value ? 'text-grape-600 font-medium' : 'text-[var(--text-primary)]'
                   }`}
@@ -227,7 +227,7 @@ export default function SearchMode({
               ].map(opt => (
                 <button
                   key={`${opt.sortBy}_${opt.sortOrder}`}
-                  onClick={() => search.setSortOrder(opt.sortBy, opt.sortOrder)}
+                  onClick={() => { search.setSortOrder(opt.sortBy, opt.sortOrder); search.setOpenFilter(null); }}
                   className={`w-full text-left px-4 py-2 text-sm hover:bg-[var(--surface-hover)] ${
                     search.searchSortBy === opt.sortBy && search.searchSortOrder === opt.sortOrder
                       ? 'text-grape-600 font-medium'


### PR DESCRIPTION
## Summary
- 정렬/유형 필터 선택 후 드롭다운이 열려있던 문제 수정 (선택 시 자동 닫힘)
- 바텀시트(카테고리, 가구) 스크롤 시 배경 화면 같이 움직이는 문제 수정
- PWA에서 바텀시트 스크롤 시 pull-to-refresh 되는 문제 차단
- release/hotfix → main PR은 merge commit 사용 규칙 문서화

## Test plan
- [ ] 정렬 옵션 선택 시 드롭다운 자동 닫힘 확인
- [ ] 유형(지출/수입) 필터 선택 시 드롭다운 자동 닫힘 확인
- [ ] 카테고리 바텀시트에서 스크롤 시 배경 안 움직이는지 확인 (PWA)
- [ ] 가구 전환 바텀시트에서 동일하게 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)