### PR TITLE
feat: 정기거래 UX 개선 — 나중에/금액수정/달력예정표시

### DIFF
--- a/backend/app/api/recurring.py
+++ b/backend/app/api/recurring.py
@@ -21,6 +21,7 @@ from app.models.income import Income
 from app.models.recurring_transaction import RecurringTransaction
 from app.models.user import User
 from app.schemas.recurring_transaction import (
+    ExecuteRequest,
     ExecuteResponse,
     RecurringTransactionCreate,
     RecurringTransactionResponse,
@@ -213,10 +214,14 @@ async def delete_recurring(
 @router.post("/{recurring_id}/execute", response_model=ExecuteResponse, status_code=status.HTTP_201_CREATED)
 async def execute_recurring_transaction(
     recurring_id: int,
+    body: ExecuteRequest | None = None,  # 금액 재정의 가능 (None이면 기본 금액 사용)
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> object:
-    """정기 거래 실행 → Expense 또는 Income 생성"""
+    """정기 거래 실행 → Expense 또는 Income 생성
+
+    body.amount를 전달하면 기본 금액 대신 재정의 금액으로 거래를 생성합니다 (#596).
+    """
     # 권한 확인 (가구 멤버십 포함)
     await _get_user_recurring(recurring_id, current_user, db)
 
@@ -230,10 +235,14 @@ async def execute_recurring_transaction(
             detail="비활성화된 정기 거래는 실행할 수 없습니다",
         )
 
-    created_id = await execute_recurring(recurring, db)
+    # body.amount가 있으면 재정의 금액 사용, 없으면 기본 금액 사용
+    override_amount = body.amount if body is not None else None
+    created_id = await execute_recurring(recurring, db, amount_override=override_amount)
 
+    # 메시지에는 실제 사용된 금액 표시
+    actual_amount = override_amount if override_amount is not None else float(recurring.amount)
     return ExecuteResponse(
-        message=f"{recurring.description} {float(recurring.amount):,.0f}원이 {'지출' if recurring.type == 'expense' else '수입'}으로 등록되었습니다",
+        message=f"{recurring.description} {actual_amount:,.0f}원이 {'지출' if recurring.type == 'expense' else '수입'}으로 등록되었습니다",
         created_id=created_id,
         type=recurring.type,
         next_due_date=recurring.next_due_date,

--- a/backend/app/schemas/recurring_transaction.py
+++ b/backend/app/schemas/recurring_transaction.py
@@ -57,6 +57,12 @@ class RecurringTransactionResponse(RecurringTransactionBase):
     model_config = {"from_attributes": True}
 
 
+class ExecuteRequest(BaseModel):
+    """정기거래 실행 시 선택적으로 금액을 재정의할 수 있는 요청 스키마"""
+
+    amount: float | None = Field(None, gt=0, description="재정의 금액 (None이면 정기거래의 기본 금액 사용)")
+
+
 class ExecuteResponse(BaseModel):
     """정기 거래 실행 결과"""
 

--- a/backend/app/services/recurring_service.py
+++ b/backend/app/services/recurring_service.py
@@ -97,7 +97,8 @@ async def execute_recurring(
     Returns:
         생성된 Expense/Income의 ID
     """
-    amount = amount_override or float(recurring.amount)
+    # amount_override가 None이면 정기거래의 기본 금액 사용
+    amount = amount_override if amount_override is not None else float(recurring.amount)
 
     if recurring.type == "expense":
         record = Expense(

--- a/backend/tests/integration/test_api_recurring.py
+++ b/backend/tests/integration/test_api_recurring.py
@@ -646,3 +646,83 @@ async def test_create_recurring_without_source_id_keeps_existing_behavior(authen
     )
     assert response.status_code == 201
     assert response.json()["next_due_date"] == today.isoformat()
+
+
+# --- 금액 재정의 실행 (#596) ---
+
+
+@pytest.mark.asyncio
+async def test_execute_with_override_amount(authenticated_client, db_session, test_user: User, test_household: Household):
+    """금액 재정의로 실행하면 재정의된 금액으로 거래가 생성된다"""
+    from sqlalchemy import select
+
+    from app.models.expense import Expense
+
+    recurring = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=17000,
+        description="넷플릭스",
+        frequency="monthly",
+        day_of_month=25,
+        start_date=date(2026, 1, 1),
+        next_due_date=date(2026, 2, 25),
+        is_active=True,
+    )
+    db_session.add(recurring)
+    await db_session.commit()
+    await db_session.refresh(recurring)
+
+    # 기본 금액(17000) 대신 19000으로 재정의하여 실행
+    response = await authenticated_client.post(
+        f"/api/recurring/{recurring.id}/execute",
+        json={"amount": 19000},
+    )
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["type"] == "expense"
+    assert data["created_id"] > 0
+
+    # 실제 생성된 Expense의 금액이 재정의된 금액인지 확인
+    result = await db_session.execute(select(Expense).where(Expense.id == data["created_id"]))
+    created_expense = result.scalar_one()
+    assert float(created_expense.amount) == 19000
+
+
+@pytest.mark.asyncio
+async def test_execute_without_body_uses_default_amount(authenticated_client, db_session, test_user: User, test_household: Household):
+    """바디 없이 실행하면 기본 금액으로 거래가 생성된다"""
+    from sqlalchemy import select
+
+    from app.models.expense import Expense
+
+    recurring = RecurringTransaction(
+        user_id=test_user.id,
+        household_id=test_household.id,
+        type="expense",
+        amount=17000,
+        description="넷플릭스",
+        frequency="monthly",
+        day_of_month=25,
+        start_date=date(2026, 1, 1),
+        next_due_date=date(2026, 2, 25),
+        is_active=True,
+    )
+    db_session.add(recurring)
+    await db_session.commit()
+    await db_session.refresh(recurring)
+
+    # 바디 없이 실행 (기존 동작 유지)
+    response = await authenticated_client.post(f"/api/recurring/{recurring.id}/execute")
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["type"] == "expense"
+    assert data["created_id"] > 0
+
+    # 실제 생성된 Expense의 금액이 정기거래 기본 금액인지 확인
+    result = await db_session.execute(select(Expense).where(Expense.id == data["created_id"]))
+    created_expense = result.scalar_one()
+    assert float(created_expense.amount) == 17000

--- a/frontend/src/api/recurring.ts
+++ b/frontend/src/api/recurring.ts
@@ -24,8 +24,8 @@ export const recurringApi = {
   delete: (id: number) =>
     apiClient.delete(`/recurring/${id}`),
 
-  execute: (id: number) =>
-    apiClient.post<ExecuteResponse>(`/recurring/${id}/execute`),
+  execute: (id: number, amount?: number) =>
+    apiClient.post<ExecuteResponse>(`/recurring/${id}/execute`, amount != null ? { amount } : undefined),
 
   skip: (id: number) =>
     apiClient.post<{ next_due_date: string }>(`/recurring/${id}/skip`),

--- a/frontend/src/components/MiniCalendar.tsx
+++ b/frontend/src/components/MiniCalendar.tsx
@@ -9,6 +9,8 @@ import { getCalendarGrid } from '../utils/calendar'
 interface DaySummary {
   expense: number
   income: number
+  scheduledExpense?: number  // 예정 정기 지출 합계
+  scheduledIncome?: number   // 예정 정기 수입 합계
 }
 
 interface MiniCalendarProps {
@@ -90,13 +92,22 @@ function MiniCalendar({
                 >
                   {day.date}
                 </span>
-                {summary && (summary.expense > 0 || summary.income > 0) && (
+                {summary && (summary.expense > 0 || summary.income > 0
+                  || (summary.scheduledExpense ?? 0) > 0 || (summary.scheduledIncome ?? 0) > 0) && (
                   <div className="flex items-center justify-center gap-0.5 mt-0.5">
+                    {/* 실제 거래 채워진 점 */}
                     {summary.expense > 0 && (
                       <div data-testid="dot" className="w-1.5 h-1.5 rounded-full bg-grape-400" />
                     )}
                     {summary.income > 0 && (
                       <div data-testid="dot" className="w-1.5 h-1.5 rounded-full bg-leaf-400" />
+                    )}
+                    {/* 예정 정기거래 빈 원 — 채워진 점과 시각적 구분 */}
+                    {(summary.scheduledExpense ?? 0) > 0 && (
+                      <div data-testid="ring" className="w-1.5 h-1.5 rounded-full border border-grape-300 dark:border-grape-400" />
+                    )}
+                    {(summary.scheduledIncome ?? 0) > 0 && (
+                      <div data-testid="ring" className="w-1.5 h-1.5 rounded-full border border-leaf-300 dark:border-leaf-400" />
                     )}
                   </div>
                 )}

--- a/frontend/src/components/__tests__/MiniCalendar.test.tsx
+++ b/frontend/src/components/__tests__/MiniCalendar.test.tsx
@@ -100,4 +100,60 @@ describe('MiniCalendar', () => {
     const dots = cell?.querySelectorAll('[data-testid="dot"]')
     expect(dots?.length ?? 0).toBe(0)
   })
+
+  describe('예정 정기거래 ring 인디케이터', () => {
+    it('예정 정기지출이 있는 날에 grape ring이 표시된다', () => {
+      const summaries = new Map([
+        ['2026-03-20', { expense: 0, income: 0, scheduledExpense: 14900 }],
+      ])
+      renderCalendar({ daySummaries: summaries })
+      const cell = document.querySelector('[data-date="2026-03-20"]')
+      const rings = cell?.querySelectorAll('[data-testid="ring"]')
+      expect(rings?.length).toBe(1)
+      expect(rings?.[0]?.className).toContain('border-grape-300')
+    })
+
+    it('예정 정기수입이 있는 날에 leaf ring이 표시된다', () => {
+      const summaries = new Map([
+        ['2026-03-25', { expense: 0, income: 0, scheduledIncome: 3500000 }],
+      ])
+      renderCalendar({ daySummaries: summaries })
+      const cell = document.querySelector('[data-date="2026-03-25"]')
+      const rings = cell?.querySelectorAll('[data-testid="ring"]')
+      expect(rings?.length).toBe(1)
+      expect(rings?.[0]?.className).toContain('border-leaf-300')
+    })
+
+    it('실제 거래와 예정이 같은 날에 있으면 dot과 ring 모두 표시된다', () => {
+      const summaries = new Map([
+        ['2026-03-14', { expense: 8000, income: 0, scheduledExpense: 14900 }],
+      ])
+      renderCalendar({ daySummaries: summaries })
+      const cell = document.querySelector('[data-date="2026-03-14"]')
+      const dots = cell?.querySelectorAll('[data-testid="dot"]')
+      const rings = cell?.querySelectorAll('[data-testid="ring"]')
+      expect(dots?.length).toBe(1)
+      expect(rings?.length).toBe(1)
+    })
+
+    it('예정 정기지출+수입 둘 다 있으면 ring 2개 표시된다', () => {
+      const summaries = new Map([
+        ['2026-03-15', { expense: 0, income: 0, scheduledExpense: 14900, scheduledIncome: 500000 }],
+      ])
+      renderCalendar({ daySummaries: summaries })
+      const cell = document.querySelector('[data-date="2026-03-15"]')
+      const rings = cell?.querySelectorAll('[data-testid="ring"]')
+      expect(rings?.length).toBe(2)
+    })
+
+    it('예정 금액이 0이면 ring이 표시되지 않는다', () => {
+      const summaries = new Map([
+        ['2026-03-20', { expense: 0, income: 0, scheduledExpense: 0, scheduledIncome: 0 }],
+      ])
+      renderCalendar({ daySummaries: summaries })
+      const cell = document.querySelector('[data-date="2026-03-20"]')
+      const rings = cell?.querySelectorAll('[data-testid="ring"]')
+      expect(rings?.length ?? 0).toBe(0)
+    })
+  })
 })

--- a/frontend/src/components/transaction/MonthlyView.tsx
+++ b/frontend/src/components/transaction/MonthlyView.tsx
@@ -140,9 +140,9 @@ export default function MonthlyView({
       {/* 오늘 처리 대기 중인 정기거래 카드 */}
       <TodayRecurringCard
         items={monthly.allRecurring}
-        onExecute={async (id) => {
+        onExecute={async (id, amount) => {
           try {
-            await recurringApi.execute(id)
+            await recurringApi.execute(id, amount)
             addToast('success', TOAST.RECURRING_EXECUTED)
             monthly.fetchData()
           } catch {

--- a/frontend/src/components/transaction/MonthlyView.tsx
+++ b/frontend/src/components/transaction/MonthlyView.tsx
@@ -12,6 +12,7 @@ import HeroSummary from '../stats/HeroSummary'
 import MiniCalendar from '../MiniCalendar'
 import TransactionItem from '../TransactionItem'
 import TodayRecurringCard from './TodayRecurringCard'
+import ScheduledPopover from './ScheduledPopover'
 import EmptyState from '../EmptyState'
 import WelcomeCard from '../WelcomeCard'
 import BotNudgeCard from '../BotNudgeCard'
@@ -89,13 +90,31 @@ export default function MonthlyView({
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
   }, [])
 
-  // 캘린더 날짜 클릭 -> 스크롤
+  // 예정 정기거래 팝오버 상태
+  const [popoverDate, setPopoverDate] = useState<string | null>(null)
+  const handlePopoverClose = useCallback(() => setPopoverDate(null), [])
+  const popoverItems = useMemo(() => {
+    if (!popoverDate) return []
+    return monthly.scheduledItems.get(popoverDate) ?? []
+  }, [popoverDate, monthly.scheduledItems])
+
+  // 캘린더 날짜 클릭 → 기존 거래가 있으면 스크롤, 예정 정기거래만 있으면 팝오버
   const handleDateClick = useCallback((dateString: string) => {
+    // 기존 거래가 있으면 해당 날짜로 스크롤
     const ref = dateRefs.current.get(dateString)
     if (ref) {
+      setPopoverDate(null)
       ref.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      return
     }
-  }, [])
+    // 예정 정기거래가 있으면 팝오버 토글
+    const scheduled = monthly.scheduledItems.get(dateString)
+    if (scheduled && scheduled.length > 0) {
+      setPopoverDate(prev => prev === dateString ? null : dateString)
+    } else {
+      setPopoverDate(null)
+    }
+  }, [monthly.scheduledItems])
 
   return (
     <>
@@ -212,6 +231,15 @@ export default function MonthlyView({
             <ChevronUp className="w-3.5 h-3.5 text-[var(--text-tertiary)]" />
           </button>
         </div>
+      )}
+
+      {/* 예정 정기거래 팝오버 — 달력 아래에 표시 */}
+      {popoverDate && popoverItems.length > 0 && (
+        <ScheduledPopover
+          date={popoverDate}
+          items={popoverItems}
+          onClose={handlePopoverClose}
+        />
       )}
 
       {/* 거래 리스트 */}

--- a/frontend/src/components/transaction/ScheduledPopover.tsx
+++ b/frontend/src/components/transaction/ScheduledPopover.tsx
@@ -1,0 +1,83 @@
+/**
+ * @file ScheduledPopover.tsx
+ * @description 달력에서 미래 날짜 클릭 시 예정된 정기거래 항목을 보여주는 팝오버
+ */
+
+import { useEffect, useRef } from 'react'
+import { CalendarClock } from 'lucide-react'
+import { formatAmount } from '../../utils/format'
+
+interface ScheduledItem {
+  id: number
+  description: string
+  amount: number
+  type: 'expense' | 'income'
+}
+
+interface ScheduledPopoverProps {
+  date: string // YYYY-MM-DD
+  items: ScheduledItem[]
+  onClose: () => void
+}
+
+/** 날짜에서 일(day) 부분만 추출하여 "N일 예정" 형태로 표시 */
+function formatPopoverTitle(date: string): string {
+  const day = parseInt(date.slice(8, 10), 10)
+  return `${day}일 예정`
+}
+
+export default function ScheduledPopover({ date, items, onClose }: ScheduledPopoverProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  // 팝오버 바깥 클릭 또는 ESC로 닫기
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [onClose])
+
+  if (items.length === 0) return null
+
+  return (
+    <div
+      ref={ref}
+      data-testid="scheduled-popover"
+      className="bg-[var(--surface-card)] rounded-xl shadow-lg border border-[var(--border-default)] p-3 mt-1 animate-fade-in"
+    >
+      <div className="flex items-center gap-1.5 mb-2">
+        <CalendarClock className="w-3.5 h-3.5 text-grape-400" />
+        <span className="text-xs font-semibold text-[var(--text-secondary)]">
+          {formatPopoverTitle(date)}
+        </span>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {items.map((item) => (
+          <div key={item.id} className="flex items-center justify-between gap-3">
+            <span className="text-sm text-[var(--text-primary)] truncate">
+              {item.description}
+            </span>
+            <span
+              className={`text-sm font-medium tabular-nums whitespace-nowrap ${
+                item.type === 'income' ? 'text-leaf-500' : 'text-grape-500'
+              }`}
+            >
+              {item.type === 'income' ? '+' : ''}{formatAmount(item.amount)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/transaction/TodayRecurringCard.tsx
+++ b/frontend/src/components/transaction/TodayRecurringCard.tsx
@@ -1,11 +1,12 @@
 import { useState, useMemo, useEffect } from 'react'
 import { formatAmount, getLocalDateString } from '../../utils/format'
+import { useToast } from '../../hooks/useToast'
 import type { RecurringTransaction } from '../../types'
 
 // sessionStorage 키: 현재 세션에서 "나중에" 처리된 정기거래 ID 목록
 const SNOOZE_KEY = 'podo-snoozed-recurring'
 
-interface TodayRecurringCardProps {
+type TodayRecurringCardProps = {
   items: RecurringTransaction[]
   onExecute: (id: number, amount?: number) => Promise<void>
   onSkip: (id: number) => Promise<void>
@@ -17,6 +18,7 @@ interface TodayRecurringCardProps {
  *  snoozedIds는 sessionStorage 기반 — 탭 닫으면 초기화되어 다음 방문 시 재표시된다.
  */
 export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRecurringCardProps) {
+  const { addToast } = useToast()
   const [processedIds, setProcessedIds] = useState<Set<number>>(new Set())
   const [snoozedIds, setSnoozedIds] = useState<Set<number>>(() => {
     // 마운트 시 sessionStorage에서 스누즈 목록 복원
@@ -37,7 +39,8 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
     setProcessedIds(new Set())
   }, [items])
 
-  const today = getLocalDateString()
+  // 날짜는 마운트 시 한 번만 계산 (렌더링마다 재계산 방지)
+  const today = useMemo(() => getLocalDateString(), [])
 
   // 오늘 또는 이전 날짜가 due_date이고, 처리/스누즈되지 않은 정기거래만 필터링
   const visibleItems = useMemo(
@@ -71,7 +74,8 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
       setProcessedIds(prev => new Set(prev).add(current.id))
       resetEditing()
     } catch {
-      // 실패 시 버튼 복원 (처리 상태 변경 없음)
+      // 실패 시 버튼 복원 (처리 상태 변경 없음), 사용자에게 에러 알림
+      addToast('error', '처리에 실패했습니다. 다시 시도해 주세요.')
     } finally {
       setIsLoading(false)
     }
@@ -146,7 +150,11 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
             <input
               type="number"
               value={editingAmount ?? ''}
-              onChange={e => setEditingAmount(e.target.value === '' ? null : Number(e.target.value))}
+              onChange={e => {
+              const val = Number(e.target.value)
+              setEditingAmount(e.target.value === '' || isNaN(val) ? null : val)
+            }}
+              aria-label="변경할 금액"
               className="flex-1 px-3 py-2 text-sm bg-transparent text-[var(--text-primary)] outline-none"
               placeholder={String(current.amount)}
               min={0}

--- a/frontend/src/components/transaction/TodayRecurringCard.tsx
+++ b/frontend/src/components/transaction/TodayRecurringCard.tsx
@@ -155,11 +155,11 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
         </div>
       )}
 
-      {/* 액션 버튼: [등록하기(flex-1)] [나중에(subtle)] [건너뛰기(flex-1)] */}
+      {/* 액션 버튼: [등록하기(flex-1)] [나후(subtle)] [건너뛰기(flex-1)] */}
       <div className="flex gap-2">
         <button
           onClick={() => handleAction('execute')}
-          disabled={isLoading}
+          disabled={isLoading || (isEditing && (editingAmount == null || editingAmount <= 0))}
           className={`flex-1 py-2 rounded-xl text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
             isExpense
               ? 'bg-grape-600 hover:bg-grape-700'

--- a/frontend/src/components/transaction/TodayRecurringCard.tsx
+++ b/frontend/src/components/transaction/TodayRecurringCard.tsx
@@ -7,7 +7,7 @@ const SNOOZE_KEY = 'podo-snoozed-recurring'
 
 interface TodayRecurringCardProps {
   items: RecurringTransaction[]
-  onExecute: (id: number) => Promise<void>
+  onExecute: (id: number, amount?: number) => Promise<void>
   onSkip: (id: number) => Promise<void>
 }
 
@@ -28,6 +28,9 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
     }
   })
   const [isLoading, setIsLoading] = useState(false)
+  // 금액 수정 모드 상태: null이면 수정 안 함, 숫자면 사용자가 입력한 금액
+  const [isEditing, setIsEditing] = useState(false)
+  const [editingAmount, setEditingAmount] = useState<number | null>(null)
 
   // items 참조가 바뀌면 (refetch 후) processedIds 클리어 — 실행된 건은 이미 next_due_date가 다음 달로 이동해 pendingItems에서 제외됨
   useEffect(() => {
@@ -49,16 +52,24 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
   const total = visibleItems.length
   const isExpense = current.type === 'expense'
 
+  // 카드 항목이 바뀔 때 편집 상태 초기화 (다음 항목으로 이동 시)
+  const resetEditing = () => {
+    setIsEditing(false)
+    setEditingAmount(null)
+  }
+
   const handleAction = async (action: 'execute' | 'skip') => {
     setIsLoading(true)
     try {
       if (action === 'execute') {
-        await onExecute(current.id)
+        // 금액 수정 모드였다면 수정된 금액 전달, 아니면 undefined (원래 금액 사용)
+        await onExecute(current.id, editingAmount ?? undefined)
       } else {
         await onSkip(current.id)
       }
       // 성공 시 처리된 ID 추가 → visibleItems에서 자동으로 제외
       setProcessedIds(prev => new Set(prev).add(current.id))
+      resetEditing()
     } catch {
       // 실패 시 버튼 복원 (처리 상태 변경 없음)
     } finally {
@@ -74,6 +85,18 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
       sessionStorage.setItem(SNOOZE_KEY, JSON.stringify([...next]))
       return next
     })
+    resetEditing()
+  }
+
+  /** 금액 수정 토글: 수정 모드 진입 시 현재 금액으로 초기화 */
+  const handleToggleEditing = () => {
+    if (isEditing) {
+      // 수정 취소 시 상태 초기화
+      resetEditing()
+    } else {
+      setIsEditing(true)
+      setEditingAmount(current.amount)
+    }
   }
 
   return (
@@ -84,7 +107,7 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
       </div>
 
       {/* 카드 본문 */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-2 min-w-0">
           {/* 지출/수입 아이콘 */}
           <span className="text-lg">{isExpense ? '💸' : '💰'}</span>
@@ -101,6 +124,36 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
           1/{total}
         </span>
       </div>
+
+      {/* 금액 수정 토글 버튼 */}
+      <div className="mb-3">
+        <button
+          onClick={handleToggleEditing}
+          disabled={isLoading}
+          className="text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] underline underline-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isEditing ? '수정 취소' : '금액 수정'}
+        </button>
+      </div>
+
+      {/* 금액 수정 입력 필드 (수정 모드일 때만 표시) */}
+      {isEditing && (
+        <div className="mb-3">
+          <div className="flex items-center border border-[var(--border-default)] rounded-lg overflow-hidden">
+            <span className="px-3 py-2 text-sm text-[var(--text-tertiary)] bg-[var(--surface-elevated)] border-r border-[var(--border-default)]">
+              ₩
+            </span>
+            <input
+              type="number"
+              value={editingAmount ?? ''}
+              onChange={e => setEditingAmount(e.target.value === '' ? null : Number(e.target.value))}
+              className="flex-1 px-3 py-2 text-sm bg-transparent text-[var(--text-primary)] outline-none"
+              placeholder={String(current.amount)}
+              min={0}
+            />
+          </div>
+        </div>
+      )}
 
       {/* 액션 버튼: [등록하기(flex-1)] [나중에(subtle)] [건너뛰기(flex-1)] */}
       <div className="flex gap-2">

--- a/frontend/src/components/transaction/TodayRecurringCard.tsx
+++ b/frontend/src/components/transaction/TodayRecurringCard.tsx
@@ -2,6 +2,9 @@ import { useState, useMemo, useEffect } from 'react'
 import { formatAmount, getLocalDateString } from '../../utils/format'
 import type { RecurringTransaction } from '../../types'
 
+// sessionStorage 키: 현재 세션에서 "나중에" 처리된 정기거래 ID 목록
+const SNOOZE_KEY = 'podo-snoozed-recurring'
+
 interface TodayRecurringCardProps {
   items: RecurringTransaction[]
   onExecute: (id: number) => Promise<void>
@@ -11,9 +14,19 @@ interface TodayRecurringCardProps {
 /** 오늘 기준 처리 대기 중인 정기거래를 카드 스택으로 보여주는 컴포넌트.
  *  한 번에 하나씩 표시하고, 등록/건너뛰기 후 다음 항목으로 이동한다.
  *  processedIds로 처리 상태를 추적하여 items 참조가 바뀌어도 안전하게 동작한다.
+ *  snoozedIds는 sessionStorage 기반 — 탭 닫으면 초기화되어 다음 방문 시 재표시된다.
  */
 export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRecurringCardProps) {
   const [processedIds, setProcessedIds] = useState<Set<number>>(new Set())
+  const [snoozedIds, setSnoozedIds] = useState<Set<number>>(() => {
+    // 마운트 시 sessionStorage에서 스누즈 목록 복원
+    try {
+      const raw = sessionStorage.getItem(SNOOZE_KEY)
+      return raw ? new Set<number>(JSON.parse(raw)) : new Set<number>()
+    } catch {
+      return new Set<number>()
+    }
+  })
   const [isLoading, setIsLoading] = useState(false)
 
   // items 참조가 바뀌면 (refetch 후) processedIds 클리어 — 실행된 건은 이미 next_due_date가 다음 달로 이동해 pendingItems에서 제외됨
@@ -23,10 +36,10 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
 
   const today = getLocalDateString()
 
-  // 오늘 또는 이전 날짜가 due_date이고 아직 처리하지 않은 정기거래만 필터링
+  // 오늘 또는 이전 날짜가 due_date이고, 처리/스누즈되지 않은 정기거래만 필터링
   const visibleItems = useMemo(
-    () => items.filter(r => r.next_due_date <= today && !processedIds.has(r.id)),
-    [items, today, processedIds],
+    () => items.filter(r => r.next_due_date <= today && !processedIds.has(r.id) && !snoozedIds.has(r.id)),
+    [items, today, processedIds, snoozedIds],
   )
 
   // 처리할 항목이 없으면 렌더링하지 않음
@@ -51,6 +64,16 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
     } finally {
       setIsLoading(false)
     }
+  }
+
+  /** "나중에" 클릭: 이번 세션에서만 숨김. API 호출 없이 즉시 처리 */
+  const handleSnooze = (id: number) => {
+    setSnoozedIds(prev => {
+      const next = new Set(prev).add(id)
+      // sessionStorage에 직렬화하여 저장 — 탭 닫으면 자동 초기화
+      sessionStorage.setItem(SNOOZE_KEY, JSON.stringify([...next]))
+      return next
+    })
   }
 
   return (
@@ -79,7 +102,7 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
         </span>
       </div>
 
-      {/* 액션 버튼 */}
+      {/* 액션 버튼: [등록하기(flex-1)] [나중에(subtle)] [건너뛰기(flex-1)] */}
       <div className="flex gap-2">
         <button
           onClick={() => handleAction('execute')}
@@ -91,6 +114,14 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
           }`}
         >
           등록하기
+        </button>
+        {/* 나중에: 세션 스누즈. 배경 없는 텍스트 버튼으로 시각적 우선순위 낮춤 */}
+        <button
+          onClick={() => handleSnooze(current.id)}
+          disabled={isLoading}
+          className="px-3 py-2 text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          나중에
         </button>
         <button
           onClick={() => handleAction('skip')}

--- a/frontend/src/components/transaction/__tests__/ScheduledPopover.test.tsx
+++ b/frontend/src/components/transaction/__tests__/ScheduledPopover.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @file ScheduledPopover.test.tsx
+ * @description 예정 정기거래 팝오버 컴포넌트 테스트
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ScheduledPopover from '../ScheduledPopover'
+
+const mockItems = [
+  { id: 1, description: '넷플릭스', amount: 14900, type: 'expense' as const },
+  { id: 2, description: '유튜브 프리미엄', amount: 14900, type: 'expense' as const },
+  { id: 3, description: '월급', amount: 3500000, type: 'income' as const },
+]
+
+describe('ScheduledPopover', () => {
+  it('날짜 제목과 항목들을 표시한다', () => {
+    render(<ScheduledPopover date="2026-03-15" items={mockItems} onClose={vi.fn()} />)
+    expect(screen.getByText('15일 예정')).toBeInTheDocument()
+    expect(screen.getByText('넷플릭스')).toBeInTheDocument()
+    expect(screen.getByText('유튜브 프리미엄')).toBeInTheDocument()
+    expect(screen.getByText('월급')).toBeInTheDocument()
+  })
+
+  it('수입에는 + 접두사가 표시된다', () => {
+    render(<ScheduledPopover date="2026-03-25" items={[mockItems[2]]} onClose={vi.fn()} />)
+    expect(screen.getByText('+₩3,500,000')).toBeInTheDocument()
+  })
+
+  it('지출에는 + 접두사가 없다', () => {
+    render(<ScheduledPopover date="2026-03-15" items={[mockItems[0]]} onClose={vi.fn()} />)
+    expect(screen.getByText('₩14,900')).toBeInTheDocument()
+  })
+
+  it('항목이 없으면 렌더링하지 않는다', () => {
+    const { container } = render(<ScheduledPopover date="2026-03-15" items={[]} onClose={vi.fn()} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('ESC 키로 닫힌다', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<ScheduledPopover date="2026-03-15" items={mockItems} onClose={onClose} />)
+    await user.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('바깥 클릭으로 닫힌다', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(
+      <div>
+        <div data-testid="outside">바깥 영역</div>
+        <ScheduledPopover date="2026-03-15" items={mockItems} onClose={onClose} />
+      </div>
+    )
+    await user.click(screen.getByTestId('outside'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/transaction/__tests__/TodayRecurringCard.test.tsx
+++ b/frontend/src/components/transaction/__tests__/TodayRecurringCard.test.tsx
@@ -4,6 +4,11 @@ import userEvent from '@testing-library/user-event'
 import TodayRecurringCard from '../TodayRecurringCard'
 import type { RecurringTransaction } from '../../../types'
 
+const mockAddToast = vi.fn()
+vi.mock('../../../hooks/useToast', () => ({
+  useToast: () => ({ addToast: mockAddToast, removeToast: vi.fn() }),
+}))
+
 const makeItem = (overrides: Partial<RecurringTransaction>): RecurringTransaction => ({
   id: 1, user_id: 1, household_id: 1, type: 'expense',
   amount: 17000, description: '넷플릭스', category_id: null,
@@ -16,7 +21,10 @@ const makeItem = (overrides: Partial<RecurringTransaction>): RecurringTransactio
 })
 
 describe('TodayRecurringCard', () => {
-  beforeEach(() => sessionStorage.clear())
+  beforeEach(() => {
+    sessionStorage.clear()
+    mockAddToast.mockClear()
+  })
   it('빈 배열이면 아무것도 렌더링하지 않는다', () => {
     const { container } = render(
       <TodayRecurringCard items={[]} onExecute={vi.fn()} onSkip={vi.fn()} />
@@ -91,6 +99,17 @@ describe('TodayRecurringCard', () => {
     await userEvent.click(screen.getByText('등록하기'))
     await waitFor(() => {
       expect(screen.getByText('등록하기').closest('button')).not.toBeDisabled()
+    })
+  })
+
+  it('API 실패 시 에러 토스트가 표시된다', async () => {
+    const onExecute = vi.fn().mockRejectedValue(new Error('fail'))
+    render(
+      <TodayRecurringCard items={[makeItem({ id: 1, next_due_date: '2026-01-01' })]} onExecute={onExecute} onSkip={vi.fn()} />
+    )
+    await userEvent.click(screen.getByText('등록하기'))
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith('error', expect.any(String))
     })
   })
 

--- a/frontend/src/components/transaction/__tests__/TodayRecurringCard.test.tsx
+++ b/frontend/src/components/transaction/__tests__/TodayRecurringCard.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TodayRecurringCard from '../TodayRecurringCard'
@@ -16,6 +16,7 @@ const makeItem = (overrides: Partial<RecurringTransaction>): RecurringTransactio
 })
 
 describe('TodayRecurringCard', () => {
+  beforeEach(() => sessionStorage.clear())
   it('빈 배열이면 아무것도 렌더링하지 않는다', () => {
     const { container } = render(
       <TodayRecurringCard items={[]} onExecute={vi.fn()} onSkip={vi.fn()} />
@@ -90,5 +91,24 @@ describe('TodayRecurringCard', () => {
     await waitFor(() => {
       expect(screen.getByText('등록하기').closest('button')).not.toBeDisabled()
     })
+  })
+
+  it('나중에 버튼 클릭 시 카드가 사라진다', async () => {
+    render(
+      <TodayRecurringCard items={[makeItem({ id: 1, next_due_date: '2026-01-01' })]} onExecute={vi.fn()} onSkip={vi.fn()} />
+    )
+    await userEvent.click(screen.getByText('나중에'))
+    expect(screen.queryByText('넷플릭스')).toBeNull()
+  })
+
+  it('나중에 클릭해도 onExecute/onSkip이 호출되지 않는다', async () => {
+    const onExecute = vi.fn()
+    const onSkip = vi.fn()
+    render(
+      <TodayRecurringCard items={[makeItem({ id: 1, next_due_date: '2026-01-01' })]} onExecute={onExecute} onSkip={onSkip} />
+    )
+    await userEvent.click(screen.getByText('나중에'))
+    expect(onExecute).not.toHaveBeenCalled()
+    expect(onSkip).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/transaction/__tests__/TodayRecurringCard.test.tsx
+++ b/frontend/src/components/transaction/__tests__/TodayRecurringCard.test.tsx
@@ -59,7 +59,8 @@ describe('TodayRecurringCard', () => {
       <TodayRecurringCard items={[makeItem({ id: 5, next_due_date: '2026-01-01' })]} onExecute={onExecute} onSkip={vi.fn()} />
     )
     await userEvent.click(screen.getByText('등록하기'))
-    expect(onExecute).toHaveBeenCalledWith(5)
+    // 금액 수정 없이 등록하면 amount는 undefined
+    expect(onExecute).toHaveBeenCalledWith(5, undefined)
   })
 
   it('건너뛰기 버튼 클릭 시 onSkip이 호출된다', async () => {
@@ -110,5 +111,35 @@ describe('TodayRecurringCard', () => {
     await userEvent.click(screen.getByText('나중에'))
     expect(onExecute).not.toHaveBeenCalled()
     expect(onSkip).not.toHaveBeenCalled()
+  })
+
+  it('금액 수정 버튼을 클릭하면 입력 필드가 표시된다', async () => {
+    render(
+      <TodayRecurringCard items={[makeItem({ id: 1, amount: 17000, next_due_date: '2026-01-01' })]} onExecute={vi.fn()} onSkip={vi.fn()} />
+    )
+    await userEvent.click(screen.getByText('금액 수정'))
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument()
+  })
+
+  it('금액 수정 후 등록하면 수정된 금액으로 onExecute가 호출된다', async () => {
+    const onExecute = vi.fn().mockResolvedValue(undefined)
+    render(
+      <TodayRecurringCard items={[makeItem({ id: 5, amount: 17000, next_due_date: '2026-01-01' })]} onExecute={onExecute} onSkip={vi.fn()} />
+    )
+    await userEvent.click(screen.getByText('금액 수정'))
+    const input = screen.getByRole('spinbutton')
+    await userEvent.clear(input)
+    await userEvent.type(input, '19000')
+    await userEvent.click(screen.getByText('등록하기'))
+    expect(onExecute).toHaveBeenCalledWith(5, 19000)
+  })
+
+  it('금액 수정 없이 등록하면 amount 없이 onExecute가 호출된다', async () => {
+    const onExecute = vi.fn().mockResolvedValue(undefined)
+    render(
+      <TodayRecurringCard items={[makeItem({ id: 5, next_due_date: '2026-01-01' })]} onExecute={onExecute} onSkip={vi.fn()} />
+    )
+    await userEvent.click(screen.getByText('등록하기'))
+    expect(onExecute).toHaveBeenCalledWith(5, undefined)
   })
 })

--- a/frontend/src/data/changelogs.ts
+++ b/frontend/src/data/changelogs.ts
@@ -18,6 +18,17 @@ export interface Changelog {
 
 export const changelogs: Changelog[] = [
   {
+    version: '0.20.0',
+    date: '2026-04-09',
+    title: '정기거래 UX 개선',
+    items: [
+      { tag: '신규', text: '달력에 정기거래 예정일이 빈 원(○)으로 미리 표시됩니다' },
+      { tag: '신규', text: '정기거래 카드에서 "나중에" 버튼으로 세션 동안 숨길 수 있습니다' },
+      { tag: '신규', text: '정기거래 등록 시 금액을 수정하여 등록할 수 있습니다' },
+      { tag: '신규', text: '달력에서 예정일을 클릭하면 예정 내역을 확인할 수 있습니다' },
+    ],
+  },
+  {
     version: '0.19.0',
     date: '2026-04-09',
     title: '예산 현황 한눈에 보기',

--- a/frontend/src/hooks/useMonthlyTransactions.ts
+++ b/frontend/src/hooks/useMonthlyTransactions.ts
@@ -206,7 +206,7 @@ export function useMonthlyTransactions({ activeHouseholdId }: UseMonthlyTransact
   const categoryMap = useMemo(() => new Map(categories.map(c => [c.id, c])), [categories])
 
   // 통합 + 정렬 + 그룹핑
-  const { grouped, totalExpense, totalIncome, daySummaries } = useMemo(() => {
+  const { grouped, totalExpense, totalIncome, daySummaries, scheduledItems } = useMemo(() => {
     const all: UnifiedTransaction[] = [
       ...expenses.map(e => ({ ...e, type: 'expense' as const })),
       ...incomes.map(i => ({ ...i, type: 'income' as const })),
@@ -245,9 +245,8 @@ export function useMonthlyTransactions({ activeHouseholdId }: UseMonthlyTransact
     for (const i of incomes) totalIncome += i.amount
 
     // 캘린더 날짜별 요약 (타입+카테고리 필터 반영)
-    const daySummaries = new Map<string, { expense: number; income: number }>()
-    const calendarSource = filtered
-    for (const tx of calendarSource) {
+    const daySummaries = new Map<string, { expense: number; income: number; scheduledExpense?: number; scheduledIncome?: number }>()
+    for (const tx of filtered) {
       const key = tx.date.slice(0, 10)
       const s = daySummaries.get(key) ?? { expense: 0, income: 0 }
       if (tx.type === 'expense') s.expense += tx.amount
@@ -255,8 +254,29 @@ export function useMonthlyTransactions({ activeHouseholdId }: UseMonthlyTransact
       daySummaries.set(key, s)
     }
 
-    return { grouped, totalExpense, totalIncome, daySummaries }
-  }, [expenses, incomes, categoryFilter, categoryMap])
+    // 정기거래 예정일을 daySummaries + scheduledItemsMap에 동시 추가 (달력 빈 원 표시 + 팝오버용)
+    const scheduledItemsMap = new Map<string, { id: number; description: string; amount: number; type: 'expense' | 'income' }[]>()
+    for (const r of allRecurring) {
+      const key = r.next_due_date.slice(0, 10)
+      if (key >= start && key < end) {
+        // daySummaries 업데이트
+        const s = daySummaries.get(key) ?? { expense: 0, income: 0 }
+        if (r.type === 'expense') {
+          s.scheduledExpense = (s.scheduledExpense ?? 0) + r.amount
+        } else {
+          s.scheduledIncome = (s.scheduledIncome ?? 0) + r.amount
+        }
+        daySummaries.set(key, s)
+
+        // scheduledItemsMap 업데이트
+        const items = scheduledItemsMap.get(key) ?? []
+        items.push({ id: r.id, description: r.description, amount: r.amount, type: r.type })
+        scheduledItemsMap.set(key, items)
+      }
+    }
+
+    return { grouped, totalExpense, totalIncome, daySummaries, scheduledItems: scheduledItemsMap }
+  }, [expenses, incomes, categoryFilter, categoryMap, allRecurring, start, end])
 
   const monthLabel = `${currentMonth + 1}월`
 
@@ -276,6 +296,7 @@ export function useMonthlyTransactions({ activeHouseholdId }: UseMonthlyTransact
     allRecurring,
     pendingRecurring,
     pendingRecurringExpense,
+    scheduledItems,
     setPendingRecurring,
 
     // 상태 업데이터 (카테고리 변경 등에서 사용 — 캐시 직접 업데이트)


### PR DESCRIPTION
## Summary
- 정기거래 카드에 "나중에" 버튼 추가 — 세션 기반으로 카드 숨김 (#597)
- 정기거래 등록 시 금액 수정 가능 — 유동 금액(관리비 등) 지원 (#596)
- 달력에 정기거래 예정일을 빈 원(○)으로 표시 + 클릭 시 팝오버 (#595)

## Changes

### #597 나중에 보기
- TodayRecurringCard에 "나중에" 버튼 추가
- sessionStorage 기반 — 현재 세션에서만 숨김, 앱 재접속 시 다시 표시
- 백엔드 변경 없음

### #596 금액 수정 등록
- **BE**: `POST /recurring/{id}/execute`에 optional body `{ amount }` 추가
- **FE**: 카드에 "금액 수정" 인라인 입력 UI, 0 이하 금액 검증
- 예상 금액(정기거래 amount)과 실제 금액(등록 시) 분리

### #595 달력 빈 원 + 팝오버
- MiniCalendar DaySummary에 scheduledExpense/scheduledIncome 추가
- 과거=채워진 점(●), 미래=빈 원(○)으로 시각 구분
- 미래 예정일 클릭 시 ScheduledPopover로 내역 확인

## Test plan
- [x] FE 1,459 테스트 통과 (119 파일)
- [x] BE 1,684 테스트 통과
- [x] ESLint 에러 0건
- [x] 프로덕션 빌드 성공
- [ ] 정기거래 카드 나중에/등록/건너뛰기 동작 확인
- [ ] 금액 수정 후 등록 시 수정된 금액으로 기록 확인
- [ ] 달력 빈 원 표시 + 팝오버 동작 확인

close #595 close #596 close #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)