### PR TITLE
fix: 히어로 카드 + 팝오버 + 정기거래 카드 UX 개선

### DIFF
--- a/frontend/src/components/stats/HeroSummary.tsx
+++ b/frontend/src/components/stats/HeroSummary.tsx
@@ -114,7 +114,7 @@ function buildAriaLabel(
   const budgetStr = formatAmount(totalBudget as number)
   switch (state.type) {
     case 'normal':
-      return `예산 ${budgetStr} 중 ${formatAmount(totalExpense)} 사용, ${formatAmount(pendingRecurringExpense)} 예정, ${formatAmount(state.remaining)} 여유`
+      return `예산 ${budgetStr} 중 ${formatAmount(totalExpense)} 사용, ${formatAmount(pendingRecurringExpense)} 예정, ${formatAmount(state.remaining)} 남은`
     case 'noRecurring':
       return `예산 ${budgetStr} 중 ${formatAmount(totalExpense)} 사용, ${formatAmount(state.remaining)} 남음`
     case 'projectedExceed':
@@ -133,13 +133,11 @@ function ProgressBar({
   totalExpense,
   totalBudget,
   pendingRecurringExpense,
-  onProgressClick,
 }: {
   state: Exclude<BudgetState, { type: 'noBudget' }>
   totalExpense: number
   totalBudget: number | null | undefined
   pendingRecurringExpense: number
-  onProgressClick?: () => void
 }) {
   const budget = totalBudget as number
   const isLoading = state.type === 'loading'
@@ -206,10 +204,7 @@ function ProgressBar({
       role="progressbar"
       aria-valuenow={Math.min(Math.round((totalExpense / budget) * 100), 100)}
       aria-label={ariaLabel}
-      className={`mt-3 ${isLoading ? 'invisible' : ''} ${onProgressClick ? 'cursor-pointer' : ''}`}
-      onClick={onProgressClick}
-      onKeyDown={onProgressClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') onProgressClick() } : undefined}
-      tabIndex={onProgressClick ? 0 : undefined}
+      className={`mt-3 ${isLoading ? 'invisible' : ''}`}
     >
       {/* 바 트랙 */}
       <div className="relative h-2 bg-[var(--surface-hover)] rounded-full overflow-visible">
@@ -244,7 +239,7 @@ function ProgressBar({
         {state.type === 'normal' && (
           <>
             <span className="text-[var(--text-muted)]">
-              쓴 돈 {formatWon(totalExpense)} ({Math.round(state.actualPct)}%)
+              지출 {formatWon(totalExpense)} ({Math.round(state.actualPct)}%)
             </span>
             <span className="text-[var(--text-muted)]">·</span>
             <span className="text-grape-400 dark:text-grape-300">
@@ -252,14 +247,14 @@ function ProgressBar({
             </span>
             <span className="text-[var(--text-muted)]">·</span>
             <span className="text-grape-500 dark:text-grape-300 font-medium">
-              여유 {formatWon(state.remaining)}
+              남은 {formatWon(state.remaining)}
             </span>
           </>
         )}
         {state.type === 'noRecurring' && (
           <>
             <span className="text-[var(--text-muted)]">
-              쓴 돈 {formatWon(totalExpense)} ({Math.round(state.actualPct)}%)
+              지출 {formatWon(totalExpense)} ({Math.round(state.actualPct)}%)
             </span>
             <span className="text-[var(--text-muted)]">·</span>
             <span className="text-grape-500 dark:text-grape-300 font-medium">
@@ -270,7 +265,7 @@ function ProgressBar({
         {state.type === 'projectedExceed' && (
           <>
             <span className="text-[var(--text-muted)]">
-              쓴 돈 {formatWon(totalExpense)} ({Math.round(state.actualPct)}%)
+              지출 {formatWon(totalExpense)} ({Math.round(state.actualPct)}%)
             </span>
             <span className="text-[var(--text-muted)]">·</span>
             <span className="text-[var(--text-muted)]">
@@ -406,26 +401,35 @@ export default function HeroSummary(props: HeroSummaryProps) {
 
   const state = classifyBudgetState(totalExpense, totalBudget, pendingRecurringExpense)
 
-  const headerLabel = totalBudget != null && totalBudget > 0 ? '이번 달 예산' : label
+  // 카드 전체를 클릭할 때 이동: 프로그레스바만 특정하지 않고 히어로 영역 전체 클릭 가능
+  const cardClickProps = onProgressClick
+    ? {
+        onClick: onProgressClick,
+        role: 'button' as const,
+        tabIndex: 0,
+        onKeyDown: (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') onProgressClick() },
+        className: `card-surface p-6 bg-gradient-to-b from-grape-50/60 to-transparent dark:from-grape-900/30 dark:to-transparent cursor-pointer ${className}`,
+      }
+    : { className: `card-surface p-6 bg-gradient-to-b from-grape-50/60 to-transparent dark:from-grape-900/30 dark:to-transparent ${className}` }
 
   return (
-    <div className={`card-surface p-6 bg-gradient-to-b from-grape-50/60 to-transparent dark:from-grape-900/30 dark:to-transparent ${className}`}>
+    <div {...cardClickProps}>
       <div className="flex justify-between items-baseline">
-        <p className="text-sm text-[var(--text-tertiary)] mb-1">{headerLabel}</p>
+        {/* "이번 달 지출"로 명확히 표기 — 예산 금액이 큰 숫자처럼 보이는 혼동 방지 */}
+        <p className="text-sm text-[var(--text-tertiary)] mb-1">{label}</p>
         {totalBudget != null && totalBudget > 0 && (
-          <p className="text-sm text-[var(--text-secondary)] tabular-nums">{formatAmount(totalBudget)}</p>
+          <p className="text-xs text-[var(--text-muted)] tabular-nums">예산 {formatAmount(totalBudget)}</p>
         )}
       </div>
       <p className="text-display text-[var(--text-primary)]">{formatAmount(totalExpense)}</p>
 
-      {/* 예산 설정됨 또는 로딩 → 프로그레스바 */}
+      {/* 예산 설정됨 또는 로딩 → 프로그레스바 (클릭 핸들러는 카드 레벨로 이동) */}
       {state.type !== 'noBudget' && (
         <ProgressBar
           state={state}
           totalExpense={totalExpense}
           totalBudget={totalBudget}
           pendingRecurringExpense={pendingRecurringExpense}
-          onProgressClick={onProgressClick}
         />
       )}
 

--- a/frontend/src/components/transaction/ScheduledPopover.tsx
+++ b/frontend/src/components/transaction/ScheduledPopover.tsx
@@ -40,10 +40,12 @@ export default function ScheduledPopover({ date, items, onClose }: ScheduledPopo
       if (e.key === 'Escape') onClose()
     }
 
-    document.addEventListener('mousedown', handleClickOutside)
+    // mousedown 대신 click 사용: mousedown은 React onClick보다 먼저 발동해
+    // popoverDate를 null로 만든 뒤 onClick이 다시 열어버리는 버그가 생김
+    document.addEventListener('click', handleClickOutside)
     document.addEventListener('keydown', handleKeyDown)
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('click', handleClickOutside)
       document.removeEventListener('keydown', handleKeyDown)
     }
   }, [onClose])

--- a/frontend/src/components/transaction/TodayRecurringCard.tsx
+++ b/frontend/src/components/transaction/TodayRecurringCard.tsx
@@ -163,33 +163,35 @@ export default function TodayRecurringCard({ items, onExecute, onSkip }: TodayRe
         </div>
       )}
 
-      {/* 액션 버튼: [등록하기(flex-1)] [나후(subtle)] [건너뛰기(flex-1)] */}
-      <div className="flex gap-2">
-        <button
-          onClick={() => handleAction('execute')}
-          disabled={isLoading || (isEditing && (editingAmount == null || editingAmount <= 0))}
-          className={`flex-1 py-2 rounded-xl text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
-            isExpense
-              ? 'bg-grape-600 hover:bg-grape-700'
-              : 'bg-leaf-600 hover:bg-leaf-700'
-          }`}
-        >
-          등록하기
-        </button>
-        {/* 나중에: 세션 스누즈. 배경 없는 텍스트 버튼으로 시각적 우선순위 낮춤 */}
+      {/* 액션 버튼: 1행 [등록하기 건너뛰기], 2행 [나중에] — 위계 명확화 */}
+      <div className="flex flex-col gap-1.5">
+        <div className="flex gap-2">
+          <button
+            onClick={() => handleAction('execute')}
+            disabled={isLoading || (isEditing && (editingAmount == null || editingAmount <= 0))}
+            className={`flex-1 py-2 rounded-xl text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+              isExpense
+                ? 'bg-grape-600 hover:bg-grape-700'
+                : 'bg-leaf-600 hover:bg-leaf-700'
+            }`}
+          >
+            등록하기
+          </button>
+          <button
+            onClick={() => handleAction('skip')}
+            disabled={isLoading}
+            className="flex-1 py-2 rounded-xl text-sm font-medium bg-[var(--surface-elevated)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            건너뛰기
+          </button>
+        </div>
+        {/* 나중에: 세션 스누즈. 전체 너비 텍스트 버튼으로 시각적 우선순위 명확히 낮춤 */}
         <button
           onClick={() => handleSnooze(current.id)}
           disabled={isLoading}
-          className="px-3 py-2 text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full py-2 text-xs text-[var(--text-muted)] hover:text-[var(--text-tertiary)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           나중에
-        </button>
-        <button
-          onClick={() => handleAction('skip')}
-          disabled={isLoading}
-          className="flex-1 py-2 rounded-xl text-sm font-medium bg-[var(--surface-elevated)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          건너뛰기
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- 히어로 카드 전체 클릭 → 모아보기 이동 (기존: 프로그레스바만 클릭 가능)
- 히어로 상단 라벨 혼동 해소 — "이번 달 예산" 제거, 우측에 `예산 N원` 소형 텍스트로 표기
- 문구 톤 통일 — "쓴 돈" → "지출", "여유" → "남은"
- 팝오버 토글 버그 수정 — `mousedown` → `click` (같은 날짜 재클릭 시 닫히지 않던 문제)
- 정기거래 카드 버튼 2층 구조 — `[등록하기 | 건너뛰기]` 위, `[나중에]` 전체 너비로 아래

## Test plan

- [ ] 히어로 카드 아무 곳이나 탭 → 모아보기 이동
- [ ] 히어로 라벨이 "N월 지출"로 표시되고, 예산은 우측 소형 텍스트로 분리
- [ ] 프로그레스바 하단 범례: "지출 · 예정 · 남은" 톤 통일 확인
- [ ] 달력 빈 원 있는 날짜 클릭 → 팝오버 열림 → 같은 날짜 다시 클릭 → 닫힘
- [ ] 정기거래 카드: [등록하기][건너뛰기] 위, [나중에] 아래 배치 확인

close #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)