### PR TITLE
fix: 상세 페이지 UX 개선 — 빠른 수정 버그 + 편집 폼 + 결제수단 칩

### DIFF
--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -25,9 +25,11 @@ if (typeof window.matchMedia === 'undefined') {
   })
 }
 
-// CI 환경(Node.js)에서 ProgressEvent가 없는 경우 polyfill (MSW + jsdom 호환)
-if (typeof globalThis.ProgressEvent === 'undefined') {
-  globalThis.ProgressEvent = class ProgressEvent extends Event {
+// CI 환경(Node.js 22+)에서 ProgressEvent polyfill
+// Node.js 22+는 globalThis.ProgressEvent를 정의하지만 JSDOM window에는 없을 수 있음.
+// 항상 window에 할당하여 환경 차이를 방지한다.
+{
+  const ProgressEventImpl = class ProgressEvent extends Event {
     readonly lengthComputable: boolean
     readonly loaded: number
     readonly total: number
@@ -38,6 +40,13 @@ if (typeof globalThis.ProgressEvent === 'undefined') {
       this.total = init?.total ?? 0
     }
   } as typeof globalThis.ProgressEvent
+
+  if (typeof globalThis.ProgressEvent === 'undefined') {
+    globalThis.ProgressEvent = ProgressEventImpl
+  }
+  if (typeof window !== 'undefined' && typeof window.ProgressEvent === 'undefined') {
+    window.ProgressEvent = ProgressEventImpl
+  }
 }
 
 // MSW 서버 설정

--- a/frontend/src/components/TransactionDetail.tsx
+++ b/frontend/src/components/TransactionDetail.tsx
@@ -454,7 +454,7 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
                   data-testid="chip-category"
                   onClick={() => handleChipTap('category')}
                   className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm min-h-[44px] bg-[var(--surface-elevated)] text-[var(--text-secondary)] transition-colors duration-400 ${
-                    quickEditField !== null ? 'opacity-50 pointer-events-none' : ''
+                    quickEditField !== null || isSaving ? 'opacity-50 pointer-events-none' : ''
                   } ${flashField === 'category' ? (cfg.color === 'grape' ? 'bg-grape-200' : 'bg-leaf-200') : ''}`}
                 >
                   {categoryEmoji && <span>{categoryEmoji}</span>}
@@ -491,7 +491,7 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
                     data-testid="chip-payment_method"
                     onClick={() => handleChipTap('payment_method')}
                     className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm min-h-[44px] bg-[var(--surface-elevated)] text-[var(--text-secondary)] transition-colors duration-400 ${
-                      quickEditField !== null ? 'opacity-50 pointer-events-none' : ''
+                      quickEditField !== null || isSaving ? 'opacity-50 pointer-events-none' : ''
                     } ${flashField === 'payment_method' ? 'bg-grape-200' : ''}`}
                   >
                     <span>{PM_ICON[paymentMethod.type] ?? '💳'}</span>

--- a/frontend/src/components/TransactionDetail.tsx
+++ b/frontend/src/components/TransactionDetail.tsx
@@ -646,14 +646,23 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
             {/* 금액 */}
             <div>
               <label htmlFor="edit-amount" className="block text-sm font-medium text-[var(--text-tertiary)] mb-2">금액</label>
-              <input
-                id="edit-amount"
-                type="number"
-                className="input-base"
-                value={editForm.amount || ''}
-                onChange={(e) => setEditForm((f) => ({ ...f, amount: Number(e.target.value) || 0 }))}
-                min={0}
-              />
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-secondary)] text-sm pointer-events-none">
+                  ₩
+                </span>
+                <input
+                  id="edit-amount"
+                  type="text"
+                  inputMode="numeric"
+                  className="input-base pl-7"
+                  value={editForm.amount === 0 ? '' : editForm.amount.toLocaleString('ko-KR')}
+                  onChange={(e) => {
+                    const raw = e.target.value.replace(/[^0-9]/g, '')
+                    setEditForm((f) => ({ ...f, amount: raw === '' ? 0 : Number(raw) }))
+                  }}
+                  placeholder="0"
+                />
+              </div>
             </div>
 
             {/* 설명 */}
@@ -662,6 +671,7 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
               <input
                 id="edit-description"
                 type="text"
+                inputMode="text"
                 className="input-base"
                 value={editForm.description}
                 onChange={(e) => setEditForm((f) => ({ ...f, description: e.target.value }))}
@@ -720,6 +730,7 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
               <input
                 id="edit-memo"
                 type="text"
+                inputMode="text"
                 className="input-base"
                 value={editForm.memo}
                 onChange={(e) => setEditForm((f) => ({ ...f, memo: e.target.value }))}

--- a/frontend/src/components/TransactionDetail.tsx
+++ b/frontend/src/components/TransactionDetail.tsx
@@ -441,10 +441,11 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
                     const val = e.target.value === '' ? null : Number(e.target.value)
                     handleQuickSave('category_id', val)
                   }}
+                  onBlur={() => setQuickEditField(null)}
                 >
                   <option value="">분류 안 됨</option>
                   {categories.map((c) => (
-                    <option key={c.id} value={c.id}>{c.name}</option>
+                    <option key={c.id} value={c.id}>{c.emoji ? `${c.emoji} ${c.name}` : c.name}</option>
                   ))}
                 </select>
               ) : (
@@ -477,10 +478,11 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
                       const val = e.target.value === '' ? null : Number(e.target.value)
                       handleQuickSave('payment_method_id', val)
                     }}
+                    onBlur={() => setQuickEditField(null)}
                   >
                     <option value="">미지정</option>
                     {paymentMethods.map((pm) => (
-                      <option key={pm.id} value={pm.id}>{pm.name}</option>
+                      <option key={pm.id} value={pm.id}>{PM_ICON[pm.type] ? `${PM_ICON[pm.type]} ${pm.name}` : pm.name}</option>
                     ))}
                   </select>
                 ) : (

--- a/frontend/src/components/TransactionDetail.tsx
+++ b/frontend/src/components/TransactionDetail.tsx
@@ -320,14 +320,14 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
     }
   }, [transaction, type, navigate, cfg.listRoute, addToast, isSaving])
 
-  /** 목록으로 이동 — 변경사항이 있으면 다이얼로그 표시 */
-  const handleNavigateAway = useCallback(() => {
+  /** 편집 취소 — 변경사항이 있으면 다이얼로그, 없으면 뷰 모드로 복귀 */
+  const handleCancelEdit = useCallback(() => {
     if (isDirty()) {
       setShowDirtyDialog(true)
     } else {
-      navigate(cfg.listRoute)
+      setMode('view')
     }
-  }, [isDirty, navigate, cfg.listRoute])
+  }, [isDirty])
 
   // ── 로딩 스켈레톤 ──
 
@@ -394,7 +394,7 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
           <button
             type="button"
             aria-label="뒤로가기"
-            onClick={handleNavigateAway}
+            onClick={handleCancelEdit}
             className="p-2 -ml-2 rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
           >
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
@@ -753,10 +753,10 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
           <div className="flex gap-3 sticky bottom-4">
             <button
               type="button"
-              onClick={handleNavigateAway}
+              onClick={handleCancelEdit}
               className="flex-1 py-3 text-sm font-semibold text-center text-[var(--text-secondary)] bg-[var(--surface-card)] border border-[var(--border-default)] rounded-xl transition-colors hover:bg-[var(--surface-hover)]"
             >
-              목록으로
+              취소
             </button>
             <button
               onClick={handleSave}
@@ -792,7 +792,7 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
                     머무르기
                   </button>
                   <button
-                    onClick={() => navigate(cfg.listRoute)}
+                    onClick={() => { setShowDirtyDialog(false); setMode('view') }}
                     className="px-4 py-2 text-sm font-medium text-white bg-rose-600 rounded-xl hover:bg-rose-700 transition-colors"
                   >
                     이동하기

--- a/frontend/src/components/TransactionDetail.tsx
+++ b/frontend/src/components/TransactionDetail.tsx
@@ -463,8 +463,8 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
                 </button>
               )}
 
-              {/* 결제수단 칩 / 드롭다운 (지출 타입이고 결제수단이 있을 때만) */}
-              {cfg.hasPaymentMethod && paymentMethod && (
+              {/* 결제수단 칩 / 드롭다운 (지출 타입이면 항상 표시 — 미지정 포함) */}
+              {cfg.hasPaymentMethod && (
                 quickEditField === 'payment_method' ? (
                   <select
                     data-testid="quick-select-payment_method"
@@ -490,12 +490,22 @@ export default function TransactionDetail({ type }: TransactionDetailProps) {
                     type="button"
                     data-testid="chip-payment_method"
                     onClick={() => handleChipTap('payment_method')}
-                    className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm min-h-[44px] bg-[var(--surface-elevated)] text-[var(--text-secondary)] transition-colors duration-400 ${
+                    className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm min-h-[44px] ${
+                      paymentMethod
+                        ? 'bg-[var(--surface-elevated)] text-[var(--text-secondary)]'
+                        : 'bg-[var(--surface-elevated)] text-[var(--text-muted)] border border-dashed border-[var(--border-default)]'
+                    } transition-colors duration-400 ${
                       quickEditField !== null || isSaving ? 'opacity-50 pointer-events-none' : ''
                     } ${flashField === 'payment_method' ? 'bg-grape-200' : ''}`}
                   >
-                    <span>{PM_ICON[paymentMethod.type] ?? '💳'}</span>
-                    {paymentMethod.name}
+                    {paymentMethod ? (
+                      <>
+                        <span>{PM_ICON[paymentMethod.type] ?? '💳'}</span>
+                        {paymentMethod.name}
+                      </>
+                    ) : (
+                      '미지정'
+                    )}
                     <span className="text-[var(--text-muted)] text-xs ml-0.5">▾</span>
                   </button>
                 )

--- a/frontend/src/components/__tests__/TransactionDetail.test.tsx
+++ b/frontend/src/components/__tests__/TransactionDetail.test.tsx
@@ -732,6 +732,50 @@ describe('TransactionDetail — 편집 모드', () => {
     expect(screen.queryByText('+ 정기거래 등록')).not.toBeInTheDocument()
   })
 
+  it('금액 입력 필드는 inputMode=numeric이고 ₩ prefix가 표시된다', async () => {
+    renderWithRouter('expense', 1)
+
+    await waitFor(() => {
+      expect(screen.getByText('₩8,000')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: '수정' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('금액')).toBeInTheDocument()
+    })
+
+    const amountInput = screen.getByLabelText('금액') as HTMLInputElement
+    expect(amountInput.getAttribute('inputmode')).toBe('numeric')
+    // 금액 8000이 쉼표 포맷으로 표시되어야 함
+    expect(amountInput.value).toBe('8,000')
+  })
+
+  it('금액 입력 시 숫자만 저장하고 쉼표 포맷으로 표시한다', async () => {
+    renderWithRouter('expense', 1)
+
+    await waitFor(() => {
+      expect(screen.getByText('₩8,000')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: '수정' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('금액')).toBeInTheDocument()
+    })
+
+    const amountInput = screen.getByLabelText('금액')
+    await userEvent.clear(amountInput)
+    await userEvent.type(amountInput, '12000')
+
+    // 저장 후 서버 응답에서 12000이 반영되어야 함
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '수정' })).toBeInTheDocument()
+    })
+  })
+
   it('편집 모드 재진입 시 editForm이 최신 transaction으로 초기화된다', async () => {
     renderWithRouter('expense', 1)
 

--- a/frontend/src/components/__tests__/TransactionDetail.test.tsx
+++ b/frontend/src/components/__tests__/TransactionDetail.test.tsx
@@ -123,7 +123,7 @@ describe('TransactionDetail — 뷰 모드', () => {
     })
   })
 
-  it('빈 필드를 숨긴다 (메모 없음, 결제수단 없음)', async () => {
+  it('결제수단 미지정 시 미지정 칩이 표시된다 (메모 없음)', async () => {
     // mockExpenses[0] has memo=null, payment_method_id=null
     renderWithRouter('expense', 1)
 
@@ -134,9 +134,35 @@ describe('TransactionDetail — 뷰 모드', () => {
     // 메모 섹션이 없어야 함
     expect(screen.queryByText('메모')).not.toBeInTheDocument()
 
-    // 결제수단 칩이 없어야 함 (payment_method_id=null)
+    // 결제수단 미지정 칩이 표시되어야 함
+    await waitFor(() => {
+      expect(screen.getByTestId('chip-payment_method')).toBeInTheDocument()
+      expect(screen.getByTestId('chip-payment_method').textContent).toContain('미지정')
+    })
+
+    // 아이콘 칩은 없어야 함 (payment_method_id=null)
     const allChips = screen.queryAllByText(/💳|💵|🏦/)
     expect(allChips).toHaveLength(0)
+  })
+
+  it('결제수단 미지정 칩 클릭 시 드롭다운이 열린다', async () => {
+    // mockExpenses[0] has payment_method_id=null
+    renderWithRouter('expense', 1)
+
+    await waitFor(() => {
+      expect(screen.getByText('₩8,000')).toBeInTheDocument()
+    })
+
+    // 미지정 칩이 표시될 때까지 대기
+    await waitFor(() => {
+      expect(screen.getByTestId('chip-payment_method')).toBeInTheDocument()
+    })
+
+    // 미지정 칩 클릭
+    await userEvent.click(screen.getByTestId('chip-payment_method'))
+
+    // 드롭다운이 열려야 함
+    expect(screen.getByTestId('quick-select-payment_method')).toBeInTheDocument()
   })
 
   it('수입 타입은 결제수단 칩을 렌더링하지 않는다', async () => {

--- a/frontend/src/components/__tests__/TransactionDetail.test.tsx
+++ b/frontend/src/components/__tests__/TransactionDetail.test.tsx
@@ -749,6 +749,9 @@ describe('TransactionDetail — 편집 모드', () => {
     expect(amountInput.getAttribute('inputmode')).toBe('numeric')
     // 금액 8000이 쉼표 포맷으로 표시되어야 함
     expect(amountInput.value).toBe('8,000')
+
+    // ₩ prefix span이 DOM에 존재해야 함
+    expect(screen.getByText('₩')).toBeInTheDocument()
   })
 
   it('금액 입력 시 숫자만 저장하고 쉼표 포맷으로 표시한다', async () => {
@@ -767,6 +770,11 @@ describe('TransactionDetail — 편집 모드', () => {
     const amountInput = screen.getByLabelText('금액')
     await userEvent.clear(amountInput)
     await userEvent.type(amountInput, '12000')
+
+    // 쉼표 포맷으로 표시되는지 확인
+    await waitFor(() => {
+      expect((amountInput as HTMLInputElement).value).toBe('12,000')
+    })
 
     // 저장 후 서버 응답에서 12000이 반영되어야 함
     await userEvent.click(screen.getByRole('button', { name: '저장' }))

--- a/frontend/src/components/__tests__/TransactionDetail.test.tsx
+++ b/frontend/src/components/__tests__/TransactionDetail.test.tsx
@@ -556,7 +556,9 @@ describe('TransactionDetail — 빠른 수정', () => {
 
     // 카테고리 칩 클릭 → select 열림
     await userEvent.click(screen.getByTestId('chip-category'))
-    expect(screen.getByTestId('quick-select-category')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('quick-select-category')).toBeInTheDocument()
+    })
 
     // select에서 blur (선택 없이)
     await userEvent.tab()

--- a/frontend/src/components/__tests__/TransactionDetail.test.tsx
+++ b/frontend/src/components/__tests__/TransactionDetail.test.tsx
@@ -546,6 +546,42 @@ describe('TransactionDetail — 빠른 수정', () => {
       expect(liveRegion.textContent).toContain('교통')
     })
   })
+
+  it('카테고리 select에서 선택 없이 blur 시 select가 닫히고 칩이 복귀한다', async () => {
+    renderWithRouter('expense', 1)
+
+    await waitFor(() => {
+      expect(screen.getByText('₩8,000')).toBeInTheDocument()
+    })
+
+    // 카테고리 칩 클릭 → select 열림
+    await userEvent.click(screen.getByTestId('chip-category'))
+    expect(screen.getByTestId('quick-select-category')).toBeInTheDocument()
+
+    // select에서 blur (선택 없이)
+    await userEvent.tab()
+
+    // select가 닫히고 칩이 복귀해야 함
+    await waitFor(() => {
+      expect(screen.queryByTestId('quick-select-category')).not.toBeInTheDocument()
+      expect(screen.getByTestId('chip-category')).toBeInTheDocument()
+    })
+  })
+
+  it('카테고리 quick-select options에 이모지가 포함된다', async () => {
+    renderWithRouter('expense', 1)
+
+    await waitFor(() => {
+      expect(screen.getByText('₩8,000')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByTestId('chip-category'))
+
+    const select = screen.getByTestId('quick-select-category') as HTMLSelectElement
+    const optionTexts = Array.from(select.options).map((o) => o.textContent ?? '')
+    // 식비 옵션에 이모지가 있어야 함
+    expect(optionTexts.some((t) => t.includes('📌') && t.includes('식비'))).toBe(true)
+  })
 })
 
 describe('TransactionDetail — 편집 모드', () => {

--- a/frontend/src/components/__tests__/TransactionDetail.test.tsx
+++ b/frontend/src/components/__tests__/TransactionDetail.test.tsx
@@ -834,7 +834,7 @@ describe('TransactionDetail — 정기거래 등록', () => {
 })
 
 describe('TransactionDetail — dirty form guard', () => {
-  it('변경 없이 "목록으로" 탭 시 바로 navigate한다', async () => {
+  it('변경 없이 "취소" 탭 시 뷰 모드로 복귀한다', async () => {
     renderWithRouter('expense', 1)
 
     await waitFor(() => {
@@ -848,15 +848,17 @@ describe('TransactionDetail — dirty form guard', () => {
       expect(screen.getByLabelText('금액')).toBeInTheDocument()
     })
 
-    // 변경 없이 목록으로 클릭
-    await userEvent.click(screen.getByRole('button', { name: '목록으로' }))
+    // 변경 없이 취소 클릭
+    await userEvent.click(screen.getByRole('button', { name: '취소' }))
 
-    // 다이얼로그 없이 바로 navigate
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-    expect(mockNavigate).toHaveBeenCalledWith('/expenses')
+    // navigate 호출 없이 뷰 모드로 복귀
+    expect(mockNavigate).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '수정' })).toBeInTheDocument()
+    })
   })
 
-  it('변경 후 "목록으로" 탭 시 확인 다이얼로그를 표시한다', async () => {
+  it('변경 후 "취소" 탭 시 확인 다이얼로그를 표시한다', async () => {
     renderWithRouter('expense', 1)
 
     await waitFor(() => {
@@ -875,8 +877,8 @@ describe('TransactionDetail — dirty form guard', () => {
     await userEvent.clear(amountInput)
     await userEvent.type(amountInput, '12000')
 
-    // 목록으로 클릭
-    await userEvent.click(screen.getByRole('button', { name: '목록으로' }))
+    // 취소 클릭
+    await userEvent.click(screen.getByRole('button', { name: '취소' }))
 
     // 확인 다이얼로그 표시
     expect(screen.getByRole('dialog')).toBeInTheDocument()
@@ -904,8 +906,8 @@ describe('TransactionDetail — dirty form guard', () => {
     await userEvent.clear(descInput)
     await userEvent.type(descInput, '새로운 설명')
 
-    // 목록으로 → 다이얼로그 열림
-    await userEvent.click(screen.getByRole('button', { name: '목록으로' }))
+    // 취소 → 다이얼로그 열림
+    await userEvent.click(screen.getByRole('button', { name: '취소' }))
     expect(screen.getByRole('dialog')).toBeInTheDocument()
 
     // 머무르기 클릭
@@ -917,7 +919,7 @@ describe('TransactionDetail — dirty form guard', () => {
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
-  it('다이얼로그에서 "이동하기" 클릭 시 목록으로 navigate한다', async () => {
+  it('다이얼로그에서 "이동하기" 클릭 시 뷰 모드로 복귀한다', async () => {
     renderWithRouter('expense', 1)
 
     await waitFor(() => {
@@ -936,15 +938,19 @@ describe('TransactionDetail — dirty form guard', () => {
     await userEvent.clear(descInput)
     await userEvent.type(descInput, '변경된 설명')
 
-    // 목록으로 → 다이얼로그 열림
-    await userEvent.click(screen.getByRole('button', { name: '목록으로' }))
+    // 취소 → 다이얼로그 열림
+    await userEvent.click(screen.getByRole('button', { name: '취소' }))
     expect(screen.getByRole('dialog')).toBeInTheDocument()
 
-    // 이동하기 클릭
+    // 이동하기 클릭 → 뷰 모드로 복귀 (navigate 호출 없음)
     await userEvent.click(screen.getByRole('button', { name: '이동하기' }))
 
-    // navigate 호출
-    expect(mockNavigate).toHaveBeenCalledWith('/expenses')
+    // navigate가 호출되지 않아야 함
+    expect(mockNavigate).not.toHaveBeenCalled()
+    // 뷰 모드의 수정 버튼이 다시 표시되어야 함
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '수정' })).toBeInTheDocument()
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

- **버그 수정**: 빠른 수정 select를 선택 없이 닫으면 칩이 사라지는 버그 수정 (`onBlur` 핸들러 추가)
- **이모지**: 카테고리/결제수단 select `<option>`에 이모지 추가
- **결제수단 미지정**: `payment_method_id=null`일 때 칩이 사라지던 문제 → "미지정" 칩 항상 표시
- **편집 취소 UX**: 편집 취소 시 목록이 아닌 뷰 모드로 복귀 ("목록으로" → "취소")
- **금액 포맷**: 편집 폼 금액에 `₩` prefix + 쉼표 포맷(8,000), `inputMode="numeric"` 적용

## Changes

- `frontend/src/components/TransactionDetail.tsx`
- `frontend/src/components/__tests__/TransactionDetail.test.tsx` (+5 tests, 1471 total)

## Test plan

- [ ] 빠른 수정 칩 클릭 → 선택 없이 바깥 탭 → 칩으로 정상 복귀 확인
- [ ] 카테고리/결제수단 select 옵션에 이모지 표시 확인
- [ ] 결제수단 없는 지출에서 "미지정" 칩 표시 + 탭으로 드롭다운 열림 확인
- [ ] 편집 모드 진입 → "취소" 클릭 → 상세 뷰모드로 복귀 확인 (목록 이동 없음)
- [ ] 금액 편집 시 쉼표 포맷 표시, 모바일 숫자 키보드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)