### PR TITLE
feat: 랜딩페이지 리뉴얼 — 콘텐츠 최신화 + 디자인 업그레이드

### DIFF
--- a/docs/superpowers/plans/2026-04-09-landing-page-renewal.md
+++ b/docs/superpowers/plans/2026-04-09-landing-page-renewal.md
@@ -1,0 +1,547 @@
+# Landing Page Renewal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 랜딩페이지 콘텐츠를 최신 기능과 싱크하고, 자산 트래킹 제거 + 가계부 핵심 기능 집중으로 리뉴얼한다.
+
+**Architecture:** 기존 컴포넌트 구조(7개 섹션) 유지, 콘텐츠/데이터를 `landingData.ts`로 분리하여 중앙 관리. 스크린샷은 `ScreenshotImage` 공유 컴포넌트로 fallback 처리. 디자인 톤(Grape), 애니메이션(CSS 키프레임 + IntersectionObserver), 반응형 구조 모두 유지.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS v4, Vite 7
+
+**Spec:** `docs/superpowers/specs/2026-04-09-landing-page-renewal-design.md`
+
+**Worktree:** `/Users/seungyong/projects/podo-budget-landing` (branch: `feature/landing-renewal`)
+
+---
+
+## File Structure
+
+| 파일 | 작업 | 책임 |
+|------|------|------|
+| `src/data/landingData.ts` | 새로 생성 | 스크린샷 경로, 기능 카드 데이터, 소셜 프루프 데이터 중앙 관리 |
+| `src/components/landing/ScreenshotImage.tsx` | 새로 생성 | 이미지 렌더링 + grape 그라디언트 fallback 플레이스홀더 |
+| `src/components/landing/HeroSection.tsx` | 수정 | 카피 + ChatPhone 채팅 예시 교체 |
+| `src/components/landing/MessengerSection.tsx` | 대폭 수정 | 메신저 전용 → 쉽고 빠른 입력 (메신저 + 앱) |
+| `src/components/landing/SharedSection.tsx` | 소폭 수정 | 설명 + 거래 예시 교체 |
+| `src/components/landing/InsightsSection.tsx` | 대폭 수정 | 폰 캐러셀 → 카드 이미지 격자 |
+| `src/components/landing/FeaturesSection.tsx` | 수정 | 데이터 파일 import + 자산→검색 카드 교체 |
+| `src/components/landing/SocialProofSection.tsx` | 대폭 수정 | 가짜 후기 → 시나리오 전환, 데이터 파일 import |
+| `src/components/landing/CTAFooter.tsx` | 소폭 수정 | 카피만 교체 |
+| `public/screenshots/` | 새 디렉토리 | 스크린샷 이미지 저장소 |
+
+---
+
+### Task 1: landingData.ts 데이터 파일 생성
+
+**Files:**
+- Create: `frontend/src/data/landingData.ts`
+
+- [ ] **Step 1: 데이터 파일 생성**
+
+```typescript
+// frontend/src/data/landingData.ts
+
+// --- 스크린샷 ---
+export const landingScreenshots = {
+  hero: {
+    path: '/screenshots/hero-chat.jpg',
+    alt: '메신저로 가계부 입력하는 화면',
+  },
+  input: {
+    messenger: {
+      path: '/screenshots/input-messenger.jpg',
+      alt: '메신저 입력 화면',
+    },
+    app: {
+      path: '/screenshots/input-app.jpg',
+      alt: '앱 내 직접 입력 화면',
+    },
+  },
+  overview: [
+    { path: '/screenshots/card-budget.jpg', caption: '예산 현황', alt: '예산 히어로 카드' },
+    { path: '/screenshots/card-category.jpg', caption: '카테고리 TOP', alt: '카테고리별 지출' },
+    { path: '/screenshots/card-recurring.jpg', caption: '정기결제 알림', alt: '정기결제 알림 카드' },
+    { path: '/screenshots/card-insight.jpg', caption: 'AI 인사이트', alt: 'AI 분석 카드' },
+  ],
+}
+
+// --- 편의 기능 카드 ---
+// icon SVG는 FeaturesSection.tsx 내에서 id 기반 매핑
+export const featureCards = [
+  { id: 'budget' as const, title: '예산 관리', description: '우리 집 예산, 얼마나 썼는지 한눈에 봐요. 넘으면 알려줘요', highlight: '한눈에', iconBg: 'bg-grape-100', iconColor: 'text-grape-700', highlightBg: 'bg-grape-100 text-grape-700' },
+  { id: 'recurring' as const, title: '정기결제 관리', description: '넷플릭스, 보험료, 공과금 결제일에 놓치지 않고 알려줘요', highlight: '놓치지 않고', iconBg: 'bg-leaf-100', iconColor: 'text-leaf-700', highlightBg: 'bg-leaf-100 text-leaf-700' },
+  { id: 'payment' as const, title: '결제수단 현황', description: '카드 실적, 현금, 이체까지 한번에 모아서 봐요', highlight: '카드 실적', iconBg: 'bg-orange-50', iconColor: 'text-orange-700', highlightBg: 'bg-orange-50 text-orange-700' },
+  { id: 'search' as const, title: '가계부 검색', description: '지난주 병원비 얼마였지? 금액, 카테고리, 기간으로 바로 찾아요', highlight: '바로 찾아요', iconBg: 'bg-yellow-50', iconColor: 'text-yellow-700', highlightBg: 'bg-yellow-50 text-yellow-700' },
+  { id: 'category' as const, title: '맞춤 카테고리', description: '나만의 분류로 자유롭게 정리해요', highlight: '자유롭게', iconBg: 'bg-green-50', iconColor: 'text-green-700', highlightBg: 'bg-green-50 text-green-700' },
+]
+
+// --- 소셜 프루프 ---
+export const socialStats = [
+  { value: 5, suffix: '초', label: '만에 입력', description: '길게 적을 필요 없이, 한 줄이면 돼요' },
+  { value: 100, suffix: '%', label: '자동 카테고리', description: '식비, 교통, 쇼핑 AI가 알아서 분류' },
+  { value: 0, suffix: '원', label: '완전 무료', description: '모든 기능 무료, 숨은 결제 없어요' },
+]
+
+export const socialScenarios = [
+  { persona: '맞벌이 부부', problem: '둘 다 쓰는데 월말에 뭐에 썼는지 모르겠어', solution: '공유 가계부로 실시간 확인' },
+  { persona: '살림 초보', problem: '가계부 앱 깔아봤는데 입력 귀찮아서 삭제함', solution: '메신저로 한 줄이면 끝' },
+  { persona: '알뜰 살림러', problem: '구독료가 매달 얼마 빠지는지 파악이 안 돼', solution: '정기결제 알림 + 예산 관리' },
+]
+```
+
+- [ ] **Step 2: TypeScript 빌드 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npx tsc --noEmit --pretty 2>&1 | head -30`
+Expected: 에러 없음 (새 파일은 아직 import하는 곳 없으므로)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add frontend/src/data/landingData.ts
+git commit -m "feat: 랜딩페이지 데이터 중앙 관리 파일 생성"
+```
+
+---
+
+### Task 2: ScreenshotImage 공유 컴포넌트 생성
+
+**Files:**
+- Create: `frontend/src/components/landing/ScreenshotImage.tsx`
+
+- [ ] **Step 1: 컴포넌트 생성**
+
+```typescript
+// frontend/src/components/landing/ScreenshotImage.tsx
+import { useState } from 'react'
+
+type ScreenshotImageProps = {
+  src: string
+  alt: string
+  caption?: string
+  className?: string
+}
+
+export function ScreenshotImage({ src, alt, caption, className = '' }: ScreenshotImageProps) {
+  const [failed, setFailed] = useState(false)
+
+  if (failed) {
+    return (
+      <div
+        className={`flex items-center justify-center rounded-2xl bg-gradient-to-br from-grape-200 to-grape-400 dark:from-grape-700 dark:to-grape-900 ${className}`}
+        role="img"
+        aria-label={alt}
+      >
+        {caption && (
+          <span className="text-sm font-medium text-white drop-shadow-sm">
+            {caption}
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={`rounded-2xl ${className}`}
+      onError={() => setFailed(true)}
+      loading="lazy"
+    />
+  )
+}
+```
+
+- [ ] **Step 2: TypeScript 빌드 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npx tsc --noEmit --pretty 2>&1 | head -30`
+Expected: 에러 없음
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add frontend/src/components/landing/ScreenshotImage.tsx
+git commit -m "feat: ScreenshotImage 공유 컴포넌트 (fallback 플레이스홀더)"
+```
+
+---
+
+### Task 3: screenshots 디렉토리 생성
+
+**Files:**
+- Create: `frontend/public/screenshots/.gitkeep`
+
+- [ ] **Step 1: 디렉토리 생성**
+
+```bash
+mkdir -p /Users/seungyong/projects/podo-budget-landing/frontend/public/screenshots
+touch /Users/seungyong/projects/podo-budget-landing/frontend/public/screenshots/.gitkeep
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add frontend/public/screenshots/.gitkeep
+git commit -m "chore: 랜딩 스크린샷 디렉토리 생성"
+```
+
+---
+
+### Task 4: HeroSection 카피 + 채팅 예시 수정
+
+**Files:**
+- Modify: `frontend/src/components/landing/HeroSection.tsx`
+
+**주의사항:** ChatPhone 내부의 애니메이션 타이밍 상수(`TO_AFTER`, `SHOW_CARD`, `RESET`, `LOOP`)는 변경하지 않는다. 텍스트 콘텐츠만 교체.
+
+- [ ] **Step 1: 메인/서브 카피 교체**
+
+HeroSection.tsx에서 텍스트 변경:
+- 메인 헤드라인 (3줄 → 2줄): `"포도알처럼" / "하나씩, 알찬" / "가계부"` → `"말하듯 기록하면," / "AI가 알아서 정리해요"`
+- 서브 카피: `"말로 기록하면 / AI가 알아서 분류하는 / 우리 집 가계부"` → `"메신저에 '남편이랑 저녁 파스타 32000원' 보내면 끝.\n카테고리, 날짜, 결제수단까지 자동으로."`
+
+- [ ] **Step 2: ChatPhone 채팅 예시 교체**
+
+ChatPhone 내부 채팅 데이터:
+- 유저 메시지: `"점심 김치찌개 8000원"` → `"남편이랑 저녁 파스타 32000원"`
+- AI 응답 카테고리: `식비` (유지)
+- AI 응답 금액: `8,000원` → `32,000원`
+- AI 응답 날짜: `오늘` (유지)
+- 스크린샷 `/screenshot-after.jpg` 참조 유지 (추후 교체)
+
+- [ ] **Step 3: 빌드 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npx tsc --noEmit --pretty 2>&1 | head -30`
+Expected: 에러 없음
+
+- [ ] **Step 4: 개발 서버에서 시각 확인**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npm run dev`
+브라우저에서 `http://localhost:5173` 접속 → Hero 섹션 카피 + 채팅 애니메이션 확인
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add frontend/src/components/landing/HeroSection.tsx
+git commit -m "feat: Hero 섹션 카피 개선 — 가치 전달 우선 + 파스타 예시"
+```
+
+---
+
+### Task 5: MessengerSection → 쉽고 빠른 입력 리뉴얼
+
+**Files:**
+- Modify: `frontend/src/components/landing/MessengerSection.tsx`
+
+**현재 구조 (167줄):** 카카오톡/텔레그램 로고 + 채팅 목업 1개 (김치찌개/택시 예시)
+
+**변경 방향:**
+- 뱃지: "핵심 기능" → "쉽고 빠른 입력"
+- 헤드라인: "메신저로 기록하세요" → "한 줄이면 끝, 나머지는 AI가"
+- 설명 교체
+- 카카오톡/텔레그램 개별 로고 제거 → 일반 메신저 아이콘 (채팅 말풍선 SVG)
+- 채팅 예시: 파스타 32000원
+- 오른쪽에 앱 입력 스크린샷 추가 (ScreenshotImage 사용)
+- 2컬럼 레이아웃: 왼쪽 메신저 목업 / 오른쪽 앱 입력 스크린샷
+
+- [ ] **Step 1: 텍스트 콘텐츠 교체**
+
+뱃지, 헤드라인, 설명, 메신저 아이콘 영역 수정:
+- 뱃지 텍스트: `"핵심 기능"` → `"쉽고 빠른 입력"`
+- 헤드라인: `"메신저로"` / `"기록하세요"` → `"한 줄이면 끝,"` / `"나머지는 AI가"`
+- 설명: `"카카오톡, 텔레그램 등..."` → `"사용하던 메신저로 보내도 되고, 앱에서 바로 입력해도 돼요. 카테고리, 날짜, 결제수단은 AI가 알아서 분류해줘요."`
+- 메신저 아이콘: 카카오톡(#FEE500)/텔레그램(#0088cc) 개별 로고 → 일반 채팅 말풍선 SVG 아이콘 1개 + 스마트폰 SVG 아이콘 1개 ("메신저" / "앱")
+
+- [ ] **Step 2: 채팅 예시 교체**
+
+채팅 대화 데이터:
+- 첫 번째 유저: `"점심 김치찌개 8000원"` → `"남편이랑 저녁 파스타 32000원"`
+- 첫 번째 봇 응답: 카테고리 `식비`, 금액 `32,000원`, 날짜 `오늘`
+- 두 번째 대화 세트: 제거 (1세트만 유지하여 간결하게)
+
+- [ ] **Step 3: 앱 입력 스크린샷 영역 추가**
+
+현재 채팅 목업 옆에 앱 내 직접 입력 스크린샷 영역 추가:
+- `landingScreenshots.input.app` import하여 사용
+- `ScreenshotImage` 컴포넌트 사용
+- 레이아웃: `md:flex-row`에서 채팅 목업과 앱 스크린샷을 나란히
+- 각각 아래에 라벨: "메신저로 보내기" / "앱에서 바로 입력"
+
+- [ ] **Step 4: 빌드 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npx tsc --noEmit --pretty 2>&1 | head -30`
+Expected: 에러 없음
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add frontend/src/components/landing/MessengerSection.tsx
+git commit -m "feat: MessengerSection → 쉽고 빠른 입력 리뉴얼 (메신저 + 앱)"
+```
+
+---
+
+### Task 6: SharedSection 거래 예시 + 설명 수정
+
+**Files:**
+- Modify: `frontend/src/components/landing/SharedSection.tsx`
+
+**현재 구조 (113줄):** members 배열(엄마/아빠/나) + transactions 배열(김치찌개/지하철/문구류)
+
+- [ ] **Step 1: 설명 + 거래 예시 교체**
+
+변경할 텍스트:
+- 설명 (line 36-38): `"가족을 초대하고 함께 써요.\n누가 어떻게 썼는지 한눈에 볼 수 있어요."` → `"초대 한 번이면 같이 써요.\n누가, 언제, 얼마 썼는지 한눈에."`
+- `transactions` 배열 (lines 9-13) — `text` 필드가 "이름 금액" 합쳐진 형태:
+  - `text: "김치찌개 8,000원"` → `text: "저녁 파스타 32,000원"`
+  - `text: "지하철 50,000원"` → `text: "아이 학원비 150,000원"`
+  - `text: "문구류 12,000원"` → `text: "주말 장보기 48,000원"`
+
+- [ ] **Step 2: 빌드 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npx tsc --noEmit --pretty 2>&1 | head -30`
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add frontend/src/components/landing/SharedSection.tsx
+git commit -m "feat: SharedSection 거래 예시 생활감 있게 교체"
+```
+
+---
+
+### Task 7: InsightsSection → 한눈에 보기 리뉴얼
+
+**Files:**
+- Modify: `frontend/src/components/landing/InsightsSection.tsx`
+
+**현재 구조 (115줄):** 폰 목업 프레임 + 캐러셀 3슬라이드 (3초 자동 전환) + 인디케이터 점
+
+**변경 방향:** 폰 목업/캐러셀 제거 → 카드 이미지 4개 격자 배치
+
+- [ ] **Step 1: 텍스트 콘텐츠 교체**
+
+- 뱃지: `"돌아보기"` → `"모아보기"`
+- 헤드라인: `"이달의 소비,"` / `"한눈에 돌아보기"` → `"이번 달,"` / `"어디에 얼마 썼지?"`
+- 설명: 기존 → `"앱 열면 바로 보여요. 예산 현황, 정기결제 일정, 카테고리별 지출, AI 분석까지."`
+
+- [ ] **Step 2: 캐러셀 → 카드 격자로 교체**
+
+캐러셀 로직(useState, useEffect, setInterval) 제거. 대신:
+- `landingScreenshots.overview` import
+- `ScreenshotImage` 컴포넌트 import
+- 2x2 격자: `grid grid-cols-2 gap-4 md:gap-6`
+- 각 카드: `ScreenshotImage` + 캡션
+- 카드 스타일: `rounded-2xl shadow-sm border border-warm-200` (기존 디자인 톤)
+- 애니메이션: `animate-fade-in-up` + stagger (`animationDelay: ${0.1 * i}s`)
+
+레이아웃 변경:
+- 현재: 텍스트(왼) + 폰 목업(오) `md:flex-row`
+- 변경: 텍스트(위) + 카드 격자(아래) 수직 배치
+
+- [ ] **Step 3: 빌드 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npx tsc --noEmit --pretty 2>&1 | head -30`
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add frontend/src/components/landing/InsightsSection.tsx
+git commit -m "feat: InsightsSection → 한눈에 보기 카드 격자 리뉴얼"
+```
+
+---
+
+### Task 8: FeaturesSection 카드 교체 + 데이터 파일 연동
+
+**Files:**
+- Modify: `frontend/src/components/landing/FeaturesSection.tsx`
+
+**현재 구조 (128줄):** `features` 배열(5개, 컴포넌트 내부 정의) + SVG icon JSX
+
+**변경 방향:**
+- 데이터를 `landingData.ts`의 `featureCards`에서 import
+- SVG 아이콘은 id 기반 매핑 함수로 컴포넌트 내부에 유지
+- 자산 트래킹(#4) → 가계부 검색으로 교체 (데이터 파일에서 이미 반영)
+
+- [ ] **Step 1: 내부 features 배열을 landingData import로 교체**
+
+```typescript
+import { featureCards } from '../../data/landingData'
+```
+
+기존 `const features = [...]` (lines 3-70) 삭제.
+
+id 기반 아이콘 매핑 함수 추가:
+```typescript
+function getFeatureIcon(id: string) {
+  const icons: Record<string, JSX.Element> = {
+    budget: (/* 기존 예산 관리 SVG */),
+    recurring: (/* 기존 정기결제 SVG */),
+    payment: (/* 기존 결제수단 SVG */),
+    search: (/* 검색 돋보기 SVG — 새로 추가 */),
+    category: (/* 기존 맞춤 카테고리 SVG */),
+  }
+  return icons[id] ?? null
+}
+```
+
+검색 아이콘 SVG (Heroicons magnifying-glass):
+```html
+<svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+  <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+</svg>
+```
+
+- [ ] **Step 2: 렌더링 부분에서 featureCards 사용**
+
+`features.map(...)` → `featureCards.map(...)` 으로 변경.
+각 카드에서 `getFeatureIcon(card.id)` 호출.
+
+- [ ] **Step 3: 빌드 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npx tsc --noEmit --pretty 2>&1 | head -30`
+
+- [ ] **Step 4: 커밋**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add frontend/src/components/landing/FeaturesSection.tsx
+git commit -m "feat: FeaturesSection 데이터 파일 연동 + 자산→검색 교체"
+```
+
+---
+
+### Task 9: SocialProofSection → 시나리오 전환
+
+**Files:**
+- Modify: `frontend/src/components/landing/SocialProofSection.tsx`
+
+**현재 구조 (235줄):** useCountUp 훅 + stats 배열 + StarIcon + scenarios (별점 + 인용문)
+
+**변경 방향:**
+- 상단 숫자 3개 유지 (useCountUp 훅 유지)
+- `stats`/`scenarios` 데이터를 `landingData.ts`에서 import
+- 헤드라인 교체
+- 별점(StarIcon) 제거
+- 시나리오 카드: 인용문 → 문제/해결 구조
+
+- [ ] **Step 1: 데이터 import + 헤드라인 교체**
+
+```typescript
+import { socialStats, socialScenarios } from '../../data/landingData'
+```
+
+기존 내부 `stats`, `scenarios` 배열 삭제.
+- 섹션 라벨: `"이런 분들이 쓰고 있어요"` → `"이런 분께 딱 맞아요"`
+- 헤드라인: `"기록이 습관이 되는 가장 쉬운 방법"` → `"이런 분께 딱 맞아요"`
+
+- [ ] **Step 2: 숫자 통계 영역 — socialStats 연동**
+
+기존 `stats` 참조를 `socialStats`로 교체. useCountUp 훅 로직은 유지.
+SVG 아이콘은 컴포넌트 내부에 유지 (id 기반 매핑 또는 인라인).
+
+**필드명 매핑 주의:**
+- 기존 코드: `stat.unit` / `stat.suffix` / `stat.desc` / `stat.icon`
+- 새 데이터: `stat.suffix` / `stat.label` / `stat.description` (icon 없음)
+- JSX에서 필드명 참조를 모두 업데이트할 것:
+  - `stat.unit` → `stat.suffix`
+  - `stat.suffix` → `stat.label`
+  - `stat.desc` → `stat.description`
+  - `stat.icon` → 컴포넌트 내부 인라인 SVG로 유지
+
+- [ ] **Step 3: 시나리오 카드 — 별점 제거 + 문제/해결 구조**
+
+기존 시나리오 카드 구조:
+```
+[별점 5개] + [페르소나] + [인용문]
+```
+
+새 구조:
+```
+[페르소나 뱃지] + [문제 텍스트 (이탤릭, warm-600)] + [→ 해결 텍스트 (grape-700, bold)]
+```
+
+StarIcon 컴포넌트 삭제.
+
+- [ ] **Step 4: 빌드 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npx tsc --noEmit --pretty 2>&1 | head -30`
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add frontend/src/components/landing/SocialProofSection.tsx
+git commit -m "feat: SocialProofSection 시나리오 전환 (별점 제거 + 문제→해결)"
+```
+
+---
+
+### Task 10: CTAFooter 카피 수정
+
+**Files:**
+- Modify: `frontend/src/components/landing/CTAFooter.tsx`
+
+- [ ] **Step 1: 카피 교체**
+
+- 헤드라인: `"포도알처럼 하나씩,"` / `"오늘부터 시작해볼까요?"` → `"오늘부터"` / `"편하게 기록해볼까요?"`
+- 설명: `"복잡한 가입 절차 없이, 메신저 하나면 시작할 수 있어요"` → `"복잡한 가입 없이, 구글 계정으로 바로 시작하세요"`
+
+나머지(CTA 버튼, 사용법 보기, 푸터 링크, 소셜 아이콘)는 변경하지 않음.
+
+- [ ] **Step 2: 빌드 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npx tsc --noEmit --pretty 2>&1 | head -30`
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add frontend/src/components/landing/CTAFooter.tsx
+git commit -m "feat: CTAFooter 카피 개선 — 행동 유도 중심"
+```
+
+---
+
+### Task 11: 전체 빌드 + 린트 검증
+
+**Files:** 전체
+
+- [ ] **Step 1: ESLint 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npm run lint`
+Expected: 에러 없음
+
+- [ ] **Step 2: TypeScript 빌드 체크**
+
+Run: `cd /Users/seungyong/projects/podo-budget-landing/frontend && npm run build`
+Expected: 빌드 성공
+
+- [ ] **Step 3: 개발 서버에서 전체 플로우 확인**
+
+`npm run dev` → `http://localhost:5173` 접속:
+1. Hero: 새 카피 + 파스타 채팅 애니메이션
+2. 쉽고 빠른 입력: 메신저 + 앱 입력 나란히
+3. 공유 가계부: 새 거래 예시
+4. 한눈에 보기: 카드 격자 (플레이스홀더)
+5. 편의 기능: 검색 카드 포함 5개
+6. 소셜 프루프: 숫자 카운트업 + 시나리오 3개
+7. CTA: 새 카피
+
+- [ ] **Step 4: 린트/빌드 에러 수정 (있다면)**
+
+- [ ] **Step 5: 최종 커밋 (수정 있을 경우)**
+
+```bash
+cd /Users/seungyong/projects/podo-budget-landing
+git add -A
+git commit -m "fix: 랜딩페이지 리뉴얼 린트/빌드 수정"
+```

--- a/docs/superpowers/specs/2026-04-09-landing-page-renewal-design.md
+++ b/docs/superpowers/specs/2026-04-09-landing-page-renewal-design.md
@@ -1,0 +1,224 @@
+# 포도가계부 랜딩페이지 리뉴얼
+
+## 개요
+
+현재 랜딩페이지의 내용을 최신 기능과 싱크하고, 디자인 품질을 업그레이드한다.
+기존 Grape 디자인 시스템 톤(v0.dev 생성)을 유지하면서 콘텐츠를 현행화한다.
+
+## 목적
+
+- 비활성화된 자산 트래킹 제거, 가계부 핵심 기능에 집중
+- IT 비친숙 30대+ 타겟에 맞게 기술 용어 제거 (자연어 → "말하듯 입력")
+- 스크린샷을 데이터 파일로 중앙 관리하여 교체 용이성 확보
+- 가짜 리뷰 → 진정성 있는 시나리오로 전환
+
+## 디자인 방향
+
+- **톤앤매너**: 기존 유지 — Grape 그라디언트 + Cream 배경, 따뜻하고 친근
+- **애니메이션**: 기존 유지 — Intersection Observer 기반 fade-in-up, 순수 CSS 키프레임
+- **레이아웃**: 기존 섹션 구조 유지, 내용과 비주얼 교체
+- **타겟 언어**: 기술 용어 배제, 생활 언어 사용, 행동 중심 표현
+
+## 데이터 중앙 관리 구조
+
+`frontend/src/data/landingData.ts`에서 스크린샷, 기능 카드, 시나리오 데이터를 중앙 관리:
+
+```typescript
+// 스크린샷
+export const landingScreenshots = {
+  hero: {
+    path: '/screenshots/hero-chat.jpg',
+    alt: '메신저로 가계부 입력하는 화면',
+  },
+  input: {
+    messenger: {
+      path: '/screenshots/input-messenger.jpg',
+      alt: '메신저 입력 화면',
+    },
+    app: {
+      path: '/screenshots/input-app.jpg',
+      alt: '앱 내 직접 입력 화면',
+    },
+  },
+  overview: [
+    { path: '/screenshots/card-budget.jpg', caption: '예산 현황', alt: '예산 히어로 카드' },
+    { path: '/screenshots/card-category.jpg', caption: '카테고리 TOP', alt: '카테고리별 지출' },
+    { path: '/screenshots/card-recurring.jpg', caption: '정기결제 알림', alt: '정기결제 알림 카드' },
+    { path: '/screenshots/card-insight.jpg', caption: 'AI 인사이트', alt: 'AI 분석 카드' },
+  ],
+}
+
+// 편의 기능 카드 — icon은 SVG JSX로 컴포넌트에서 정의 (데이터 파일에는 텍스트만)
+// 스타일 속성은 기존 FeaturesSection 패턴 유지 (iconBg, iconColor, highlightBg)
+export const featureCards = [
+  { id: 'budget', title: '예산 관리', description: '우리 집 예산, 얼마나 썼는지 한눈에 봐요. 넘으면 알려줘요', highlight: '한눈에', iconBg: 'bg-grape-100', iconColor: 'text-grape-700', highlightBg: 'bg-grape-100 text-grape-700' },
+  { id: 'recurring', title: '정기결제 관리', description: '넷플릭스, 보험료, 공과금 결제일에 놓치지 않고 알려줘요', highlight: '놓치지 않고', iconBg: 'bg-leaf-100', iconColor: 'text-leaf-700', highlightBg: 'bg-leaf-100 text-leaf-700' },
+  { id: 'payment', title: '결제수단 현황', description: '카드 실적, 현금, 이체까지 한번에 모아서 봐요', highlight: '카드 실적', iconBg: 'bg-orange-50', iconColor: 'text-orange-700', highlightBg: 'bg-orange-50 text-orange-700' },
+  { id: 'search', title: '가계부 검색', description: '지난주 병원비 얼마였지? 금액, 카테고리, 기간으로 바로 찾아요', highlight: '바로 찾아요', iconBg: 'bg-yellow-50', iconColor: 'text-yellow-700', highlightBg: 'bg-yellow-50 text-yellow-700' },
+  { id: 'category', title: '맞춤 카테고리', description: '나만의 분류로 자유롭게 정리해요', highlight: '자유롭게', iconBg: 'bg-green-50', iconColor: 'text-green-700', highlightBg: 'bg-green-50 text-green-700' },
+]
+// icon SVG는 FeaturesSection.tsx 내에서 id 기반 매핑 (JSX는 데이터 파일에 넣지 않음)
+
+// 소셜 프루프 — 숫자 통계
+export const socialStats = [
+  { value: 5, suffix: '초', label: '만에 입력', description: '길게 적을 필요 없이, 한 줄이면 돼요' },
+  { value: 100, suffix: '%', label: '자동 카테고리', description: '식비, 교통, 쇼핑 AI가 알아서 분류' },
+  { value: 0, suffix: '원', label: '완전 무료', description: '모든 기능 무료, 숨은 결제 없어요' },
+]
+
+// 소셜 프루프 시나리오
+export const socialScenarios = [
+  { persona: '맞벌이 부부', problem: '둘 다 쓰는데 월말에 뭐에 썼는지 모르겠어', solution: '공유 가계부로 실시간 확인' },
+  { persona: '살림 초보', problem: '가계부 앱 깔아봤는데 입력 귀찮아서 삭제함', solution: '메신저로 한 줄이면 끝' },
+  { persona: '알뜰 살림러', problem: '구독료가 매달 얼마 빠지는지 파악이 안 돼', solution: '정기결제 알림 + 예산 관리' },
+]
+```
+
+이미지 파일은 `frontend/public/screenshots/` 디렉토리에 저장.
+
+### 스크린샷 플레이스홀더
+
+실제 스크린샷이 준비되기 전까지 grape 그라디언트 배경 + 캡션 텍스트로 플레이스홀더 표시.
+
+공유 컴포넌트: `src/components/landing/ScreenshotImage.tsx`
+```typescript
+// props: { src, alt, caption?, className? }
+// 정상: <img> 렌더링
+// 로드 실패: grape 그라디언트 배경 + caption 텍스트 fallback
+// 내부적으로 useState + onError 핸들러로 구현
+```
+
+모든 랜딩 섹션에서 `<img>` 대신 `<ScreenshotImage>` 사용.
+
+---
+
+## 섹션별 상세 설계
+
+### 섹션 1: Hero (개선)
+
+**변경 내용**: 카피 개선 — 브랜드 메타포보다 가치 전달 우선
+
+| 항목 | 현재 | 변경 |
+|------|------|------|
+| 뱃지 | "드디어 꾸준히 쓰게 되는 가계부" | 유지 |
+| 메인 카피 | "포도알처럼 하나씩, 알찬 가계부" | **"말하듯 기록하면, AI가 알아서 정리해요"** |
+| 서브 카피 | "말로 기록하면 / AI가 알아서 분류하는 / 우리 집 가계부" | **"메신저에 '남편이랑 저녁 파스타 32000원' 보내면 끝. 카테고리, 날짜, 결제수단까지 자동으로."** |
+| CTA | "지금 무료로 시작하기 →" | 유지 |
+| 채팅 폰 애니메이션 | 김치찌개 8000원 예시 | **파스타 32000원 예시로 교체** |
+
+### 섹션 2: 쉽고 빠른 입력 (기존 MessengerSection 리뉴얼)
+
+**변경 내용**: 메신저 전용 → 메신저 + 앱 입력 2가지 방식
+
+| 항목 | 현재 | 변경 |
+|------|------|------|
+| 뱃지 | "핵심 기능" | **"쉽고 빠른 입력"** |
+| 헤드라인 | "메신저로 기록하세요" | **"한 줄이면 끝, 나머지는 AI가"** |
+| 설명 | 카카오톡/텔레그램 명시 | **"사용하던 메신저로 보내도 되고, 앱에서 바로 입력해도 돼요. 카테고리, 날짜, 결제수단은 AI가 알아서 분류해줘요."** |
+| 비주얼 | 메신저 채팅 목업 1개 | **메신저 목업 + 앱 입력 스크린샷 나란히** |
+| 채팅 예시 | 김치찌개/택시 | **파스타 32000원** |
+
+- 카카오톡/텔레그램 개별 로고 제거, 일반 메신저 아이콘 사용
+- 앱 입력은 `landingScreenshots.input.app` 스크린샷 사용
+
+### 섹션 3: 공유 가계부 (유지 + 소폭 개선)
+
+**변경 내용**: 구조 유지, 거래 예시만 생활감 있게
+
+| 항목 | 현재 | 변경 |
+|------|------|------|
+| 헤드라인 | "가족이 함께 쓰는 하나의 가계부" | 유지 |
+| 설명 | 초대/공유 설명 | **"초대 한 번이면 같이 써요. 누가, 언제, 얼마 썼는지 한눈에."** |
+| 거래 예시 | 김치찌개/지하철/문구류 | **저녁 파스타 32,000원 / 아이 학원비 150,000원 / 주말 장보기 48,000원** |
+| 태그 4개 | 실시간 동기화 등 | 유지 |
+
+### 섹션 4: 한눈에 보기 (기존 InsightsSection 리뉴얼)
+
+**변경 내용**: 캐러셀(폰 목업) → 카드 이미지 격자 배치
+
+| 항목 | 현재 | 변경 |
+|------|------|------|
+| 뱃지 | "돌아보기" | **"모아보기"** |
+| 헤드라인 | "이달의 소비, 한눈에 돌아보기" | **"이번 달, 어디에 얼마 썼지?"** |
+| 설명 | 소비 분석 | **"앱 열면 바로 보여요. 예산 현황, 정기결제 일정, 카테고리별 지출, AI 분석까지."** |
+| 비주얼 | 폰 목업 캐러셀 3장 | **카드 이미지 4개 격자/스택 배치** |
+
+카드 이미지 (`landingScreenshots.overview`):
+1. 예산 히어로 카드 — 홈 첫화면 프로그레스바 (전체 예산 현황)
+2. 카테고리 TOP 카드 — 이번 달 카테고리별 지출
+3. 정기결제 알림 카드 — 오늘 결제 예정 알림
+4. AI 인사이트 카드 — AI 분석 코멘트
+
+폰 목업 프레임 제거 → 카드가 크게 보여서 30대+ 타겟에 읽기 편함.
+
+### 섹션 5: 편의 기능 (카드 교체)
+
+**변경 내용**: 자산 트래킹 제거, 가계부 검색 추가, 카피 전체 수정
+
+| # | 현재 | 변경 |
+|---|------|------|
+| 1 | 예산 관리 — 한도 설정, 초과 알림 | **예산 관리** — "우리 집 예산, 얼마나 썼는지 한눈에 봐요. 넘으면 알려줘요" |
+| 2 | 정기결제 관리 — 자동 기록 | **정기결제 관리** — "넷플릭스, 보험료, 공과금 결제일에 놓치지 않고 알려줘요" |
+| 3 | 결제수단별 현황 — 카드/현금/이체 | **결제수단 현황** — "카드 실적, 현금, 이체까지 한번에 모아서 봐요" |
+| 4 | ~~자산 트래킹~~ | **가계부 검색** — "지난주 병원비 얼마였지? 금액, 카테고리, 기간으로 바로 찾아요" |
+| 5 | 맞춤 카테고리 | **맞춤 카테고리** — "나만의 분류로 자유롭게 정리해요" (유지) |
+
+### 섹션 6: 소셜 프루프 (가짜 후기 → 시나리오 전환)
+
+**변경 내용**: 별점 + 인용문 제거, "이런 분께 딱" 시나리오로 전환
+
+| 항목 | 현재 | 변경 |
+|------|------|------|
+| 헤드라인 | "기록이 습관이 되는 가장 쉬운 방법" | **"이런 분께 딱 맞아요"** |
+| 콘텐츠 | 별점 5개 + 가짜 후기 3개 | **문제 → 해결 시나리오 3개** |
+
+상단 숫자 3개 유지:
+- "5초면 입력"
+- "100% 자동 카테고리"
+- "0원 완전 무료"
+
+시나리오 카드 3개:
+
+| 페르소나 | 문제 | 포도가계부로 해결 |
+|----------|------|-------------------|
+| 맞벌이 부부 | "둘 다 쓰는데 월말에 뭐에 썼는지 모르겠어" | 공유 가계부로 실시간 확인 |
+| 살림 초보 | "가계부 앱 깔아봤는데 입력 귀찮아서 삭제함" | 메신저로 한 줄이면 끝 |
+| 알뜰 살림러 | "구독료가 매달 얼마 빠지는지 파악이 안 돼" | 정기결제 알림 + 예산 관리 |
+
+### 섹션 7: CTA 푸터 (소폭 개선)
+
+| 항목 | 현재 | 변경 |
+|------|------|------|
+| 헤드라인 | "포도알처럼 하나씩, 오늘부터 시작해볼까요?" | **"오늘부터 편하게 기록해볼까요?"** |
+| 설명 | "복잡한 가입 없이, 메신저로 시작" | **"복잡한 가입 없이, 구글 계정으로 바로 시작하세요"** |
+| "사용법 보기" 버튼 | 토스트 메시지 출력 | 유지 (변경 없음) |
+| 푸터 링크 | 개인정보처리방침, 이용약관, FAQ, 문의, 사용법 | 유지 (변경 없음) |
+| 소셜 아이콘 | X, Instagram | 유지 (변경 없음) |
+
+---
+
+## 변경하지 않는 것
+
+- Header 컴포넌트 (로고 + 로그인 버튼, 스크롤 시 frosted glass 효과)
+- LandingPage.tsx (섹션 import + 인증 리다이렉트 로직)
+- 전체 디자인 톤 (Grape 디자인 시스템, Cream 배경)
+- 애니메이션 패턴 (Intersection Observer, CSS 키프레임, stagger 효과)
+- useInView 훅, useCountUp 로직
+- 반응형 구조 (모바일 퍼스트)
+- 다크모드 지원
+- CTAFooter의 "사용법 보기" 버튼, 푸터 링크, 소셜 아이콘
+
+## 파일 변경 범위
+
+| 파일 | 작업 |
+|------|------|
+| `src/data/landingData.ts` | 새로 생성 — 스크린샷 + 기능 카드 + 시나리오 데이터 |
+| `src/components/landing/ScreenshotImage.tsx` | 새로 생성 — 이미지 + fallback 플레이스홀더 |
+| `src/components/landing/HeroSection.tsx` | 카피 + 채팅 예시 수정 |
+| `src/components/landing/MessengerSection.tsx` | 리뉴얼 → 쉽고 빠른 입력 |
+| `src/components/landing/SharedSection.tsx` | 거래 예시 + 설명 수정 |
+| `src/components/landing/InsightsSection.tsx` | 리뉴얼 → 한눈에 보기 (카드 격자) |
+| `src/components/landing/FeaturesSection.tsx` | 카드 교체 + 카피 수정 |
+| `src/components/landing/SocialProofSection.tsx` | 리뉴얼 → 시나리오 전환 |
+| `src/components/landing/CTAFooter.tsx` | 카피 수정 |
+| `public/screenshots/` | 새 스크린샷 디렉토리 (이미지는 추후 교체) |

--- a/frontend/src/components/landing/CTAFooter.tsx
+++ b/frontend/src/components/landing/CTAFooter.tsx
@@ -36,13 +36,13 @@ export function CTAFooter() {
           </span>
 
           <h2 className="text-2xl font-bold leading-snug text-white sm:text-3xl md:text-4xl">
-            <span className="block">포도알처럼 하나씩,</span>
-            <span className="block">오늘부터 시작해볼까요?</span>
+            <span className="block">오늘부터</span>
+            <span className="block">편하게 기록해볼까요?</span>
           </h2>
 
           <p className="mt-4 max-w-md text-base leading-relaxed text-white/80 md:text-lg">
-            <span className="block">복잡한 가입 절차 없이</span>
-            <span className="block">메신저 하나로 바로 시작하세요.</span>
+            <span className="block">복잡한 가입 없이,</span>
+            <span className="block">구글 계정으로 바로 시작하세요.</span>
           </p>
 
           {/* CTA 버튼 */}

--- a/frontend/src/components/landing/FeaturesSection.tsx
+++ b/frontend/src/components/landing/FeaturesSection.tsx
@@ -1,73 +1,37 @@
 import { useInView } from '../../hooks/useInView'
+import { featureCards } from '../../data/landingData'
 
-const features = [
-  {
-    title: "예산 관리",
-    description: "이번 달 얼마까지 쓸 건지 정해두면, 초과할 때 알려줘요.",
-    highlight: "초과 알림",
-    iconBg: "bg-grape-100",
-    iconColor: "text-grape-700",
-    highlightBg: "bg-grape-100 text-grape-700",
-    icon: (
+function getFeatureIcon(id: string) {
+  const icons: Record<string, JSX.Element> = {
+    budget: (
       <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
       </svg>
     ),
-  },
-  {
-    title: "정기결제 관리",
-    description: "넷플릭스, 통신비, 보험료까지. 매달 나가는 고정 지출을 잊지 않고 관리해요.",
-    highlight: "자동 기록",
-    iconBg: "bg-leaf-100",
-    iconColor: "text-leaf-700",
-    highlightBg: "bg-leaf-100 text-leaf-700",
-    icon: (
+    recurring: (
       <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
       </svg>
     ),
-  },
-  {
-    title: "결제수단별 현황",
-    description: "카드, 현금, 계좌이체. 어디서 얼마나 썼는지 한눈에 볼 수 있어요.",
-    highlight: "통합 관리",
-    iconBg: "bg-orange-50",
-    iconColor: "text-orange-700",
-    highlightBg: "bg-orange-50 text-orange-700",
-    icon: (
+    payment: (
       <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z" />
       </svg>
     ),
-  },
-  {
-    title: "자산 트래킹",
-    description: "은행 잔고부터 투자금까지. 내 전체 자산이 어떻게 흐르는지 추적해요.",
-    highlight: "자산 현황",
-    iconBg: "bg-yellow-50",
-    iconColor: "text-yellow-700",
-    highlightBg: "bg-yellow-50 text-yellow-700",
-    icon: (
+    search: (
       <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
       </svg>
     ),
-  },
-  {
-    title: "맞춤 카테고리",
-    description: "기본 카테고리가 안 맞으신다면? 내 방식대로 만들어보세요.",
-    highlight: "자유롭게",
-    iconBg: "bg-green-50",
-    iconColor: "text-leaf-700",
-    highlightBg: "bg-green-50 text-leaf-700",
-    icon: (
+    category: (
       <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z" />
         <path strokeLinecap="round" strokeLinejoin="round" d="M6 6h.008v.008H6V6z" />
       </svg>
     ),
-  },
-]
+  }
+  return icons[id] ?? null
+}
 
 export function FeaturesSection() {
   const { ref, isInView } = useInView()
@@ -96,7 +60,7 @@ export function FeaturesSection() {
 
         {/* 기능 카드 그리드 */}
         <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {features.map((feature, i) => (
+          {featureCards.map((feature, i) => (
             <div
               key={feature.title}
               className={`group relative overflow-hidden rounded-2xl border border-warm-300 bg-white p-6 shadow-sm transition-all duration-[400ms] [transition-timing-function:cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-1 hover:border-grape-400 hover:shadow-lg ${
@@ -113,7 +77,7 @@ export function FeaturesSection() {
               <div
                 className={`mb-4 flex h-12 w-12 items-center justify-center rounded-xl transition-transform duration-300 group-hover:scale-110 ${feature.iconBg} ${feature.iconColor}`}
               >
-                {feature.icon}
+                {getFeatureIcon(feature.id)}
               </div>
 
               <h3 className="mb-2 text-lg font-semibold text-warm-900">{feature.title}</h3>

--- a/frontend/src/components/landing/FeaturesSection.tsx
+++ b/frontend/src/components/landing/FeaturesSection.tsx
@@ -1,8 +1,9 @@
+import type { ReactNode } from 'react'
 import { useInView } from '../../hooks/useInView'
 import { featureCards } from '../../data/landingData'
 
-function getFeatureIcon(id: string) {
-  const icons: Record<string, JSX.Element> = {
+function getFeatureIcon(id: string): ReactNode {
+  const icons: Record<string, ReactNode> = {
     budget: (
       <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -109,7 +109,7 @@ function ChatPhone({ visible }: { visible: boolean }) {
           {chatStep >= 1 && (
             <div className="animate-bubble-in flex justify-end">
               <div className="max-w-[75%] rounded-2xl rounded-br-sm bg-grape-600 px-3 py-2 text-xs text-white shadow-sm">
-                점심 김치찌개 8000원
+                남편이랑 저녁 파스타 32000원
               </div>
             </div>
           )}
@@ -123,7 +123,7 @@ function ChatPhone({ visible }: { visible: boolean }) {
           {chatStep >= 3 && (
             <div className="animate-bubble-in flex justify-start">
               <div className="max-w-[80%] rounded-2xl rounded-bl-sm bg-stone-100 px-3 py-2 text-xs leading-relaxed text-stone-700 shadow-sm">
-                🍇 김치찌개 8,000원 기록했어요
+                🍇 저녁 파스타 32,000원 기록했어요
                 <br /><br />
                 <span className="text-stone-400">3월 31일 (월) · 식비</span>
               </div>
@@ -149,7 +149,7 @@ function ChatPhone({ visible }: { visible: boolean }) {
       >
         <img
           src="/screenshot-after.jpg"
-          alt="김치찌개 추가된 거래 목록"
+          alt="저녁 파스타 추가된 거래 목록"
           style={screenshotStyle}
         />
 
@@ -160,12 +160,12 @@ function ChatPhone({ visible }: { visible: boolean }) {
               <div className="flex items-center gap-2">
                 <span className="flex h-7 w-7 items-center justify-center rounded-full bg-grape-100 text-sm">🍇</span>
                 <div>
-                  <p className="text-xs font-bold text-stone-800">김치찌개</p>
+                  <p className="text-xs font-bold text-stone-800">저녁 파스타</p>
                   <p className="text-[10px] text-stone-400">식비 · 방금</p>
                 </div>
               </div>
               <div className="text-right">
-                <p className="text-sm font-bold text-rose-500">-8,000원</p>
+                <p className="text-sm font-bold text-rose-500">-32,000원</p>
                 <p className="text-[10px] font-medium text-leaf-600">✓ 추가됐어요</p>
               </div>
             </div>
@@ -214,16 +214,14 @@ export function HeroSection() {
               backgroundClip: "text",
             }}
           >
-            <span className="block">포도알처럼</span>
-            <span className="block">하나씩, 알찬</span>
+            <span className="block">말하듯 기록하면,</span>
             <span className="block" style={{ WebkitTextFillColor: "#292524", color: "#292524" }}>
-              가계부
+              AI가 알아서 정리해요
             </span>
           </h1>
           <p className="mt-5 max-w-sm text-base leading-relaxed text-stone-500 sm:text-lg">
-            <span className="block">말로 기록하면</span>
-            <span className="block font-semibold text-stone-700">AI가 알아서 분류하는</span>
-            <span className="block">우리 집 가계부</span>
+            <span className="block">메신저에 '남편이랑 저녁 파스타 32000원' 보내면 끝.</span>
+            <span className="block font-semibold text-stone-700">카테고리, 날짜, 결제수단까지 자동으로.</span>
           </p>
           <Link
             to="/login"

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -125,7 +125,7 @@ function ChatPhone({ visible }: { visible: boolean }) {
               <div className="max-w-[80%] rounded-2xl rounded-bl-sm bg-stone-100 px-3 py-2 text-xs leading-relaxed text-stone-700 shadow-sm">
                 🍇 저녁 파스타 32,000원 기록했어요
                 <br /><br />
-                <span className="text-stone-400">3월 31일 (월) · 식비</span>
+                <span className="text-stone-400">오늘 · 식비</span>
               </div>
             </div>
           )}

--- a/frontend/src/components/landing/InsightsSection.tsx
+++ b/frontend/src/components/landing/InsightsSection.tsx
@@ -1,26 +1,9 @@
-import { useEffect, useState } from 'react'
 import { useInView } from '../../hooks/useInView'
-
-const SLIDES = [
-  { src: "/screenshot-report-1.jpg", alt: "월간 리포트 — 요약" },
-  { src: "/screenshot-report-2.jpg", alt: "월간 리포트 — 카테고리·예산" },
-  { src: "/screenshot-report-3.jpg", alt: "월간 리포트 — AI 분석" },
-]
-
-const SLIDE_INTERVAL = 3000
+import { landingScreenshots } from '../../data/landingData'
+import { ScreenshotImage } from './ScreenshotImage'
 
 export function InsightsSection() {
   const { ref, isInView } = useInView()
-  const [current, setCurrent] = useState(0)
-
-  // 섹션이 보일 때만 자동 슬라이드
-  useEffect(() => {
-    if (!isInView) return
-    const id = setInterval(() => {
-      setCurrent((c) => (c + 1) % SLIDES.length)
-    }, SLIDE_INTERVAL)
-    return () => clearInterval(id)
-  }, [isInView])
 
   return (
     <section
@@ -38,75 +21,38 @@ export function InsightsSection() {
         className="relative mx-auto flex max-w-5xl flex-col items-center px-4 sm:px-6 lg:px-8"
       >
         {/* 헤더 */}
-        <div className={`mb-16 text-center ${isInView ? "animate-fade-in-up" : "opacity-0"}`}>
+        <div className={`mb-12 text-center ${isInView ? "animate-fade-in-up" : "opacity-0"}`}>
           <span className="mb-4 inline-block rounded-full bg-grape-500/10 px-4 py-1.5 text-sm font-medium text-grape-500">
-            돌아보기
+            모아보기
           </span>
           <h2 className="mt-4 text-2xl font-bold leading-snug text-warm-900 sm:text-3xl md:text-4xl">
-            <span className="block">이달의 소비,</span>
-            <span className="block">한눈에 돌아보기</span>
+            <span className="block">이번 달,</span>
+            <span className="block">어디에 얼마 썼지?</span>
           </h2>
           <p className="mx-auto mt-4 max-w-sm text-base leading-relaxed text-warm-500">
-            이번 달 어디에 얼마 썼는지,
-            <br />어떤 걸 줄일 수 있는지 보여줘요.
+            앱 열면 바로 보여요. 예산 현황, 정기결제 일정, 카테고리별 지출, AI 분석까지.
           </p>
         </div>
 
-        {/* 폰 목업 + 슬라이드 */}
-        <div
-          className={`flex flex-col items-center ${isInView ? "animate-fade-in-up" : "opacity-0"}`}
-          style={{ animationDelay: "0.2s" }}
-        >
-          {/* 폰 프레임 */}
-          <div className="relative h-[560px] w-[272px] overflow-hidden rounded-[3rem] border-[7px] border-stone-900/10 bg-white shadow-2xl md:h-[620px] md:w-[295px]">
-            {/* Notch */}
-            <div className="absolute left-1/2 top-[5px] z-20 h-4 w-20 -translate-x-1/2 rounded-full bg-stone-900/10" />
-
-            {/* 슬라이드 트랙 */}
+        {/* 2x2 카드 격자 */}
+        <div className="grid grid-cols-2 gap-4 md:gap-6 max-w-2xl mx-auto w-full">
+          {landingScreenshots.overview.map((item, i) => (
             <div
-              className="flex h-full transition-transform duration-700 ease-in-out"
-              style={{ width: `${SLIDES.length * 100}%`, transform: `translateX(-${current * (100 / SLIDES.length)}%)` }}
+              key={item.path}
+              className={`rounded-2xl border border-warm-200 bg-white shadow-sm overflow-hidden ${isInView ? "animate-fade-in-up" : "opacity-0"}`}
+              style={{ animationDelay: `${0.1 * i}s` }}
             >
-              {SLIDES.map((slide) => (
-                <div
-                  key={slide.src}
-                  className="relative overflow-hidden"
-                  style={{ width: `${100 / SLIDES.length}%`, flexShrink: 0 }}
-                >
-                  <img
-                    src={slide.src}
-                    alt={slide.alt}
-                    className="w-full object-cover"
-                    style={{ objectPosition: "top", height: "calc(100% + 20px)" }}
-                  />
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* 인디케이터 */}
-          <div className="mt-5 flex items-center gap-2">
-            {SLIDES.map((_, i) => (
-              <button
-                key={i}
-                type="button"
-                onClick={() => setCurrent(i)}
-                className={`rounded-full transition-all duration-300 ${
-                  i === current
-                    ? "w-6 bg-grape-500 h-2"
-                    : "w-2 bg-warm-300 h-2 hover:bg-warm-400"
-                }`}
-                aria-label={`슬라이드 ${i + 1}`}
+              <ScreenshotImage
+                src={item.path}
+                alt={item.alt}
+                caption={item.caption}
+                className="aspect-[4/3] w-full object-cover"
               />
-            ))}
-          </div>
-
-          {/* 뱃지 */}
-          <div className="mt-5">
-            <span className="rounded-full border border-grape-200 bg-grape-100 px-4 py-2 text-sm font-medium text-grape-500">
-              언제든 현황 확인
-            </span>
-          </div>
+              <p className="px-3 py-2 text-sm font-medium text-warm-700 text-center">
+                {item.caption}
+              </p>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/frontend/src/components/landing/MessengerSection.tsx
+++ b/frontend/src/components/landing/MessengerSection.tsx
@@ -49,7 +49,7 @@ export function MessengerSection() {
 
         {/* Visual Area — 두 가지 입력 방식 나란히 */}
         <div
-          className={`flex flex-1 items-start justify-center gap-4 ${
+          className={`flex flex-1 flex-col items-start justify-center gap-4 sm:flex-row ${
             isInView ? "animate-fade-in-up" : "opacity-0"
           }`}
           style={{ animationDelay: "0.2s" }}

--- a/frontend/src/components/landing/MessengerSection.tsx
+++ b/frontend/src/components/landing/MessengerSection.tsx
@@ -1,4 +1,6 @@
 import { useInView } from '../../hooks/useInView'
+import { ScreenshotImage } from './ScreenshotImage'
+import { landingScreenshots } from '../../data/landingData'
 
 export function MessengerSection() {
   const { ref, isInView } = useInView()
@@ -16,148 +18,116 @@ export function MessengerSection() {
           }`}
         >
           <span className="mb-4 inline-block rounded-full bg-grape-500/10 px-4 py-1.5 text-sm font-medium text-grape-500">
-            핵심 기능
+            쉽고 빠른 입력
           </span>
           <h2 className="text-2xl font-bold leading-snug text-warm-900 sm:text-3xl md:text-4xl">
-            <span className="block">메신저로</span>
-            <span className="block">기록하세요</span>
+            <span className="block">한 줄이면 끝,</span>
+            <span className="block">나머지는 AI가</span>
           </h2>
           <p className="mt-4 max-w-lg text-base leading-relaxed text-warm-500 md:mt-6 md:text-lg">
-            <span className="block sm:inline">카카오톡, 텔레그램 등</span>{" "}
-            <span className="block sm:inline">평소 쓰는 메신저에서</span>
-          </p>
-          <p className="mt-2 max-w-lg text-base leading-relaxed text-warm-500 md:text-lg">
-            <span className="font-medium text-warm-900">&apos;점심 김치찌개 8000원&apos;</span>{" "}
-            <span className="block sm:inline">한 줄이면 끝.</span>
-          </p>
-          <p className="mt-4 text-base leading-relaxed text-warm-500 md:text-lg">
-            카테고리, 날짜, 결제수단까지 알아서 분류해드려요.
+            사용하던 메신저로 보내도 되고, 앱에서 바로 입력해도 돼요. 카테고리, 날짜, 결제수단은 AI가 알아서 분류해줘요.
           </p>
 
-          {/* Messenger Icons */}
+          {/* Input Method Icons */}
           <div className="mt-8 flex items-center gap-3">
-            <div className="flex items-center gap-2 rounded-full bg-[#FEE500] px-4 py-2">
-              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="#3C1E1E">
-                <path d="M12 3C6.48 3 2 6.58 2 11c0 2.77 1.81 5.2 4.5 6.6-.14.85-.5 2.57-.57 2.97-.09.52.19.51.4.37.17-.11 2.53-1.72 3.56-2.42.69.1 1.4.15 2.11.15 5.52 0 10-3.58 10-8s-4.48-8-10-8z"/>
+            {/* 메신저 아이콘 */}
+            <div className="flex items-center gap-2 rounded-full bg-warm-100 px-4 py-2">
+              <svg viewBox="0 0 24 24" className="h-5 w-5 text-warm-700" fill="none" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
               </svg>
-              <span className="text-sm font-medium text-[#3C1E1E]">카카오톡</span>
+              <span className="text-sm font-medium text-warm-700">메신저</span>
             </div>
-            <div className="flex items-center gap-2 rounded-full bg-[#0088cc] px-4 py-2">
-              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="white">
-                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69a.2.2 0 00-.05-.18c-.06-.05-.14-.03-.21-.02-.09.02-1.49.95-4.22 2.79-.4.27-.76.41-1.08.4-.36-.01-1.04-.2-1.55-.37-.63-.2-1.12-.31-1.08-.66.02-.18.27-.36.74-.55 2.92-1.27 4.86-2.11 5.83-2.51 2.78-1.16 3.35-1.36 3.73-1.36.08 0 .27.02.39.12.1.08.13.19.14.27-.01.06.01.24 0 .38z"/>
+            {/* 앱 아이콘 */}
+            <div className="flex items-center gap-2 rounded-full bg-warm-100 px-4 py-2">
+              <svg viewBox="0 0 24 24" className="h-5 w-5 text-warm-700" fill="none" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
               </svg>
-              <span className="text-sm font-medium text-white">텔레그램</span>
+              <span className="text-sm font-medium text-warm-700">앱에서 바로</span>
             </div>
           </div>
         </div>
 
-        {/* Chat Mockup */}
+        {/* Visual Area — 두 가지 입력 방식 나란히 */}
         <div
-          className={`flex flex-1 items-center justify-center ${
+          className={`flex flex-1 items-start justify-center gap-4 ${
             isInView ? "animate-fade-in-up" : "opacity-0"
           }`}
           style={{ animationDelay: "0.2s" }}
         >
-          <div className="w-full max-w-sm rounded-3xl border border-warm-300 bg-white p-6 shadow-xl">
-            {/* Chat Header */}
-            <div className="mb-6 flex items-center gap-3 border-b border-warm-300 pb-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-grape-500">
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  className="h-5 w-5 text-white"
+          {/* 왼쪽 카드: 채팅 목업 */}
+          <div className="flex flex-col items-center flex-1">
+            <div className="w-full rounded-2xl border border-warm-200 bg-white p-5 shadow-lg overflow-hidden">
+              {/* Chat Header */}
+              <div className="mb-4 flex items-center gap-3 border-b border-warm-200 pb-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-full bg-grape-500">
+                  <svg viewBox="0 0 24 24" fill="none" className="h-4 w-4 text-white">
+                    <circle cx="12" cy="8" r="3" fill="currentColor" />
+                    <circle cx="7" cy="14" r="3" fill="currentColor" />
+                    <circle cx="17" cy="14" r="3" fill="currentColor" />
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-warm-900">포도가계부</p>
+                  <p className="text-xs text-warm-500">AI 가계부 봇</p>
+                </div>
+              </div>
+
+              {/* Chat Messages */}
+              <div className="space-y-3">
+                {/* 사용자 메시지 */}
+                <div
+                  className={`flex justify-end ${isInView ? "animate-bubble-in" : "opacity-0"}`}
+                  style={{ animationDelay: "0.3s" }}
                 >
-                  <circle cx="12" cy="8" r="3" fill="currentColor" />
-                  <circle cx="7" cy="14" r="3" fill="currentColor" />
-                  <circle cx="17" cy="14" r="3" fill="currentColor" />
-                </svg>
-              </div>
-              <div>
-                <p className="font-semibold text-warm-900">포도가계부</p>
-                <p className="text-xs text-warm-500">AI 가계부 봇</p>
-              </div>
-            </div>
-
-            {/* Chat Messages */}
-            <div className="space-y-4">
-              {/* User message 1 */}
-              <div
-                className={`flex justify-end ${isInView ? "animate-bubble-in" : "opacity-0"}`}
-                style={{ animationDelay: "0.3s" }}
-              >
-                <div className="max-w-[80%] rounded-2xl rounded-tr-sm bg-grape-500/20 px-4 py-2.5">
-                  <p className="text-sm text-warm-900">점심 김치찌개 8000원</p>
-                </div>
-              </div>
-
-              {/* Bot response 1 */}
-              <div
-                className={`flex justify-start ${isInView ? "animate-bubble-in" : "opacity-0"}`}
-                style={{ animationDelay: "0.55s" }}
-              >
-                <div className="max-w-[85%] rounded-2xl rounded-tl-sm border border-warm-300 bg-white px-4 py-3 shadow-sm">
-                  <div className="space-y-1.5 text-sm">
-                    <div className="flex items-center justify-between">
-                      <span className="text-warm-500">카테고리</span>
-                      <span className="font-medium text-warm-900">식비</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="text-warm-500">금액</span>
-                      <span className="font-medium text-warm-900">8,000원</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="text-warm-500">날짜</span>
-                      <span className="font-medium text-warm-900">오늘</span>
-                    </div>
-                    <div className="mt-2 flex items-center gap-1.5 text-leaf-500">
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                      </svg>
-                      <span className="text-sm font-medium">기록됐어요</span>
-                    </div>
+                  <div className="max-w-[85%] rounded-2xl rounded-tr-sm bg-grape-500/20 px-3 py-2">
+                    <p className="text-sm text-warm-900">남편이랑 저녁 파스타 32000원</p>
                   </div>
                 </div>
-              </div>
 
-              {/* User message 2 */}
-              <div
-                className={`flex justify-end ${isInView ? "animate-bubble-in" : "opacity-0"}`}
-                style={{ animationDelay: "0.8s" }}
-              >
-                <div className="max-w-[80%] rounded-2xl rounded-tr-sm bg-grape-500/20 px-4 py-2.5">
-                  <p className="text-sm text-warm-900">어제 택시 15000원 카드로</p>
-                </div>
-              </div>
-
-              {/* Bot response 2 */}
-              <div
-                className={`flex justify-start ${isInView ? "animate-bubble-in" : "opacity-0"}`}
-                style={{ animationDelay: "1.05s" }}
-              >
-                <div className="max-w-[85%] rounded-2xl rounded-tl-sm border border-warm-300 bg-white px-4 py-3 shadow-sm">
-                  <div className="space-y-1.5 text-sm">
-                    <div className="flex items-center justify-between">
-                      <span className="text-warm-500">카테고리</span>
-                      <span className="font-medium text-warm-900">교통</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="text-warm-500">금액</span>
-                      <span className="font-medium text-warm-900">15,000원</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span className="text-warm-500">결제수단</span>
-                      <span className="font-medium text-warm-900">카드</span>
-                    </div>
-                    <div className="mt-2 flex items-center gap-1.5 text-leaf-500">
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                      </svg>
-                      <span className="text-sm font-medium">기록됐어요</span>
+                {/* 봇 응답 */}
+                <div
+                  className={`flex justify-start ${isInView ? "animate-bubble-in" : "opacity-0"}`}
+                  style={{ animationDelay: "0.55s" }}
+                >
+                  <div className="max-w-[90%] rounded-2xl rounded-tl-sm border border-warm-200 bg-white px-3 py-2.5 shadow-sm">
+                    <div className="space-y-1.5 text-sm">
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-warm-500">카테고리</span>
+                        <span className="font-medium text-warm-900">식비</span>
+                      </div>
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-warm-500">금액</span>
+                        <span className="font-medium text-warm-900">32,000원</span>
+                      </div>
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-warm-500">날짜</span>
+                        <span className="font-medium text-warm-900">오늘</span>
+                      </div>
+                      <div className="mt-1.5 flex items-center gap-1.5 text-leaf-500">
+                        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                        </svg>
+                        <span className="text-sm font-medium">기록됐어요</span>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
+            <p className="mt-3 text-sm font-medium text-warm-500 text-center">메신저로 보내기</p>
+          </div>
+
+          {/* 오른쪽 카드: 앱 스크린샷 */}
+          <div className="flex flex-col items-center flex-1">
+            <div className="w-full rounded-2xl border border-warm-200 overflow-hidden">
+              <ScreenshotImage
+                src={landingScreenshots.input.app.path}
+                alt={landingScreenshots.input.app.alt}
+                caption="앱에서 바로 입력"
+                className="h-full w-full object-cover"
+              />
+            </div>
+            <p className="mt-3 text-sm font-medium text-warm-500 text-center">앱에서 바로 입력</p>
           </div>
         </div>
       </div>

--- a/frontend/src/components/landing/ScreenshotImage.tsx
+++ b/frontend/src/components/landing/ScreenshotImage.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+
+type ScreenshotImageProps = {
+  src: string
+  alt: string
+  caption?: string
+  className?: string
+}
+
+export function ScreenshotImage({ src, alt, caption, className = '' }: ScreenshotImageProps) {
+  const [failed, setFailed] = useState(false)
+
+  if (failed) {
+    return (
+      <div
+        className={`flex items-center justify-center rounded-2xl bg-gradient-to-br from-grape-200 to-grape-400 dark:from-grape-700 dark:to-grape-900 ${className}`}
+        role="img"
+        aria-label={alt}
+      >
+        {caption && (
+          <span className="text-sm font-medium text-white drop-shadow-sm">
+            {caption}
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={`rounded-2xl ${className}`}
+      onError={() => setFailed(true)}
+      loading="lazy"
+    />
+  )
+}

--- a/frontend/src/components/landing/SharedSection.tsx
+++ b/frontend/src/components/landing/SharedSection.tsx
@@ -7,9 +7,9 @@ const members = [
 ]
 
 const transactions = [
-  { member: "엄마", color: "bg-grape-100 text-grape-700", text: "김치찌개 8,000원", time: "방금 전",   rotate: "-rotate-2", pos: "left-0 -top-6" },
-  { member: "아빠", color: "bg-leaf-100 text-leaf-700", text: "지하철 50,000원",  time: "3분 전",   rotate: "rotate-2",  pos: "right-0 top-4" },
-  { member: "나",   color: "bg-yellow-100 text-yellow-700", text: "문구류 12,000원",  time: "10분 전",  rotate: "-rotate-1", pos: "left-4 bottom-0" },
+  { member: "엄마", color: "bg-grape-100 text-grape-700", text: "저녁 파스타 32,000원", time: "방금 전",   rotate: "-rotate-2", pos: "left-0 -top-6" },
+  { member: "아빠", color: "bg-leaf-100 text-leaf-700", text: "아이 학원비 150,000원",  time: "3분 전",   rotate: "rotate-2",  pos: "right-0 top-4" },
+  { member: "나",   color: "bg-yellow-100 text-yellow-700", text: "주말 장보기 48,000원",  time: "10분 전",  rotate: "-rotate-1", pos: "left-4 bottom-0" },
 ]
 
 export function SharedSection() {
@@ -33,9 +33,9 @@ export function SharedSection() {
             <span className="block">하나의 가계부</span>
           </h2>
           <p className="mx-auto mt-5 max-w-md text-base leading-relaxed text-warm-500">
-            가족을 초대하고 함께 써요.
+            초대 한 번이면 같이 써요.
             <br />
-            누가 어떻게 썼는지 한눈에 볼 수 있어요.
+            누가, 언제, 얼마 썼는지 한눈에.
           </p>
         </div>
 

--- a/frontend/src/components/landing/SocialProofSection.tsx
+++ b/frontend/src/components/landing/SocialProofSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import { socialStats, socialScenarios } from '../../data/landingData'
 
 function useCountUp(target: number, duration = 2000, started = false) {
   const [value, setValue] = useState(0)
@@ -28,77 +29,22 @@ function useCountUp(target: number, duration = 2000, started = false) {
   return value
 }
 
-const stats = [
-  {
-    value: 5,
-    unit: "초",
-    suffix: "만에 입력",
-    desc: "길게 쓸 필요 없이\n한 줄이면 충분해요",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-6 w-6">
-        <circle cx="12" cy="12" r="9" />
-        <polyline points="12 6 12 12 15.5 14" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    ),
-  },
-  {
-    value: 100,
-    unit: "%",
-    suffix: "자동 카테고리",
-    desc: "식비·교통·쇼핑\nAI가 알아서 분류해요",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-6 w-6">
-        <path d="M12 2L2 7l10 5 10-5-10-5z" strokeLinejoin="round" />
-        <path d="M2 17l10 5 10-5" strokeLinejoin="round" />
-        <path d="M2 12l10 5 10-5" strokeLinejoin="round" />
-      </svg>
-    ),
-  },
-  {
-    value: 0,
-    unit: "원",
-    suffix: "완전 무료",
-    desc: "모든 기능을\n무료로 사용하세요",
-    icon: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-6 w-6">
-        <path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z" strokeLinejoin="round" />
-        <path d="M12 6v2m0 8v2M8 12h8" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    ),
-  },
+// 인덱스별 SVG 아이콘 (0: 시계, 1: 레이어, 2: 쉴드체크)
+const statIcons = [
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-6 w-6">
+    <circle cx="12" cy="12" r="9" />
+    <polyline points="12 6 12 12 15.5 14" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>,
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-6 w-6">
+    <path d="M12 2L2 7l10 5 10-5-10-5z" strokeLinejoin="round" />
+    <path d="M2 17l10 5 10-5" strokeLinejoin="round" />
+    <path d="M2 12l10 5 10-5" strokeLinejoin="round" />
+  </svg>,
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="h-6 w-6">
+    <path d="M12 2a10 10 0 1 0 0 20A10 10 0 0 0 12 2z" strokeLinejoin="round" />
+    <path d="M12 6v2m0 8v2M8 12h8" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>,
 ]
-
-const scenarios = [
-  {
-    tag: "맞벌이 부부",
-    tagColor: "bg-grape-100 text-grape-700",
-    quote: "매달 가계부 정리에 30분 쓰던 시간이 사라졌어요.",
-    initial: "김",
-    avatarBg: "bg-grape-200 text-grape-700",
-  },
-  {
-    tag: "자취 3년차",
-    tagColor: "bg-leaf-100 text-leaf-700",
-    quote: "카톡으로 보내면 끝이라 까먹을 일이 없어요.",
-    initial: "이",
-    avatarBg: "bg-leaf-200 text-leaf-700",
-  },
-  {
-    tag: "육아맘",
-    tagColor: "bg-amber-100 text-amber-700",
-    quote: "남편이랑 같이 쓰니까 누가 뭘 썼는지 한눈에.",
-    initial: "박",
-    avatarBg: "bg-amber-200 text-amber-700",
-  },
-]
-
-function StarIcon() {
-  return (
-    <svg viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4 text-amber-400">
-      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-    </svg>
-  )
-}
 
 export function SocialProofSection() {
   const sectionRef = useRef<HTMLDivElement>(null)
@@ -120,9 +66,9 @@ export function SocialProofSection() {
     return () => observer.disconnect()
   }, [])
 
-  const count0 = useCountUp(stats[0].value, 1800, inView)
-  const count1 = useCountUp(stats[1].value, 2000, inView)
-  const count2 = useCountUp(stats[2].value, 1400, inView)
+  const count0 = useCountUp(socialStats[0].value, 1800, inView)
+  const count1 = useCountUp(socialStats[1].value, 2000, inView)
+  const count2 = useCountUp(socialStats[2].value, 1400, inView)
   const counts = [count0, count1, count2]
 
   return (
@@ -139,16 +85,16 @@ export function SocialProofSection() {
           }}
         >
           <p className="mb-3 text-xs font-bold uppercase tracking-widest text-grape-400">
-            이런 분들이 쓰고 있어요
+            이런 분께 딱 맞아요
           </p>
           <h2 className="text-balance text-3xl font-bold text-warm-800 sm:text-4xl">
-            기록이 습관이 되는<br className="sm:hidden" /> 가장 쉬운 방법
+            이런 분께 딱 맞아요
           </h2>
         </div>
 
         {/* 스탯 행 */}
         <div className="mb-20 grid grid-cols-3 gap-3 sm:gap-6">
-          {stats.map((stat, i) => (
+          {socialStats.map((stat, i) => (
             <div
               key={i}
               className="flex flex-col items-center gap-3 rounded-3xl bg-white p-5 text-center shadow-sm sm:p-8"
@@ -159,19 +105,19 @@ export function SocialProofSection() {
               }}
             >
               <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-grape-100 text-grape-600">
-                {stat.icon}
+                {statIcons[i]}
               </div>
               <div>
                 <div className="flex items-baseline justify-center gap-0.5">
                   <span className="text-3xl font-extrabold tabular-nums text-grape-600 sm:text-4xl">
                     {counts[i]}
                   </span>
-                  <span className="text-lg font-bold text-grape-500 sm:text-xl">{stat.unit}</span>
+                  <span className="text-lg font-bold text-grape-500 sm:text-xl">{stat.suffix}</span>
                 </div>
-                <p className="mt-0.5 text-sm font-semibold text-warm-700">{stat.suffix}</p>
+                <p className="mt-0.5 text-sm font-semibold text-warm-700">{stat.label}</p>
               </div>
               <p className="hidden whitespace-pre-line text-xs leading-relaxed text-warm-400 sm:block">
-                {stat.desc}
+                {stat.description}
               </p>
             </div>
           ))}
@@ -190,40 +136,27 @@ export function SocialProofSection() {
           <div className="h-px flex-1 bg-grape-200" />
         </div>
 
-        {/* 시나리오 카드 */}
+        {/* 시나리오 카드 — 문제→해결 구조 */}
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          {scenarios.map((s, i) => (
+          {socialScenarios.map((s, i) => (
             <div
               key={i}
-              className="flex flex-col gap-5 rounded-3xl bg-white p-6 shadow-sm"
+              className="rounded-2xl border border-warm-200 bg-white p-6 shadow-sm"
               style={{
                 opacity: inView ? 1 : 0,
                 transform: inView ? "translateY(0)" : "translateY(28px)",
                 transition: `opacity 0.6s ease-out ${0.45 + i * 0.12}s, transform 0.6s ease-out ${0.45 + i * 0.12}s`,
               }}
             >
-              {/* 태그 + 별점 */}
-              <div className="flex items-center justify-between">
-                <span className={`rounded-full px-3 py-1 text-xs font-bold ${s.tagColor}`}>
-                  {s.tag}
-                </span>
-                <div className="flex gap-0.5">
-                  {Array.from({ length: 5 }).map((_, j) => <StarIcon key={j} />)}
-                </div>
-              </div>
-
-              {/* 인용문 */}
-              <p className="flex-1 text-[15px] leading-relaxed text-warm-600">
-                &ldquo;{s.quote}&rdquo;
+              <span className="inline-block rounded-full bg-grape-100 px-3 py-1 text-sm font-medium text-grape-700">
+                {s.persona}
+              </span>
+              <p className="mt-4 text-base italic text-warm-600">
+                &ldquo;{s.problem}&rdquo;
               </p>
-
-              {/* 아바타 */}
-              <div className="flex items-center gap-2.5">
-                <div className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold ${s.avatarBg}`}>
-                  {s.initial}
-                </div>
-                <span className="text-xs text-warm-400">포도 사용자</span>
-              </div>
+              <p className="mt-3 text-sm font-semibold text-grape-700">
+                → {s.solution}
+              </p>
             </div>
           ))}
         </div>

--- a/frontend/src/components/landing/SocialProofSection.tsx
+++ b/frontend/src/components/landing/SocialProofSection.tsx
@@ -85,7 +85,7 @@ export function SocialProofSection() {
           }}
         >
           <p className="mb-3 text-xs font-bold uppercase tracking-widest text-grape-400">
-            이런 분께 딱 맞아요
+            사용자 시나리오
           </p>
           <h2 className="text-balance text-3xl font-bold text-warm-800 sm:text-4xl">
             이런 분께 딱 맞아요

--- a/frontend/src/data/landingData.ts
+++ b/frontend/src/data/landingData.ts
@@ -1,0 +1,46 @@
+// --- 스크린샷 ---
+export const landingScreenshots = {
+  hero: {
+    path: '/screenshots/hero-chat.jpg',
+    alt: '메신저로 가계부 입력하는 화면',
+  },
+  input: {
+    messenger: {
+      path: '/screenshots/input-messenger.jpg',
+      alt: '메신저 입력 화면',
+    },
+    app: {
+      path: '/screenshots/input-app.jpg',
+      alt: '앱 내 직접 입력 화면',
+    },
+  },
+  overview: [
+    { path: '/screenshots/card-budget.jpg', caption: '예산 현황', alt: '예산 히어로 카드' },
+    { path: '/screenshots/card-category.jpg', caption: '카테고리 TOP', alt: '카테고리별 지출' },
+    { path: '/screenshots/card-recurring.jpg', caption: '정기결제 알림', alt: '정기결제 알림 카드' },
+    { path: '/screenshots/card-insight.jpg', caption: 'AI 인사이트', alt: 'AI 분석 카드' },
+  ],
+}
+
+// --- 편의 기능 카드 ---
+// icon SVG는 FeaturesSection.tsx 내에서 id 기반 매핑
+export const featureCards = [
+  { id: 'budget' as const, title: '예산 관리', description: '우리 집 예산, 얼마나 썼는지 한눈에 봐요. 넘으면 알려줘요', highlight: '한눈에', iconBg: 'bg-grape-100', iconColor: 'text-grape-700', highlightBg: 'bg-grape-100 text-grape-700' },
+  { id: 'recurring' as const, title: '정기결제 관리', description: '넷플릭스, 보험료, 공과금 결제일에 놓치지 않고 알려줘요', highlight: '놓치지 않고', iconBg: 'bg-leaf-100', iconColor: 'text-leaf-700', highlightBg: 'bg-leaf-100 text-leaf-700' },
+  { id: 'payment' as const, title: '결제수단 현황', description: '카드 실적, 현금, 이체까지 한번에 모아서 봐요', highlight: '카드 실적', iconBg: 'bg-orange-50', iconColor: 'text-orange-700', highlightBg: 'bg-orange-50 text-orange-700' },
+  { id: 'search' as const, title: '가계부 검색', description: '지난주 병원비 얼마였지? 금액, 카테고리, 기간으로 바로 찾아요', highlight: '바로 찾아요', iconBg: 'bg-yellow-50', iconColor: 'text-yellow-700', highlightBg: 'bg-yellow-50 text-yellow-700' },
+  { id: 'category' as const, title: '맞춤 카테고리', description: '나만의 분류로 자유롭게 정리해요', highlight: '자유롭게', iconBg: 'bg-green-50', iconColor: 'text-green-700', highlightBg: 'bg-green-50 text-green-700' },
+]
+
+// --- 소셜 프루프 ---
+export const socialStats = [
+  { value: 5, suffix: '초', label: '만에 입력', description: '길게 적을 필요 없이, 한 줄이면 돼요' },
+  { value: 100, suffix: '%', label: '자동 카테고리', description: '식비, 교통, 쇼핑 AI가 알아서 분류' },
+  { value: 0, suffix: '원', label: '완전 무료', description: '모든 기능 무료, 숨은 결제 없어요' },
+]
+
+export const socialScenarios = [
+  { persona: '맞벌이 부부', problem: '둘 다 쓰는데 월말에 뭐에 썼는지 모르겠어', solution: '공유 가계부로 실시간 확인' },
+  { persona: '살림 초보', problem: '가계부 앱 깔아봤는데 입력 귀찮아서 삭제함', solution: '메신저로 한 줄이면 끝' },
+  { persona: '알뜰 살림러', problem: '구독료가 매달 얼마 빠지는지 파악이 안 돼', solution: '정기결제 알림 + 예산 관리' },
+]

--- a/frontend/src/data/landingData.ts
+++ b/frontend/src/data/landingData.ts
@@ -1,4 +1,5 @@
 // --- 스크린샷 ---
+// hero, input.messenger는 현재 인라인 목업으로 대체 중. 추후 스크린샷 교체 시 사용.
 export const landingScreenshots = {
   hero: {
     path: '/screenshots/hero-chat.jpg',

--- a/frontend/src/pages/GuidePage.tsx
+++ b/frontend/src/pages/GuidePage.tsx
@@ -160,7 +160,16 @@ export default function GuidePage() {
             <strong>주기:</strong> 매일 / 매주 / 매월 / 매년 선택 가능
           </p>
           <p>
-            <strong>관리:</strong> 실행 예정인 거래를 가계부 상단에서 확인하고 건너뛰기 가능
+            <strong>금액 수정:</strong> 정기거래 등록 시 기본 금액을 수정하여 등록할 수 있습니다
+          </p>
+          <p>
+            <strong>달력 표시:</strong> 정기거래 예정일은 달력에 빈 원(○)으로 미리 표시되어 예정을 한눈에 파악할 수 있어요
+          </p>
+          <p>
+            <strong>달력 조회:</strong> 달력의 예정일을 탭하면 예정된 정기거래 내역을 확인할 수 있습니다
+          </p>
+          <p>
+            <strong>카드 관리:</strong> 가계부 상단의 정기거래 카드에서 실행/건너뛰기 또는 "나중에" 버튼으로 세션 동안 숨길 수 있어요
           </p>
         </ExampleBox>
       </SectionCard>


### PR DESCRIPTION
## Summary
- 랜딩페이지 콘텐츠를 최신 앱 기능과 싱크, 자산 트래킹 제거 + 가계부 핵심 기능 집중
- 스크린샷/기능카드/시나리오 데이터를 `landingData.ts`로 중앙 관리 (교체 용이성 확보)
- 기술 용어 → 생활 언어로 전환 (30대+ 일반 사용자 타겟)
- 가짜 후기 → "이런 분께 딱" 시나리오 카드로 전환

## Changes
- **Hero**: "말하듯 기록하면, AI가 알아서 정리해요" 카피 + 파스타 예시
- **쉽고 빠른 입력**: 메신저 + 앱 입력 2가지 방식 나란히, 카톡/텔레그램 로고 제거
- **공유 가계부**: 거래 예시 생활감 있게 (파스타/학원비/장보기)
- **한눈에 보기**: 폰 캐러셀 → 카드 이미지 4개 격자 (예산/카테고리/정기결제/AI)
- **편의 기능**: 자산 트래킹 → 가계부 검색 교체
- **소셜 프루프**: 별점 후기 → 문제→해결 시나리오 (맞벌이/살림초보/알뜰살림러)
- **CTA**: "오늘부터 편하게 기록해볼까요?" 행동 유도 카피
- **인프라**: `ScreenshotImage` 공유 컴포넌트 (grape 그라디언트 fallback)

## Test plan
- [ ] `npm run lint` — 0 errors
- [ ] `npm run build` — 빌드 성공
- [ ] 개발 서버에서 전체 7개 섹션 스크롤 확인
- [ ] 모바일 뷰포트에서 반응형 레이아웃 확인
- [ ] 다크모드 확인
- [ ] ScreenshotImage fallback 플레이스홀더 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)