### PR TITLE
fix: 팝오버 버그 수정 + 히어로 문구 개선

### DIFF
--- a/frontend/src/components/MiniCalendar.tsx
+++ b/frontend/src/components/MiniCalendar.tsx
@@ -78,7 +78,7 @@ function MiniCalendar({
               <button
                 key={colIdx}
                 data-date={day.dateString}
-                onClick={() => onDateClick(day.dateString)}
+                onClick={(e) => { e.stopPropagation(); onDateClick(day.dateString) }}
                 className="flex flex-col items-center py-1 px-1 rounded-lg hover:bg-[var(--surface-hover)] transition-colors min-h-[40px]"
               >
                 <span

--- a/frontend/src/components/stats/HeroSummary.tsx
+++ b/frontend/src/components/stats/HeroSummary.tsx
@@ -114,7 +114,7 @@ function buildAriaLabel(
   const budgetStr = formatAmount(totalBudget as number)
   switch (state.type) {
     case 'normal':
-      return `예산 ${budgetStr} 중 ${formatAmount(totalExpense)} 사용, ${formatAmount(pendingRecurringExpense)} 예정, ${formatAmount(state.remaining)} 남은`
+      return `예산 ${budgetStr} 중 ${formatAmount(totalExpense)} 사용, ${formatAmount(pendingRecurringExpense)} 예정, ${formatAmount(state.remaining)} 여유`
     case 'noRecurring':
       return `예산 ${budgetStr} 중 ${formatAmount(totalExpense)} 사용, ${formatAmount(state.remaining)} 남음`
     case 'projectedExceed':
@@ -247,7 +247,7 @@ function ProgressBar({
             </span>
             <span className="text-[var(--text-muted)]">·</span>
             <span className="text-grape-500 dark:text-grape-300 font-medium">
-              남은 {formatWon(state.remaining)}
+              여유 {formatWon(state.remaining)}
             </span>
           </>
         )}

--- a/frontend/src/components/transaction/MonthlyView.tsx
+++ b/frontend/src/components/transaction/MonthlyView.tsx
@@ -148,7 +148,7 @@ export default function MonthlyView({
 
       {/* 월간 지출 히어로 요약 — currentMonth는 0-indexed이므로 +1 */}
       <HeroSummary
-        label={`${monthly.currentMonth + 1}월 지출`}
+        label="지출"
         totalExpense={monthly.totalExpense}
         totalBudget={totalBudget}
         pendingRecurringExpense={pendingRecurringExpense}

--- a/frontend/src/components/transaction/__tests__/MonthlyView.test.tsx
+++ b/frontend/src/components/transaction/__tests__/MonthlyView.test.tsx
@@ -118,7 +118,7 @@ describe('MonthlyView 컴포넌트', () => {
   it('월간 지출 히어로 라벨을 표시한다', () => {
     renderPage()
     const now = new Date()
-    expect(screen.getByText(`${now.getMonth() + 1}월 지출`)).toBeInTheDocument()
+    expect(screen.getByText(`지출`)).toBeInTheDocument()
   })
 
   it('미니 캘린더(요일 헤더)를 표시한다', async () => {
@@ -263,7 +263,7 @@ describe('MonthlyView 컴포넌트', () => {
     await waitFor(() => {
       // HeroSummary label — "N월 지출"
       const now = new Date()
-      expect(screen.getByText(`${now.getMonth() + 1}월 지출`)).toBeInTheDocument()
+      expect(screen.getByText(`지출`)).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/transaction/__tests__/MonthlyView.test.tsx
+++ b/frontend/src/components/transaction/__tests__/MonthlyView.test.tsx
@@ -117,8 +117,7 @@ describe('MonthlyView 컴포넌트', () => {
 
   it('월간 지출 히어로 라벨을 표시한다', () => {
     renderPage()
-    const now = new Date()
-    expect(screen.getByText(`지출`)).toBeInTheDocument()
+    expect(screen.getByText('지출')).toBeInTheDocument()
   })
 
   it('미니 캘린더(요일 헤더)를 표시한다', async () => {
@@ -261,9 +260,7 @@ describe('MonthlyView 컴포넌트', () => {
     setupCurrentMonthHandlers()
     renderPage()
     await waitFor(() => {
-      // HeroSummary label — "N월 지출"
-      const now = new Date()
-      expect(screen.getByText(`지출`)).toBeInTheDocument()
+      expect(screen.getByText('지출')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/__tests__/TransactionList.test.tsx
+++ b/frontend/src/pages/__tests__/TransactionList.test.tsx
@@ -114,8 +114,7 @@ describe('TransactionList', () => {
 
   it('월간 지출 히어로 라벨을 표시한다', async () => {
     renderPage()
-    const now = new Date()
-    expect(screen.getByText(`지출`)).toBeInTheDocument()
+    expect(screen.getByText('지출')).toBeInTheDocument()
   })
 
   it('데이터 로드 후 거래 목록을 표시한다', async () => {

--- a/frontend/src/pages/__tests__/TransactionList.test.tsx
+++ b/frontend/src/pages/__tests__/TransactionList.test.tsx
@@ -115,7 +115,7 @@ describe('TransactionList', () => {
   it('월간 지출 히어로 라벨을 표시한다', async () => {
     renderPage()
     const now = new Date()
-    expect(screen.getByText(`${now.getMonth() + 1}월 지출`)).toBeInTheDocument()
+    expect(screen.getByText(`지출`)).toBeInTheDocument()
   })
 
   it('데이터 로드 후 거래 목록을 표시한다', async () => {


### PR DESCRIPTION
## Summary

- **팝오버 버그 수정**: 날짜 셀 클릭 시 `e.stopPropagation()` 추가 — document click 핸들러가 팝오버를 즉시 닫아버리던 문제 해결 (클릭 → 팝오버 열림 → 버블링 → 즉시 닫힘)
- 히어로 라벨 `"N월 지출"` → `"지출"` — 월 네비게이션과 중복 제거
- `"남은"` → `"여유"` — 지출·예정·여유 한자어 통일

## Test plan

- [ ] 달력에서 빈 원(○) 있는 날짜 클릭 → 팝오버 표시
- [ ] 같은 날짜 다시 클릭 → 팝오버 닫힘 (토글)
- [ ] 팝오버 바깥 클릭 → 팝오버 닫힘
- [ ] 히어로 카드 라벨이 "지출"로만 표시
- [ ] 프로그레스바 하단 "지출 · 예정 · 여유" 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)