### PR TITLE
fix: 설정 서브페이지 UX 3종 수정 — 추가폼 버그, 예산 모바일, 헤더 아이콘

### DIFF
--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -8,7 +8,7 @@
 
 import { useState, useEffect, useMemo } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
-import { ArrowLeft, BarChart3, AlertTriangle, Wallet } from 'lucide-react'
+import { ArrowLeft, BarChart3, AlertTriangle, Wallet, PiggyBank } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { TOAST } from '../constants/toastMessages'
 import budgetApi from '../api/budgets'
@@ -232,6 +232,7 @@ export default function BudgetManager() {
           <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
+          <PiggyBank className="w-5 h-5 text-grape-500 flex-shrink-0" />
           <h1 className="text-lg font-semibold text-[var(--text-primary)]">예산 관리</h1>
         </div>
         <ErrorState message={error} onRetry={loadData} />
@@ -386,36 +387,34 @@ export default function BudgetManager() {
             {overview.map((item) => {
               const pct = getCategoryPercent(item.category_id)
               return (
-                <div key={item.category_id} className="px-5 py-4">
-                  <div className="flex items-center gap-3">
-                    {/* 카테고리 이름 */}
-                    <span className="w-14 font-medium text-[var(--text-primary)] shrink-0 text-sm truncate">
+                <div key={item.category_id} className="px-4 py-3.5 space-y-2">
+                  {/* 카테고리 이름 + 비율 */}
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-sm text-[var(--text-primary)] truncate">
                       {item.category_name}
                     </span>
-
-                    {/* 최근 3개월 지출 — 데스크톱 */}
-                    <div className="flex-1 text-xs text-[var(--text-muted)] min-w-0">
-                      {item.monthly_spending.length > 0 ? (
-                        <span>
-                          {item.monthly_spending
-                            .slice(0, 3)
-                            .map((s) => `${s.month}월 ${s.amount.toLocaleString('ko-KR')}원`)
-                            .join(' / ')}
-                        </span>
-                      ) : (
-                        <span className="text-warm-300">지출 내역 없음</span>
-                      )}
-                    </div>
-
-                    {/* 비율 표시 */}
                     {pct != null && (
-                      <span className="text-xs text-grape-500 font-medium shrink-0 w-12 text-right">
+                      <span className="text-xs text-grape-500 font-medium shrink-0">
                         {pct.toFixed(1)}%
                       </span>
                     )}
+                  </div>
 
-                    {/* 예산 입력 + 저장 버튼 */}
-                    <div className="flex items-center gap-1.5 shrink-0">
+                  {/* 최근 지출 참고 */}
+                  {item.monthly_spending.length > 0 ? (
+                    <p className="text-xs text-[var(--text-muted)]">
+                      {item.monthly_spending
+                        .slice(0, 2)
+                        .map((s) => `${s.month}월 ${s.amount.toLocaleString('ko-KR')}원`)
+                        .join(' / ')}
+                    </p>
+                  ) : (
+                    <p className="text-xs text-[var(--text-muted)]">최근 지출 내역 없음</p>
+                  )}
+
+                  {/* 예산 입력 + 저장 */}
+                  <div className="flex items-center gap-2">
+                    <div className="flex flex-1 items-center gap-1">
                       <input
                         type="number"
                         inputMode="numeric"
@@ -423,21 +422,21 @@ export default function BudgetManager() {
                         step="1000"
                         value={localAmounts[item.category_id] ?? ''}
                         onChange={(e) => handleAmountChange(item.category_id, e.target.value)}
-                        className="input-base w-28 text-right"
+                        className="input-base flex-1 text-right"
                         placeholder="예산 없음"
                         aria-label={`${item.category_name} 예산`}
                       />
                       <span className="text-xs text-[var(--text-tertiary)] shrink-0">원</span>
-                      {isDirty(item) && (
-                        <button
-                          onClick={() => handleSave(item)}
-                          disabled={savingIds.has(item.category_id)}
-                          className="px-3 py-1.5 text-xs font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 disabled:opacity-50 transition-colors whitespace-nowrap"
-                        >
-                          {savingIds.has(item.category_id) ? '저장 중...' : '저장'}
-                        </button>
-                      )}
                     </div>
+                    {isDirty(item) && (
+                      <button
+                        onClick={() => handleSave(item)}
+                        disabled={savingIds.has(item.category_id)}
+                        className="px-3 py-1.5 text-xs font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 disabled:opacity-50 transition-colors whitespace-nowrap shrink-0"
+                      >
+                        {savingIds.has(item.category_id) ? '저장 중...' : '저장'}
+                      </button>
+                    )}
                   </div>
                 </div>
               )

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useState } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
-import { ArrowLeft, Lock, Plus } from 'lucide-react'
+import { ArrowLeft, Lock, Plus, Tags } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { TOAST } from '../constants/toastMessages'
 import { categoryApi } from '../api/categories'
@@ -232,6 +232,7 @@ export default function CategoryManager() {
           <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
+          <Tags className="w-5 h-5 text-grape-500 flex-shrink-0" />
           <h1 className="text-lg font-semibold text-[var(--text-primary)]">카테고리 관리</h1>
         </div>
         <CategoryManagerSkeleton />
@@ -247,6 +248,7 @@ export default function CategoryManager() {
           <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
+          <Tags className="w-5 h-5 text-grape-500 flex-shrink-0" />
           <h1 className="text-lg font-semibold text-[var(--text-primary)]">카테고리 관리</h1>
         </div>
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]">
@@ -263,6 +265,7 @@ export default function CategoryManager() {
           <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
+          <Tags className="w-5 h-5 text-grape-500 flex-shrink-0" />
           <h1 className="text-lg font-semibold text-[var(--text-primary)]">카테고리 관리</h1>
         </div>
         <button
@@ -366,7 +369,7 @@ export default function CategoryManager() {
       )}
 
       {/* 카테고리 목록 */}
-      {categories.length === 0 && !isAdding ? (
+      {categories.length === 0 && !isAdding && (
         <EmptyState
           variant="section"
           title="아직 카테고리가 없습니다"
@@ -376,7 +379,8 @@ export default function CategoryManager() {
             onClick: () => setIsAdding(true),
           }}
         />
-      ) : (
+      )}
+      {categories.length > 0 && (
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 divide-y divide-[var(--border-subtle)]">
           {categories.map((category, index) => {
             const isEditing = editingId === category.id

--- a/frontend/src/pages/HouseholdListPage.tsx
+++ b/frontend/src/pages/HouseholdListPage.tsx
@@ -114,6 +114,7 @@ export default function HouseholdListPage() {
           <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
+          <Users className="w-5 h-5 text-grape-500 flex-shrink-0" />
           <h1 className="text-lg font-semibold text-[var(--text-primary)]">공유 가계부</h1>
         </div>
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]">
@@ -131,6 +132,7 @@ export default function HouseholdListPage() {
           <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
+          <Users className="w-5 h-5 text-grape-500 flex-shrink-0" />
           <h1 className="text-lg font-semibold text-[var(--text-primary)]">공유 가계부</h1>
         </div>
         <button

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -6,7 +6,7 @@
 
 import { useState, useEffect } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
-import { ArrowLeft, Plus, Pencil, Trash2, Pause, Play, Zap } from 'lucide-react'
+import { ArrowLeft, Plus, Pencil, Trash2, Pause, Play, Zap, Repeat } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { TOAST } from '../constants/toastMessages'
 import { recurringApi } from '../api/recurring'
@@ -225,6 +225,7 @@ export default function RecurringList() {
           <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
+          <Repeat className="w-5 h-5 text-grape-500 flex-shrink-0" />
           <h1 className="text-lg font-semibold text-[var(--text-primary)]">반복 거래</h1>
         </div>
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60">
@@ -242,6 +243,7 @@ export default function RecurringList() {
           <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
+          <Repeat className="w-5 h-5 text-grape-500 flex-shrink-0" />
           <h1 className="text-lg font-semibold text-[var(--text-primary)]">반복 거래</h1>
         </div>
         <button


### PR DESCRIPTION
## Summary

- CategoryManager 추가 폼 UI 버그 수정 (카테고리 없을 때 + 추가 폼 열면 빈 카드 컨테이너 렌더링)
- BudgetManager 카테고리별 예산 모바일 레이아웃 개선
- 설정 서브페이지 헤더 아이콘 통일

## Changes

**CategoryManager — 추가 폼 버그**
`isAdding=true && categories.length=0` 상태에서 추가 폼과 함께 빈 카드 컨테이너가 렌더링되던 문제 수정. 조건을 `categories.length > 0`일 때만 카드 리스트 렌더링하도록 분리.

**BudgetManager — 카테고리별 예산 모바일**
이름/최근지출/비율/입력/저장이 한 줄에 몰려 모바일 overflow 발생하던 구조를 3단 스택으로 개선:
1. 카테고리 이름 + 비율
2. 최근 지출 참고 (2개월)
3. 금액 입력 + 저장 버튼

**헤더 아이콘 통일**
PaymentMethodManager만 CreditCard 아이콘이 있고 나머지는 없던 불일치 해소:
- CategoryManager → `Tags`
- BudgetManager → `PiggyBank`
- RecurringList → `Repeat`
- HouseholdListPage → `Users`

## Test plan

- [ ] 카테고리 관리: 카테고리 없는 상태에서 추가 버튼 → 폼만 표시, 빈 카드 없음
- [ ] 예산 관리: 모바일 화면에서 카테고리별 예산 행이 정상 표시
- [ ] 설정 서브페이지 헤더에 아이콘 + 타이틀 균일하게 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)