### PR TITLE
fix: 히어로 프로그레스바 애니메이션 + 랜딩페이지 중복 제거

### DIFF
--- a/frontend/src/components/landing/MessengerSection.tsx
+++ b/frontend/src/components/landing/MessengerSection.tsx
@@ -27,24 +27,6 @@ export function MessengerSection() {
           <p className="mt-4 max-w-lg text-base leading-relaxed text-warm-500 md:mt-6 md:text-lg">
             사용하던 메신저로 보내도 되고, 앱에서 바로 입력해도 돼요. 카테고리, 날짜, 결제수단은 AI가 알아서 분류해줘요.
           </p>
-
-          {/* Input Method Icons */}
-          <div className="mt-8 flex items-center gap-3">
-            {/* 메신저 아이콘 */}
-            <div className="flex items-center gap-2 rounded-full bg-warm-100 px-4 py-2">
-              <svg viewBox="0 0 24 24" className="h-5 w-5 text-warm-700" fill="none" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-              </svg>
-              <span className="text-sm font-medium text-warm-700">메신저</span>
-            </div>
-            {/* 앱 아이콘 */}
-            <div className="flex items-center gap-2 rounded-full bg-warm-100 px-4 py-2">
-              <svg viewBox="0 0 24 24" className="h-5 w-5 text-warm-700" fill="none" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
-              </svg>
-              <span className="text-sm font-medium text-warm-700">앱에서 바로</span>
-            </div>
-          </div>
         </div>
 
         {/* Visual Area — 두 가지 입력 방식 나란히 */}

--- a/frontend/src/components/stats/HeroSummary.tsx
+++ b/frontend/src/components/stats/HeroSummary.tsx
@@ -145,8 +145,9 @@ function ProgressBar({
   // 애니메이션용 상태
   const [animActual, setAnimActual] = useState(0)
   const [animProjected, setAnimProjected] = useState(0)
-  // 예정 바를 항상 렌더링하되 width 0으로 시작하기 위한 플래그
-  const [showProjected, setShowProjected] = useState(false)
+
+  // 예정 바 렌더링 여부 — state에서 파생 (effect 안에서 setState 불필요)
+  const hasProjected = state.type === 'normal' || state.type === 'projectedExceed'
 
   useEffect(() => {
     if (isLoading) return
@@ -179,9 +180,6 @@ function ProgressBar({
         break
       }
     }
-
-    // 예정 바가 있으면 미리 width 0으로 렌더링
-    setShowProjected(projectedWidth > 0)
 
     // 지출 바 먼저 차오른 뒤 예정 바가 이어서 차오르도록 딜레이 분리
     requestAnimationFrame(() => {
@@ -223,7 +221,7 @@ function ProgressBar({
           style={{ width: `${(animActual / totalBarMax) * 100}%` }}
         />
         {/* 예정 지출 구간 — 처음부터 렌더링(width 0)하여 transition으로 자연스럽게 이어짐 */}
-        {showProjected && (
+        {hasProjected && (
           <div
             className={`absolute top-0 h-full rounded-r-full ${
               state.type === 'projectedExceed' ? 'bg-warm-300 dark:bg-warm-400' : 'bg-grape-200 dark:bg-grape-300'

--- a/frontend/src/components/stats/HeroSummary.tsx
+++ b/frontend/src/components/stats/HeroSummary.tsx
@@ -145,6 +145,8 @@ function ProgressBar({
   // 애니메이션용 상태
   const [animActual, setAnimActual] = useState(0)
   const [animProjected, setAnimProjected] = useState(0)
+  // 예정 바를 항상 렌더링하되 width 0으로 시작하기 위한 플래그
+  const [showProjected, setShowProjected] = useState(false)
 
   useEffect(() => {
     if (isLoading) return
@@ -177,6 +179,9 @@ function ProgressBar({
         break
       }
     }
+
+    // 예정 바가 있으면 미리 width 0으로 렌더링
+    setShowProjected(projectedWidth > 0)
 
     // 지출 바 먼저 차오른 뒤 예정 바가 이어서 차오르도록 딜레이 분리
     requestAnimationFrame(() => {
@@ -217,8 +222,8 @@ function ProgressBar({
           className={`absolute top-0 left-0 h-full rounded-l-full ${animProjected === 0 ? 'rounded-r-full' : ''} ${getActualColor()} transition-all duration-700 ease-out`}
           style={{ width: `${(animActual / totalBarMax) * 100}%` }}
         />
-        {/* 예정 지출 구간 */}
-        {animProjected > 0 && (
+        {/* 예정 지출 구간 — 처음부터 렌더링(width 0)하여 transition으로 자연스럽게 이어짐 */}
+        {showProjected && (
           <div
             className={`absolute top-0 h-full rounded-r-full ${
               state.type === 'projectedExceed' ? 'bg-warm-300 dark:bg-warm-400' : 'bg-grape-200 dark:bg-grape-300'


### PR DESCRIPTION
## Summary
- 히어로 카드 프로그레스바에서 예정 지출 바가 갑자기 나타나던 문제 수정 — 지출 바 애니메이션 후 자연스럽게 이어서 차오름
- 랜딩페이지 MessengerSection에서 텍스트 영역의 입력방식 아이콘 칩 제거 (카드 캡션과 중복)

## Test plan
- [ ] 예산 설정 + 정기지출 예정이 있는 상태에서 홈 진입 → 프로그레스바가 지출→예정 순서로 부드럽게 애니메이션되는지 확인
- [ ] 랜딩페이지(`/`) 메신저 섹션에서 중복 칩이 사라지고 깔끔하게 보이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)