### PR TITLE
style: 더보기 페이지 UI 정비 — 섹션 그루핑, 헤더 통일, CategoryManager 카드 전환

### DIFF
--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -226,7 +226,17 @@ export default function BudgetManager() {
   }
 
   if (error) {
-    return <ErrorState message={error} onRetry={loadData} />
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+            <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
+          </button>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">예산 관리</h1>
+        </div>
+        <ErrorState message={error} onRetry={loadData} />
+      </div>
+    )
   }
 
   const totalNum = Number(localTotalBudget)
@@ -235,9 +245,12 @@ export default function BudgetManager() {
 
   return (
     <div className="space-y-6 animate-page-in">
-      <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
-        <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
-      </button>
+      <div className="flex items-center gap-3">
+        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+          <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
+        </button>
+        <h1 className="text-lg font-semibold text-[var(--text-primary)]">예산 관리</h1>
+      </div>
 
       {/* 월 총 예산 카드 */}
       <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-5">

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -31,6 +31,48 @@ function CategoryManagerSkeleton() {
   )
 }
 
+/** 위/아래 이동 버튼 */
+function MoveButtons({
+  name,
+  index,
+  total,
+  reordering,
+  isSystem,
+  onMove,
+}: {
+  name: string
+  index: number
+  total: number
+  reordering: boolean
+  isSystem: boolean
+  onMove: (direction: 'up' | 'down') => void
+}) {
+  return (
+    <div className="flex flex-col gap-0.5 flex-shrink-0">
+      <button
+        onClick={() => onMove('up')}
+        disabled={index === 0 || reordering || isSystem}
+        className="p-0.5 text-[var(--text-muted)] hover:text-grape-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        aria-label={`${name} 위로 이동`}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clipRule="evenodd" />
+        </svg>
+      </button>
+      <button
+        onClick={() => onMove('down')}
+        disabled={index === total - 1 || reordering || isSystem}
+        className="p-0.5 text-[var(--text-muted)] hover:text-grape-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        aria-label={`${name} 아래로 이동`}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
+        </svg>
+      </button>
+    </div>
+  )
+}
+
 export default function CategoryManager() {
   const goBack = useGoBack('/settings')
   const { addToast } = useToast()
@@ -184,7 +226,17 @@ export default function CategoryManager() {
   }
 
   if (loading) {
-    return <CategoryManagerSkeleton />
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+            <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
+          </button>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">카테고리 관리</h1>
+        </div>
+        <CategoryManagerSkeleton />
+      </div>
+    )
   }
 
   /* 에러 발생 시 */
@@ -246,285 +298,201 @@ export default function CategoryManager() {
         </button>
       </div>
 
-      {/* 카테고리 목록 */}
-      <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-[var(--border-default)] bg-[var(--surface-elevated)]">
-                <th className="px-2 sm:px-3 py-3 text-center text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider w-16">
-                  순서
-                </th>
-                <th className="px-2 sm:px-3 py-3 text-center text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider w-16">
-                  아이콘
-                </th>
-                <th className="px-4 sm:px-6 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
-                  이름
-                </th>
-                <th className="px-4 sm:px-6 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider hidden md:table-cell">
-                  설명
-                </th>
-                <th className="px-4 sm:px-6 py-3 text-left text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider hidden sm:table-cell">
-                  만든 날
-                </th>
-                <th className="px-4 sm:px-6 py-3 text-right text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
-                  작업
-                </th>
-              </tr>
-            </thead>
-          <tbody className="divide-y divide-[var(--border-subtle)]">
-            {/* 추가 폼 (isAdding일 때) */}
-            {isAdding && (
-              <tr className="bg-grape-50">
-                <td className="px-2 sm:px-3 py-4"></td>
-                <td className="px-2 sm:px-3 py-4 text-center">
+      {/* 추가 폼 */}
+      {isAdding && (
+        <div className="bg-grape-50 rounded-2xl border border-grape-200 p-4 space-y-3">
+          <div className="flex items-start gap-3">
+            <input
+              type="text"
+              value={newEmoji}
+              onChange={(e) => {
+                const val = e.target.value
+                if (val.length <= 2) setNewEmoji(val || '📌')
+              }}
+              className="input-base w-14 text-center text-xl p-2 flex-shrink-0"
+              maxLength={2}
+            />
+            <div className="flex-1 min-w-0 space-y-2">
+              <input
+                type="text"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="카테고리 이름"
+                className="input-base w-full"
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
+              />
+              <input
+                type="text"
+                value={newDescription}
+                onChange={(e) => setNewDescription(e.target.value)}
+                placeholder="설명 (선택)"
+                className="input-base w-full"
+              />
+              {activeTab === 'expense' && (
+                <label className="flex items-center gap-1.5 text-xs text-[var(--text-secondary)] cursor-pointer">
                   <input
-                    type="text"
-                    value={newEmoji}
-                    onChange={(e) => {
-                      const val = e.target.value
-                      if (val.length <= 2) setNewEmoji(val || '📌')
-                    }}
-                    className="input-base w-14 text-center text-xl p-2"
-                    maxLength={2}
+                    type="checkbox"
+                    checked={newIsSavings}
+                    onChange={(e) => setNewIsSavings(e.target.checked)}
+                    className="rounded border-[var(--input-border)] text-grape-600 focus:ring-grape-500"
                   />
-                </td>
-                <td className="px-4 sm:px-6 py-4">
-                  <input
-                    type="text"
-                    value={newName}
-                    onChange={(e) => setNewName(e.target.value)}
-                    placeholder="카테고리 이름"
-                    className="input-base w-full"
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
-                    autoFocus
-                  />
-                  {activeTab === 'expense' && (
-                    <label className="flex items-center gap-1.5 mt-2 text-xs text-[var(--text-secondary)] cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={newIsSavings}
-                        onChange={(e) => setNewIsSavings(e.target.checked)}
-                        className="rounded border-[var(--input-border)] text-grape-600 focus:ring-grape-500"
-                      />
-                      저축성 지출
-                    </label>
-                  )}
-                </td>
-                <td className="px-4 sm:px-6 py-4 hidden md:table-cell">
-                  <input
-                    type="text"
-                    value={newDescription}
-                    onChange={(e) => setNewDescription(e.target.value)}
-                    placeholder="설명 (선택)"
-                    className="input-base w-full"
-                  />
-                </td>
-                <td className="px-4 sm:px-6 py-4 hidden sm:table-cell"></td>
-                <td className="px-4 sm:px-6 py-4 text-right">
-                  <div className="flex justify-end gap-2">
-                    <button
-                      onClick={handleAdd}
-                      className="px-3 py-1.5 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
-                    >
-                      저장
-                    </button>
-                    <button
-                      onClick={() => {
-                        setIsAdding(false)
-                        setNewName('')
-                        setNewDescription('')
-                        setNewIsSavings(false)
-                        setNewEmoji('📌')
-                      }}
-                      className="px-3 py-1.5 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
-                    >
-                      취소
-                    </button>
-                  </div>
-                </td>
-              </tr>
-            )}
+                  저축성 지출
+                </label>
+              )}
+            </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={() => {
+                setIsAdding(false)
+                setNewName('')
+                setNewDescription('')
+                setNewIsSavings(false)
+                setNewEmoji('📌')
+              }}
+              className="px-3 py-1.5 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
+            >
+              취소
+            </button>
+            <button
+              onClick={handleAdd}
+              className="px-3 py-1.5 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
+            >
+              저장
+            </button>
+          </div>
+        </div>
+      )}
 
-            {/* 카테고리 목록 */}
-            {categories.length > 0 ? (
-              categories.map((category, index) => {
-                const isEditing = editingId === category.id
-                return (
-                  <tr
-                    key={category.id}
-                    className={isEditing ? 'bg-grape-50' : 'hover:bg-[var(--surface-elevated)] transition-colors'}
-                  >
-                    <td className="px-2 sm:px-3 py-4">
-                      <div className="flex flex-col items-center gap-0.5">
-                        <button
-                          onClick={() => handleMove(index, 'up')}
-                          disabled={index === 0 || reordering || category.is_system}
-                          className="p-0.5 text-[var(--text-muted)] hover:text-grape-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                          aria-label={`${category.name} 위로 이동`}
-                        >
-                          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                            <path fillRule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clipRule="evenodd" />
-                          </svg>
-                        </button>
-                        <button
-                          onClick={() => handleMove(index, 'down')}
-                          disabled={index === categories.length - 1 || reordering || category.is_system}
-                          className="p-0.5 text-[var(--text-muted)] hover:text-grape-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                          aria-label={`${category.name} 아래로 이동`}
-                        >
-                          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                            <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
-                          </svg>
-                        </button>
-                      </div>
-                    </td>
-                    <td className="px-2 sm:px-3 py-4 text-center">
-                      {isEditing ? (
+      {/* 카테고리 목록 */}
+      {categories.length === 0 && !isAdding ? (
+        <EmptyState
+          variant="section"
+          title="아직 카테고리가 없습니다"
+          description="새 카테고리를 추가하여 지출을 체계적으로 관리해보세요."
+          action={{
+            label: '+ 카테고리 추가',
+            onClick: () => setIsAdding(true),
+          }}
+        />
+      ) : (
+        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 divide-y divide-[var(--border-subtle)]">
+          {categories.map((category, index) => {
+            const isEditing = editingId === category.id
+            return (
+              <div key={category.id} className={isEditing ? 'bg-grape-50' : undefined}>
+                {isEditing ? (
+                  /* 인라인 편집 폼 */
+                  <div className="px-4 py-4 space-y-3">
+                    <div className="flex items-start gap-3">
+                      <input
+                        type="text"
+                        value={editForm.emoji}
+                        onChange={(e) => {
+                          const val = e.target.value
+                          if (val.length <= 2) setEditForm({ ...editForm, emoji: val || '📌' })
+                        }}
+                        className="input-base w-14 text-center text-xl p-2 flex-shrink-0"
+                        maxLength={2}
+                      />
+                      <div className="flex-1 min-w-0 space-y-2">
                         <input
                           type="text"
-                          value={editForm.emoji}
-                          onChange={(e) => {
-                            const val = e.target.value
-                            if (val.length <= 2) setEditForm({ ...editForm, emoji: val || '📌' })
-                          }}
-                          className="input-base w-14 text-center text-xl p-2"
-                          maxLength={2}
+                          value={editForm.name}
+                          onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+                          className="input-base w-full"
+                          // eslint-disable-next-line jsx-a11y/no-autofocus
+                          autoFocus
                         />
-                      ) : (
-                        <span className="text-xl">{category.emoji}</span>
-                      )}
-                    </td>
-                    <td className="px-4 sm:px-6 py-4">
-                      {isEditing ? (
-                        <div>
-                          <input
-                            type="text"
-                            value={editForm.name}
-                            onChange={(e) =>
-                              setEditForm({ ...editForm, name: e.target.value })
-                            }
-                            className="input-base w-full"
-                            // eslint-disable-next-line jsx-a11y/no-autofocus
-                            autoFocus
-                          />
-                          {activeTab === 'expense' && (
-                            <label className="flex items-center gap-1.5 mt-2 text-xs text-[var(--text-secondary)] cursor-pointer">
-                              <input
-                                type="checkbox"
-                                checked={editForm.is_savings}
-                                onChange={(e) =>
-                                  setEditForm({ ...editForm, is_savings: e.target.checked })
-                                }
-                                className="rounded border-[var(--input-border)] text-grape-600 focus:ring-grape-500"
-                              />
-                              저축성 지출
-                            </label>
-                          )}
-                        </div>
-                      ) : (
-                        <div>
-                          <span className="font-medium text-[var(--text-primary)]">
-                            {category.name}
-                          </span>
-                          {category.is_savings && (
-                            <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium text-leaf-700 bg-leaf-100 rounded">
-                              저축
-                            </span>
-                          )}
-                          {/* 모바일에서만 설명 표시 */}
-                          <div className="md:hidden text-sm text-[var(--text-secondary)] mt-1">
-                            {category.description || '-'}
-                          </div>
-                        </div>
-                      )}
-                    </td>
-                    <td className="px-4 sm:px-6 py-4 hidden md:table-cell">
-                      {isEditing ? (
                         <input
                           type="text"
                           value={editForm.description}
-                          onChange={(e) =>
-                            setEditForm({
-                              ...editForm,
-                              description: e.target.value,
-                            })
-                          }
+                          onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
+                          placeholder="설명 (선택)"
                           className="input-base w-full"
                         />
-                      ) : (
-                        <span className="text-sm text-[var(--text-secondary)]">
-                          {category.description || '-'}
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-4 sm:px-6 py-4 hidden sm:table-cell">
-                      <span className="text-sm text-[var(--text-tertiary)]">
-                        {category.created_at.slice(0, 10).replace(/-/g, '.')}
-                      </span>
-                    </td>
-                    <td className="px-4 sm:px-6 py-4 text-right">
-                      {category.is_system ? (
-                        <div className="flex justify-end items-center gap-2">
-                          <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-[var(--text-tertiary)] bg-[var(--surface-elevated)] rounded-md">
-                            <Lock className="w-3 h-3" aria-hidden="true" />
-                            기본
+                        {activeTab === 'expense' && (
+                          <label className="flex items-center gap-1.5 text-xs text-[var(--text-secondary)] cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={editForm.is_savings}
+                              onChange={(e) => setEditForm({ ...editForm, is_savings: e.target.checked })}
+                              className="rounded border-[var(--input-border)] text-grape-600 focus:ring-grape-500"
+                            />
+                            저축성 지출
+                          </label>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex justify-end gap-2">
+                      <button
+                        onClick={() => setEditingId(null)}
+                        className="px-3 py-1.5 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
+                      >
+                        취소
+                      </button>
+                      <button
+                        onClick={() => handleUpdate(category.id)}
+                        className="px-3 py-1.5 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
+                      >
+                        저장
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  /* 일반 카드 행 */
+                  <div className="flex items-center gap-3 px-4 py-4">
+                    <MoveButtons
+                      name={category.name}
+                      index={index}
+                      total={categories.length}
+                      reordering={reordering}
+                      isSystem={category.is_system}
+                      onMove={(dir) => handleMove(index, dir)}
+                    />
+                    <span className="text-xl flex-shrink-0 w-8 text-center">{category.emoji}</span>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        <span className="font-medium text-[var(--text-primary)]">{category.name}</span>
+                        {category.is_savings && (
+                          <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium text-leaf-700 bg-leaf-100 rounded">
+                            저축
                           </span>
-                        </div>
-                      ) : isEditing ? (
-                        <div className="flex justify-end gap-2">
-                          <button
-                            onClick={() => handleUpdate(category.id)}
-                            className="px-3 py-1.5 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
-                          >
-                            저장
-                          </button>
-                          <button
-                            onClick={() => setEditingId(null)}
-                            className="px-3 py-1.5 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
-                          >
-                            취소
-                          </button>
-                        </div>
-                      ) : (
-                        <div className="flex justify-end gap-2">
-                          <button
-                            onClick={() => startEdit(category)}
-                            className="px-3 py-1.5 text-sm font-medium text-grape-600 bg-grape-50 rounded-lg hover:bg-grape-100 transition-colors"
-                          >
-                            수정
-                          </button>
-                          <button
-                            onClick={() => setDeleteTarget(category.id)}
-                            className="px-3 py-1.5 text-sm font-medium text-rose-600 bg-rose-50 rounded-lg hover:bg-rose-100 transition-colors"
-                          >
-                            삭제
-                          </button>
-                        </div>
+                        )}
+                      </div>
+                      {category.description && (
+                        <p className="text-xs text-[var(--text-secondary)] mt-0.5">{category.description}</p>
                       )}
-                    </td>
-                  </tr>
-                )
-              })
-            ) : (
-              <tr>
-                <td colSpan={6}>
-                  <EmptyState
-                    variant="section"
-                    title="아직 카테고리가 없습니다"
-                    description="새 카테고리를 추가하여 지출을 체계적으로 관리해보세요."
-                    action={{
-                      label: '+ 카테고리 추가',
-                      onClick: () => setIsAdding(true),
-                    }}
-                  />
-                </td>
-              </tr>
-            )}
-          </tbody>
-          </table>
+                    </div>
+                    {category.is_system ? (
+                      <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-[var(--text-tertiary)] bg-[var(--surface-elevated)] rounded-md flex-shrink-0">
+                        <Lock className="w-3 h-3" aria-hidden="true" />
+                        기본
+                      </span>
+                    ) : (
+                      <div className="flex gap-2 flex-shrink-0">
+                        <button
+                          onClick={() => startEdit(category)}
+                          className="px-3 py-1.5 text-sm font-medium text-grape-600 bg-grape-50 rounded-lg hover:bg-grape-100 transition-colors"
+                        >
+                          수정
+                        </button>
+                        <button
+                          onClick={() => setDeleteTarget(category.id)}
+                          className="px-3 py-1.5 text-sm font-medium text-rose-600 bg-rose-50 rounded-lg hover:bg-rose-100 transition-colors"
+                        >
+                          삭제
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )
+          })}
         </div>
-      </div>
+      )}
 
       {/* 삭제 확인 모달 */}
       {deleteTarget !== null && (

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -191,9 +191,12 @@ export default function CategoryManager() {
   if (error) {
     return (
       <div className="space-y-6">
-        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
-          <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
-        </button>
+        <div className="flex items-center gap-3">
+          <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+            <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
+          </button>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">카테고리 관리</h1>
+        </div>
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]">
           <ErrorState onRetry={fetchCategories} />
         </div>
@@ -204,9 +207,12 @@ export default function CategoryManager() {
   return (
     <div className="space-y-6 animate-page-in">
       <div className="flex items-center justify-between">
-        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
-          <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
-        </button>
+        <div className="flex items-center gap-3">
+          <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+            <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
+          </button>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">카테고리 관리</h1>
+        </div>
         <button
           onClick={() => setIsAdding(true)}
           className="flex items-center gap-1.5 px-4 py-2 bg-grape-600 text-white rounded-xl text-sm font-medium shadow-sm hover:bg-grape-700 transition-colors"

--- a/frontend/src/pages/HouseholdListPage.tsx
+++ b/frontend/src/pages/HouseholdListPage.tsx
@@ -110,9 +110,12 @@ export default function HouseholdListPage() {
   if (error && households.length === 0) {
     return (
       <div className="space-y-6">
-        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
-          <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
-        </button>
+        <div className="flex items-center gap-3">
+          <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+            <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
+          </button>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">공유 가계부</h1>
+        </div>
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]">
           <ErrorState onRetry={fetchHouseholds} />
         </div>
@@ -124,13 +127,11 @@ export default function HouseholdListPage() {
     <div className="space-y-6">
       {/* 헤더 */}
       <div className="flex items-center justify-between">
-        <div>
+        <div className="flex items-center gap-3">
           <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
-          <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
-        </button>
-          <p className="text-sm text-[var(--text-tertiary)] mt-1">
-            가족이나 친구들과 함께 지출을 관리하세요
-          </p>
+            <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
+          </button>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">공유 가계부</h1>
         </div>
         <button
           onClick={() => setShowCreateModal(true)}

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -221,9 +221,12 @@ export default function RecurringList() {
   if (error) {
     return (
       <div className="space-y-6">
-        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
-          <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
-        </button>
+        <div className="flex items-center gap-3">
+          <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+            <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
+          </button>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">반복 거래</h1>
+        </div>
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60">
           <ErrorState onRetry={loadData} />
         </div>
@@ -235,9 +238,12 @@ export default function RecurringList() {
     <div className="space-y-6 animate-page-in">
       {/* 헤더 */}
       <div className="flex items-center justify-between">
-        <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
-          <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
-        </button>
+        <div className="flex items-center gap-3">
+          <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
+            <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
+          </button>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">반복 거래</h1>
+        </div>
         <button
           onClick={openAdd}
           className="flex items-center gap-1.5 px-4 py-2 bg-grape-600 text-white rounded-xl text-sm font-medium shadow-sm hover:bg-grape-700 transition-colors"

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -34,57 +34,65 @@ const SECTION_REDIRECTS: Record<string, SettingsSection | string> = {
 interface MenuItem {
   to: string
   label: string
-  description: string
+  description?: string
   icon: LucideIcon
   badge?: React.ReactNode
-  section?: SettingsSection
   external?: boolean
 }
 
+interface MenuSection {
+  label: string
+  items: MenuItem[]
+}
+
+/* ─── 단일 메뉴 아이템 렌더링 ─── */
+function SettingsMenuItem({ item, isLast }: { item: MenuItem; isLast: boolean }) {
+  const Icon = item.icon
+  const className = `flex items-center gap-4 px-5 py-4 hover:bg-grape-50 transition-colors ${
+    !isLast ? 'border-b border-[var(--border-subtle)]' : ''
+  }`
+  const content = (
+    <>
+      <div className="relative flex-shrink-0">
+        <Icon className="w-5 h-5 text-grape-500" />
+        {item.badge}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-[var(--text-primary)]">{item.label}</p>
+        {item.description && (
+          <p className="text-xs text-[var(--text-tertiary)] truncate">{item.description}</p>
+        )}
+      </div>
+      <ChevronRight className="w-4 h-4 text-[var(--text-muted)] flex-shrink-0" />
+    </>
+  )
+  return item.external ? (
+    <a href={item.to} target="_blank" rel="noopener noreferrer" className={className}>
+      {content}
+    </a>
+  ) : (
+    <Link to={item.to} className={className}>
+      {content}
+    </Link>
+  )
+}
+
 /* ─── 메뉴 목록 (설정 메인) ─── */
-function SettingsMenu({ menuItems }: { menuItems: MenuItem[] }) {
+function SettingsMenu({ sections }: { sections: MenuSection[] }) {
   return (
     <div className="space-y-6 animate-page-in">
-      <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] overflow-hidden">
-        {menuItems.map((item, idx) => {
-          const Icon = item.icon
-          const className = `flex items-center gap-4 px-5 py-4 hover:bg-grape-50 transition-colors ${
-            idx < menuItems.length - 1 ? 'border-b border-[var(--border-subtle)]' : ''
-          }`
-          const content = (
-            <>
-              <div className="relative flex-shrink-0">
-                <Icon className="w-5 h-5 text-grape-500" />
-                {item.badge}
-              </div>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-[var(--text-primary)]">{item.label}</p>
-                <p className="text-xs text-[var(--text-tertiary)] truncate">{item.description}</p>
-              </div>
-              <ChevronRight className="w-4 h-4 text-[var(--text-muted)] flex-shrink-0" />
-            </>
-          )
-          return item.external ? (
-            <a
-              key={item.to}
-              href={item.to}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={className}
-            >
-              {content}
-            </a>
-          ) : (
-            <Link
-              key={item.to}
-              to={item.to}
-              className={className}
-            >
-              {content}
-            </Link>
-          )
-        })}
-      </div>
+      {sections.map((section) => (
+        <div key={section.label}>
+          <p className="text-xs font-semibold text-[var(--text-tertiary)] uppercase tracking-wide px-1 mb-2">
+            {section.label}
+          </p>
+          <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] overflow-hidden">
+            {section.items.map((item, idx) => (
+              <SettingsMenuItem key={item.to} item={item} isLast={idx === section.items.length - 1} />
+            ))}
+          </div>
+        </div>
+      ))}
     </div>
   )
 }
@@ -104,79 +112,49 @@ export default function SettingsPage() {
   const { section } = useParams<{ section: string }>()
   const navigate = useNavigate()
 
-  const menuItems: MenuItem[] = [
+  const menuSections: MenuSection[] = [
     {
-      to: '/categories',
-      label: '카테고리',
-      description: '지출/수입 분류 카테고리 관리',
-      icon: Tags,
+      label: '가계부',
+      items: [
+        { to: '/categories', label: '카테고리', icon: Tags },
+        { to: '/budgets', label: '예산 관리', icon: PiggyBank },
+        { to: '/payment-methods', label: '결제수단', icon: CreditCard },
+        { to: '/recurring', label: '반복 거래', icon: Repeat },
+        { to: '/households', label: '공유 가계부', icon: Users },
+      ],
     },
     {
-      to: '/budgets',
-      label: '예산 관리',
-      description: '카테고리별/월 총 예산 설정',
-      icon: PiggyBank,
+      label: '설정',
+      items: [
+        {
+          to: '/settings/appearance',
+          label: '화면 모드',
+          description: resolvedTheme === 'dark' ? '다크 모드' : '라이트 모드',
+          icon: resolvedTheme === 'dark' ? Moon : Sun,
+        },
+        {
+          to: '/settings/my-account',
+          label: '내 계정',
+          icon: User,
+        },
+      ],
     },
     {
-      to: '/payment-methods',
-      label: '결제수단',
-      description: '카드/현금 태깅 + 실적 추적',
-      icon: CreditCard,
+      label: '지원',
+      items: [
+        {
+          to: '/settings/changelog',
+          label: '새소식',
+          icon: Megaphone,
+          badge: hasUnread ? (
+            <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full border-2 border-[var(--surface-card)]" />
+          ) : undefined,
+        },
+        { to: '/guide', label: '사용 가이드', icon: BookOpen },
+        { to: '/feedback', label: '피드백', description: '기능 요청 · 버그 신고', icon: MessageSquarePlus },
+        ...(user?.is_admin ? [{ to: '/admin', label: '관리자', icon: ShieldCheck }] : []),
+      ],
     },
-    {
-      to: '/recurring',
-      label: '반복 거래',
-      description: '정기 지출/수입 관리',
-      icon: Repeat,
-    },
-    {
-      to: '/households',
-      label: '공유 가계부',
-      description: '가구 생성, 초대, 멤버 관리',
-      icon: Users,
-    },
-    {
-      to: '/settings/appearance',
-      label: '화면 모드',
-      description: resolvedTheme === 'dark' ? '다크 모드' : '라이트 모드',
-      icon: resolvedTheme === 'dark' ? Moon : Sun,
-      section: 'appearance',
-    },
-    {
-      to: '/settings/my-account',
-      label: '내 계정',
-      description: '프로필, 텔레그램/카카오톡 연동, 로그아웃',
-      icon: User,
-      section: 'my-account',
-    },
-    {
-      to: '/settings/changelog',
-      label: '새소식',
-      description: '앱 업데이트 내역',
-      icon: Megaphone,
-      section: 'changelog',
-      badge: hasUnread ? (
-        <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full border-2 border-[var(--surface-card)]" />
-      ) : undefined,
-    },
-    {
-      to: '/guide',
-      label: '사용 가이드',
-      description: '앱 기능별 상세 사용법',
-      icon: BookOpen,
-    },
-    {
-      to: '/feedback',
-      label: '피드백',
-      description: '기능 요청/버그 신고',
-      icon: MessageSquarePlus,
-    },
-    ...(user?.is_admin ? [{
-      to: '/admin',
-      label: '관리자',
-      description: '운영 현황, 피드백 관리, 사용자 관리',
-      icon: ShieldCheck,
-    }] : []),
   ]
 
   if (!user) return null
@@ -216,7 +194,7 @@ export default function SettingsPage() {
             <ChevronRight className="w-4 h-4 text-white/50" />
           </button>
         )}
-        <SettingsMenu menuItems={menuItems} />
+        <SettingsMenu sections={menuSections} />
         {showIosGuide && <IosInstallGuide onClose={() => setShowIosGuide(false)} />}
       </div>
     )
@@ -230,6 +208,6 @@ export default function SettingsPage() {
     case 'my-account':
       return <MyAccountSection />
     default:
-      return <SettingsMenu menuItems={menuItems} />
+      return <SettingsMenu sections={menuSections} />
   }
 }

--- a/frontend/src/pages/__tests__/BudgetManager.test.tsx
+++ b/frontend/src/pages/__tests__/BudgetManager.test.tsx
@@ -141,6 +141,16 @@ beforeEach(() => {
 })
 
 describe('BudgetManager', () => {
+  describe('기본 렌더링', () => {
+    it('데이터 로드 후 페이지 헤더에 예산 관리 타이틀을 표시한다', async () => {
+      setupSuccessHandlers()
+      renderBudgetManager()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 1, name: '예산 관리' })).toBeInTheDocument()
+      })
+    })
+  })
+
   describe('로딩 상태', () => {
     it('데이터 로드 중에는 로딩 스피너를 표시한다', () => {
       setupSuccessHandlers()

--- a/frontend/src/pages/__tests__/CategoryManager.test.tsx
+++ b/frontend/src/pages/__tests__/CategoryManager.test.tsx
@@ -49,6 +49,9 @@ beforeEach(() => {
   mockAddToast = vi.fn()
 })
 
+// 기본 탭은 expense → expense + both 타입만 표시됨
+const expenseCategories = mockCategories.filter((c) => c.type === 'expense' || c.type === 'both')
+
 describe('CategoryManager', () => {
   describe('기본 렌더링', () => {
     it('페이지 헤더에 카테고리 관리 타이틀을 표시한다', async () => {
@@ -72,16 +75,14 @@ describe('CategoryManager', () => {
       })
     })
 
-    it('카테고리 테이블을 표시한다', async () => {
+    it('카테고리 목록을 카드 형태로 표시한다 (테이블 없음)', async () => {
       renderCategoryManager()
       await waitFor(() => {
-        expect(screen.getByRole('table')).toBeInTheDocument()
+        expect(screen.queryByRole('table')).not.toBeInTheDocument()
+        expect(screen.getByText(expenseCategories[0].name)).toBeInTheDocument()
       })
     })
   })
-
-  // 기본 탭은 expense → expense + both 타입만 표시됨
-  const expenseCategories = mockCategories.filter((c) => c.type === 'expense' || c.type === 'both')
 
   describe('카테고리 목록 표시', () => {
     it('expense 탭 카테고리를 표시한다', async () => {

--- a/frontend/src/pages/__tests__/CategoryManager.test.tsx
+++ b/frontend/src/pages/__tests__/CategoryManager.test.tsx
@@ -51,6 +51,13 @@ beforeEach(() => {
 
 describe('CategoryManager', () => {
   describe('기본 렌더링', () => {
+    it('페이지 헤더에 카테고리 관리 타이틀을 표시한다', async () => {
+      renderCategoryManager()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: '카테고리 관리' })).toBeInTheDocument()
+      })
+    })
+
     it('추가 버튼과 테이블을 포함한 페이지를 표시한다', async () => {
       renderCategoryManager()
       await waitFor(() => {

--- a/frontend/src/pages/__tests__/HouseholdListPage.test.tsx
+++ b/frontend/src/pages/__tests__/HouseholdListPage.test.tsx
@@ -91,6 +91,13 @@ describe('HouseholdListPage', () => {
     }
   })
 
+  describe('기본 렌더링', () => {
+    it('페이지 헤더에 공유 가계부 타이틀을 표시한다', () => {
+      renderHouseholdList()
+      expect(screen.getByRole('heading', { name: '공유 가계부' })).toBeInTheDocument()
+    })
+  })
+
   describe('로딩 상태', () => {
     it('로딩 중에는 스피너를 표시한다', () => {
       storeState = {
@@ -146,17 +153,7 @@ describe('HouseholdListPage', () => {
   })
 
   describe('가구 목록 표시', () => {
-    it('가구 설명 안내 문구를 표시한다', () => {
-      storeState = {
-        households: mockHouseholds,
-        isLoading: false,
-        error: null,
-      }
 
-      renderHouseholdList()
-
-      expect(screen.getByText('가족이나 친구들과 함께 지출을 관리하세요')).toBeInTheDocument()
-    })
 
     it('가구 목록을 카드 형태로 표시한다', () => {
       storeState = {

--- a/frontend/src/pages/__tests__/RecurringList.test.tsx
+++ b/frontend/src/pages/__tests__/RecurringList.test.tsx
@@ -72,6 +72,13 @@ describe('RecurringList', () => {
 
   // ==================== 기본 렌더링 ====================
 
+  it('페이지 헤더에 반복 거래 타이틀을 표시한다', async () => {
+    renderRecurringList()
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: '반복 거래' })).toBeInTheDocument()
+    })
+  })
+
   it('필터 탭을 표시한다', () => {
     renderRecurringList()
     expect(screen.getByText('전체')).toBeInTheDocument()

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -96,10 +96,11 @@ describe('SettingsPage', () => {
       expect(screen.getByText('카테고리')).toBeInTheDocument()
     })
 
-    it('9개 메뉴 항목을 표시한다 (약관/개인정보는 독립 메뉴에서 제거됨)', () => {
+    it('10개 메뉴 항목을 표시한다 (약관/개인정보는 독립 메뉴에서 제거됨)', () => {
       renderSettingsPage()
       expect(screen.getByText('카테고리')).toBeInTheDocument()
       expect(screen.getByText('예산 관리')).toBeInTheDocument()
+      expect(screen.getByText('결제수단')).toBeInTheDocument()
       expect(screen.getByText('반복 거래')).toBeInTheDocument()
       expect(screen.getByText('공유 가계부')).toBeInTheDocument()
       expect(screen.getByText('화면 모드')).toBeInTheDocument()
@@ -112,11 +113,37 @@ describe('SettingsPage', () => {
       expect(screen.queryByText('서비스 이용약관')).not.toBeInTheDocument()
     })
 
-    it('메뉴 설명을 표시한다', () => {
+    it('3개 섹션 헤더(가계부, 설정, 지원)를 표시한다', () => {
       renderSettingsPage()
-      expect(screen.getByText('앱 업데이트 내역')).toBeInTheDocument()
-      expect(screen.getByText('프로필, 텔레그램/카카오톡 연동, 로그아웃')).toBeInTheDocument()
-      expect(screen.getByText('지출/수입 분류 카테고리 관리')).toBeInTheDocument()
+      expect(screen.getByText('가계부')).toBeInTheDocument()
+      expect(screen.getByText('설정')).toBeInTheDocument()
+      expect(screen.getByText('지원')).toBeInTheDocument()
+    })
+
+    it('불필요한 메뉴 설명은 표시하지 않는다', () => {
+      renderSettingsPage()
+      // 자명한 메뉴는 description 없음
+      expect(screen.queryByText('지출/수입 분류 카테고리 관리')).not.toBeInTheDocument()
+      expect(screen.queryByText('카테고리별/월 총 예산 설정')).not.toBeInTheDocument()
+      expect(screen.queryByText('정기 지출/수입 관리')).not.toBeInTheDocument()
+      expect(screen.queryByText('가구 생성, 초대, 멤버 관리')).not.toBeInTheDocument()
+      expect(screen.queryByText('앱 업데이트 내역')).not.toBeInTheDocument()
+      expect(screen.queryByText('앱 기능별 상세 사용법')).not.toBeInTheDocument()
+      expect(screen.queryByText('프로필, 텔레그램/카카오톡 연동, 로그아웃')).not.toBeInTheDocument()
+    })
+
+    it('화면 모드 description은 현재 테마 상태를 표시한다', () => {
+      renderSettingsPage()
+      // 라이트/다크 모드 상태 중 하나가 표시되어야 한다
+      const hasModeText =
+        screen.queryByText('라이트 모드') !== null ||
+        screen.queryByText('다크 모드') !== null
+      expect(hasModeText).toBe(true)
+    })
+
+    it('피드백 description은 기능 요청/버그 신고 범위를 표시한다', () => {
+      renderSettingsPage()
+      expect(screen.getByText('기능 요청 · 버그 신고')).toBeInTheDocument()
     })
 
     it('더보기 메뉴에 외부 auth.podonest.com 링크가 없어야 한다', () => {
@@ -248,13 +275,6 @@ describe('SettingsPage', () => {
       expect(codeBtns.length).toBeGreaterThanOrEqual(1)
       // 연동 해제 버튼은 없어야 한다 (is_linked=false 상태이므로)
       expect(screen.queryByRole('button', { name: '연동 해제' })).not.toBeInTheDocument()
-    })
-  })
-
-  describe('화면 모드 서브 페이지', () => {
-    it('화면 모드 설정을 표시한다', () => {
-      renderSettingsPage('/settings/appearance')
-      expect(screen.getByText('화면 모드')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Summary

- 설정 더보기 페이지를 3개 섹션(가계부 / 설정 / 지원)으로 구분하고 불필요한 description 제거
- CategoryManager, BudgetManager, RecurringList, HouseholdListPage에 일관된 페이지 헤더(뒤로가기 + 타이틀) 추가
- CategoryManager 테이블 레이아웃을 모바일 친화적인 카드 레이아웃으로 전환

## Changes

**SettingsPage**
- 9개 항목을 `가계부 / 설정 / 지원` 3개 섹션으로 분리
- `SettingsMenuItem` 서브 컴포넌트 추출
- 자명한 메뉴의 description 제거 (카테고리, 예산 관리, 공유 가계부 등)
- 화면 모드(현재 상태)·피드백("기능 요청 · 버그 신고")만 description 유지
- `MenuItem.section` 미사용 필드 제거

**서브 페이지 헤더 통일** (CategoryManager, BudgetManager, RecurringList, HouseholdListPage)
- 뒤로가기 버튼 + 페이지 타이틀 헤더를 모든 상태(로딩/에러/정상)에 일관되게 표시

**CategoryManager 카드 전환**
- `<table>` 레이아웃 → `<div>` 카드 행 기반으로 교체 (모바일 anti-pattern 해소)
- `MoveButtons` 서브 컴포넌트 추출
- 인라인 편집 폼 / 상단 추가 폼 카드로 분리
- `created_at` 컬럼 제거

## Test plan

- [ ] 테스트 1476개 전부 통과 확인
- [ ] 설정 더보기 페이지 — 3섹션 헤더, 메뉴 항목 정상 표시
- [ ] 카테고리 관리 — 카드 목록, 추가/수정/삭제/순서 변경 동작
- [ ] 예산 관리, 반복 거래, 공유 가계부 — 헤더 타이틀 표시 확인

close #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)