### PR TITLE
style: 더보기 페이지 3라운드 정비 — 숫자 포맷, UX/용어, 디자인 톤

### DIFF
--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -295,10 +295,10 @@ export default function BudgetManager() {
             </div>
             <div className="flex justify-between text-xs text-[var(--text-secondary)]">
               <span>
-                배정: {formatAmount(allocatedTotal)} / {formatAmount(totalNum)} ({allocationPercent.toFixed(1)}%)
+                배정: <span className="tabular-nums">{formatAmount(allocatedTotal)}</span> / <span className="tabular-nums">{formatAmount(totalNum)}</span> ({allocationPercent.toFixed(1)}%)
               </span>
               <span className={remainingBudget != null && remainingBudget < 0 ? 'text-rose-600 font-semibold' : ''}>
-                남은 예산: {remainingBudget != null ? formatAmount(remainingBudget) : '-'}
+                남은 예산: <span className="tabular-nums">{remainingBudget != null ? formatAmount(remainingBudget) : '-'}</span>
               </span>
             </div>
           </div>
@@ -346,9 +346,9 @@ export default function BudgetManager() {
                 </div>
                 <div className="flex justify-between text-xs text-[var(--text-secondary)]">
                   <span>
-                    사용: {formatAmount(alert.spent_amount)} / {formatAmount(alert.budget_amount)}
+                    사용: <span className="tabular-nums">{formatAmount(alert.spent_amount)}</span> / <span className="tabular-nums">{formatAmount(alert.budget_amount)}</span>
                   </span>
-                  <span>남은 금액: {formatAmount(alert.remaining_amount)}</span>
+                  <span>남은 금액: <span className="tabular-nums">{formatAmount(alert.remaining_amount)}</span></span>
                 </div>
                 {alert.is_exceeded && (
                   <div className="flex items-center gap-1 mt-2">
@@ -405,7 +405,7 @@ export default function BudgetManager() {
                     <p className="text-xs text-[var(--text-muted)]">
                       {item.monthly_spending
                         .slice(0, 2)
-                        .map((s) => `${s.month}월 ${s.amount.toLocaleString('ko-KR')}원`)
+                        .map((s) => `${s.month}월 ${formatAmount(s.amount)}`)
                         .join(' / ')}
                     </p>
                   ) : (

--- a/frontend/src/pages/HouseholdListPage.tsx
+++ b/frontend/src/pages/HouseholdListPage.tsx
@@ -8,7 +8,7 @@ import type { } from 'react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGoBack } from '../hooks/useGoBack'
-import { ArrowLeft, Users, Calendar } from 'lucide-react'
+import { ArrowLeft, Users, Calendar, Plus } from 'lucide-react'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { useToast } from '../hooks/useToast'
 import { TOAST } from '../constants/toastMessages'
@@ -137,9 +137,10 @@ export default function HouseholdListPage() {
         </div>
         <button
           onClick={() => setShowCreateModal(true)}
-          className="px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 transition-colors"
+          className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-grape-600 rounded-xl shadow-sm hover:bg-grape-700 transition-colors"
         >
-          + 가구 만들기
+          <Plus className="w-4 h-4" />
+          가구 만들기
         </button>
       </div>
 

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -13,6 +13,7 @@ import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { paymentMethodApi } from '../api/paymentMethods'
 import { formatAmount } from '../utils/format'
 import type { PaymentMethod, PaymentMethodUsage, PaymentMethodType } from '../types'
+import { Skeleton } from '../components/skeleton/Skeleton'
 
 const TYPE_LABELS: Record<PaymentMethodType, string> = {
   credit_card: '신용카드',
@@ -235,10 +236,12 @@ export default function PaymentMethodManager() {
       {/* 로딩 */}
       {loading && (
         <div className="space-y-3">
-          {[...Array(2)].map((_, i) => (
-            <div key={i} className="bg-[var(--surface-card)] rounded-2xl p-4 animate-pulse">
-              <div className="h-4 w-24 bg-warm-200 rounded mb-2" />
-              <div className="h-3 w-16 bg-warm-200 rounded" />
+          {[1, 2, 3].map(i => (
+            <div key={i} className="bg-[var(--surface-card)] rounded-2xl p-4">
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-28" />
+                <Skeleton className="h-3 w-20" />
+              </div>
             </div>
           ))}
         </div>

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -250,7 +250,7 @@ export default function PaymentMethodManager() {
 
       {/* 빈 상태 */}
       {!loading && methods.length === 0 && (
-        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] ">
+        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60">
           <EmptyState
             variant="section"
             title="등록된 결제수단이 없습니다"
@@ -264,7 +264,7 @@ export default function PaymentMethodManager() {
       {!loading && methods.length > 0 && !editMode && (
         <div className="space-y-4">
           {/* 주 결제수단 드롭다운 */}
-          <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-5">
+          <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-5">
             <label htmlFor="primary-payment" className="block text-sm font-semibold text-[var(--text-primary)] mb-2">
               주 결제수단
             </label>
@@ -300,7 +300,7 @@ export default function PaymentMethodManager() {
                   <div
                     key={method.id}
                     data-testid={`payment-method-${method.id}`}
-                    className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4"
+                    className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-4"
                   >
                     <div className="flex items-center justify-between mb-1">
                       <div className="flex items-center gap-2">
@@ -358,7 +358,7 @@ export default function PaymentMethodManager() {
             <div
               key={method.id}
               data-testid={`payment-method-${method.id}`}
-              className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4"
+              className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-4"
             >
               {/* 편집 중인 항목 */}
               {editingMethod?.id === method.id ? (
@@ -457,7 +457,7 @@ export default function PaymentMethodManager() {
 
       {/* 추가 폼 */}
       {showForm && (
-        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-5 space-y-4">
+        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-5 space-y-4">
           <h2 className="text-sm font-semibold text-[var(--text-primary)]">새 결제수단</h2>
 
           <div>

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -307,10 +307,10 @@ export default function PaymentMethodManager() {
                     {hasTarget && usage && (
                       <div className="mt-2" data-testid={`usage-bar-${method.id}`}>
                         <div className="flex justify-between items-center mb-1">
-                          <span className="text-xs text-[var(--text-secondary)]">
+                          <span className="text-xs text-[var(--text-secondary)] tabular-nums">
                             {formatAmount(usage.spent_amount)} / {formatAmount(method.monthly_target!)}
                           </span>
-                          <span className={`text-xs ${isAchieved ? 'text-leaf-600 font-medium' : 'text-[var(--text-muted)]'}`}>
+                          <span className={`text-xs tabular-nums ${isAchieved ? 'text-leaf-600 font-medium' : 'text-[var(--text-muted)]'}`}>
                             {isAchieved ? '실적 달성' : `잔여 ${formatAmount(usage.remaining ?? 0)}`}
                           </span>
                         </div>
@@ -328,7 +328,7 @@ export default function PaymentMethodManager() {
                         </div>
                         {/* 실적 넛지 */}
                         {!isAchieved && remaining !== null && remaining > 0 && (
-                          <p className="text-xs text-grape-600 mt-1" data-testid={`nudge-${method.id}`}>
+                          <p className="text-xs text-grape-600 mt-1 tabular-nums" data-testid={`nudge-${method.id}`}>
                             실적까지 {formatAmount(remaining)} 남음
                           </p>
                         )}

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -5,9 +5,9 @@
  */
 
 import { useState, useEffect, useCallback } from 'react'
-import { Link } from 'react-router-dom'
 import { ArrowLeft, CreditCard, Plus, Trash2, Pencil, ChevronUp, ChevronDown } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
+import { useGoBack } from '../hooks/useGoBack'
 import { TOAST } from '../constants/toastMessages'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import { paymentMethodApi } from '../api/paymentMethods'
@@ -36,6 +36,7 @@ function getCurrentMonth(): string {
 
 export default function PaymentMethodManager() {
   const { addToast } = useToast()
+  const goBack = useGoBack('/settings')
   const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
 
   const [methods, setMethods] = useState<PaymentMethod[]>([])
@@ -209,13 +210,13 @@ export default function PaymentMethodManager() {
       {/* 헤더 */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <Link
-            to="/settings"
+          <button
+            onClick={() => goBack()}
             aria-label="뒤로가기"
-            className="p-2 -ml-2 rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
+            className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
           >
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
-          </Link>
+          </button>
           <div className="flex items-center gap-2">
             <CreditCard className="w-5 h-5 text-grape-500" />
             <h1 className="text-lg font-semibold text-[var(--text-primary)]">결제수단</h1>

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -14,6 +14,7 @@ import { paymentMethodApi } from '../api/paymentMethods'
 import { formatAmount } from '../utils/format'
 import type { PaymentMethod, PaymentMethodUsage, PaymentMethodType } from '../types'
 import { Skeleton } from '../components/skeleton/Skeleton'
+import EmptyState from '../components/EmptyState'
 
 const TYPE_LABELS: Record<PaymentMethodType, string> = {
   credit_card: '신용카드',
@@ -249,9 +250,13 @@ export default function PaymentMethodManager() {
 
       {/* 빈 상태 */}
       {!loading && methods.length === 0 && (
-        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-8 text-center">
-          <CreditCard className="w-10 h-10 text-[var(--text-muted)] mx-auto mb-3" />
-          <p className="text-sm font-medium text-[var(--text-secondary)]">결제수단을 추가하면 지출에 태깅할 수 있어요</p>
+        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] ">
+          <EmptyState
+            variant="section"
+            title="등록된 결제수단이 없습니다"
+            description="결제수단을 추가하면 지출 입력 시 태깅할 수 있어요"
+            action={{ label: '결제수단 추가', onClick: () => setShowForm(true) }}
+          />
         </div>
       )}
 

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -226,7 +226,7 @@ export default function RecurringList() {
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
           <Repeat className="w-5 h-5 text-grape-500 flex-shrink-0" />
-          <h1 className="text-lg font-semibold text-[var(--text-primary)]">반복 거래</h1>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">정기거래</h1>
         </div>
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60">
           <ErrorState onRetry={loadData} />
@@ -244,7 +244,7 @@ export default function RecurringList() {
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
           <Repeat className="w-5 h-5 text-grape-500 flex-shrink-0" />
-          <h1 className="text-lg font-semibold text-[var(--text-primary)]">반복 거래</h1>
+          <h1 className="text-lg font-semibold text-[var(--text-primary)]">정기거래</h1>
         </div>
         <button
           onClick={openAdd}

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -308,7 +308,7 @@ export default function RecurringList() {
                         <span className="font-medium text-[var(--text-primary)]">{r.description}</span>
                       </div>
                     </td>
-                    <td className={`px-5 py-3 text-right font-semibold ${r.type === 'expense' ? 'text-[var(--text-primary)]' : 'text-leaf-600'}`}>
+                    <td className={`px-5 py-3 text-right font-semibold tabular-nums ${r.type === 'expense' ? 'text-[var(--text-primary)]' : 'text-leaf-600'}`}>
                       {r.type === 'income' ? '+' : ''}{formatAmount(r.amount)}
                     </td>
                     <td className="px-5 py-3 text-[var(--text-secondary)]">{formatFrequency(r)}</td>
@@ -353,7 +353,7 @@ export default function RecurringList() {
                     <span className={`w-2 h-2 rounded-full flex-shrink-0 ${r.type === 'expense' ? 'bg-grape-500' : 'bg-leaf-500'}`} />
                     <span className="font-medium text-[var(--text-primary)] truncate">{r.description}</span>
                   </div>
-                  <span className={`font-semibold whitespace-nowrap ml-2 ${r.type === 'expense' ? 'text-[var(--text-primary)]' : 'text-leaf-600'}`}>
+                  <span className={`font-semibold whitespace-nowrap ml-2 tabular-nums ${r.type === 'expense' ? 'text-[var(--text-primary)]' : 'text-leaf-600'}`}>
                     {r.type === 'income' ? '+' : ''}{formatAmount(r.amount)}
                   </span>
                 </div>

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -410,8 +410,16 @@ export default function RecurringList() {
       {/* 삭제 확인 모달 */}
       {deleteTargetId !== null && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-2">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-recurring-modal-title"
+            className="bg-[var(--surface-card)] rounded-2xl shadow-xl max-w-md w-full p-6"
+          >
+            <h3
+              id="delete-recurring-modal-title"
+              className="text-lg font-semibold text-[var(--text-primary)] mb-2"
+            >
               정기거래 삭제
             </h3>
             <p className="text-[var(--text-secondary)] mb-6">

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -72,6 +72,9 @@ export default function RecurringList() {
   const [formData, setFormData] = useState<RecurringFormData>(emptyForm)
   const [submitting, setSubmitting] = useState(false)
 
+  /* 삭제 확인 모달 */
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null)
+
   /* 데이터 로드 */
   const loadData = async () => {
     try {
@@ -184,12 +187,18 @@ export default function RecurringList() {
     }
   }
 
-  /* 삭제 */
-  const handleDelete = async (id: number) => {
-    if (!confirm('정말 삭제하시겠습니까?')) return
+  /* 삭제: 확인 모달 표시 */
+  const requestDelete = (id: number) => {
+    setDeleteTargetId(id)
+  }
+
+  /* 삭제: 실제 삭제 실행 */
+  const handleDelete = async () => {
+    if (deleteTargetId === null) return
     try {
-      await recurringApi.delete(id)
+      await recurringApi.delete(deleteTargetId)
       addToast('success', TOAST.RECURRING_DELETED)
+      setDeleteTargetId(null)
       loadData()
     } catch {
       addToast('error', TOAST.DELETE_FAILED)
@@ -333,7 +342,7 @@ export default function RecurringList() {
                         <button onClick={() => openEdit(r)} className="p-2 rounded-md hover:bg-[var(--surface-hover)] text-[var(--text-tertiary)]" title="수정">
                           <Pencil className="w-4 h-4" />
                         </button>
-                        <button onClick={() => handleDelete(r.id)} className="p-2 rounded-md hover:bg-red-50 text-[var(--text-tertiary)] hover:text-red-600" title="삭제">
+                        <button onClick={() => requestDelete(r.id)} className="p-2 rounded-md hover:bg-red-50 text-[var(--text-tertiary)] hover:text-red-600" title="삭제">
                           <Trash2 className="w-4 h-4" />
                         </button>
                       </div>
@@ -374,7 +383,7 @@ export default function RecurringList() {
                     <button onClick={() => openEdit(r)} className="p-1 text-[var(--text-muted)]">
                       <Pencil className="w-4 h-4" />
                     </button>
-                    <button onClick={() => handleDelete(r.id)} className="p-1 text-[var(--text-muted)]">
+                    <button onClick={() => requestDelete(r.id)} className="p-1 text-[var(--text-muted)]">
                       <Trash2 className="w-4 h-4" />
                     </button>
                   </div>
@@ -396,6 +405,34 @@ export default function RecurringList() {
           onSubmit={handleSubmit}
           onClose={() => setShowModal(false)}
         />
+      )}
+
+      {/* 삭제 확인 모달 */}
+      {deleteTargetId !== null && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl max-w-md w-full p-6">
+            <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-2">
+              정기거래 삭제
+            </h3>
+            <p className="text-[var(--text-secondary)] mb-6">
+              정말로 이 정기거래를 삭제하시겠습니까?
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setDeleteTargetId(null)}
+                className="px-4 py-2 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-lg transition-colors"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleDelete}
+                className="px-4 py-2 text-sm font-medium text-white bg-rose-600 rounded-lg hover:bg-rose-700 transition-colors"
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -119,7 +119,7 @@ export default function SettingsPage() {
         { to: '/categories', label: '카테고리', icon: Tags },
         { to: '/budgets', label: '예산 관리', icon: PiggyBank },
         { to: '/payment-methods', label: '결제수단', icon: CreditCard },
-        { to: '/recurring', label: '반복 거래', icon: Repeat },
+        { to: '/recurring', label: '정기거래', icon: Repeat },
         { to: '/households', label: '공유 가계부', icon: Users },
       ],
     },

--- a/frontend/src/pages/__tests__/BudgetManager.test.tsx
+++ b/frontend/src/pages/__tests__/BudgetManager.test.tsx
@@ -181,13 +181,22 @@ describe('BudgetManager', () => {
       })
     })
 
-    it('카테고리별 최근 지출 내역을 표시한다', async () => {
+    it('카테고리별 최근 지출 내역을 ₩ 접두사 포맷으로 표시한다', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
 
       await waitFor(() => {
-        // 식비 최근 1월 195,000원
-        expect(screen.getByText(/1월.*195,000원/)).toBeInTheDocument()
+        // 식비 최근 1월 ₩195,000 (formatAmount 사용, 원 접미사 아님)
+        expect(screen.getByText(/1월.*₩195,000/)).toBeInTheDocument()
+      })
+    })
+
+    it('최근 지출 표시에 원 접미사를 사용하지 않는다', async () => {
+      setupSuccessHandlers()
+      renderBudgetManager()
+
+      await waitFor(() => {
+        expect(screen.queryByText(/195,000원/)).not.toBeInTheDocument()
       })
     })
 
@@ -489,6 +498,72 @@ describe('BudgetManager', () => {
       await waitFor(() => {
         expect(screen.getByText('등록된 카테고리가 없습니다')).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('금액 표시 스타일', () => {
+    it('배분 현황의 배정/총 예산 금액에 tabular-nums 스타일 span이 있다', async () => {
+      setupSuccessHandlers(3000000)
+      renderBudgetManager()
+
+      await waitFor(() => {
+        expect(screen.getByText(/배정:/)).toBeInTheDocument()
+      })
+
+      // 배정 현황 행: 금액 표시 span들에 tabular-nums 적용
+      const allSpans = document.querySelectorAll('span.tabular-nums')
+      const allocationSpans = Array.from(allSpans).filter(
+        (el) => el.textContent && (el.textContent.includes('₩300,000') || el.textContent.includes('₩3,000,000'))
+      )
+      expect(allocationSpans.length).toBeGreaterThan(0)
+    })
+
+    it('배분 현황의 남은 예산 금액에 tabular-nums 스타일 span이 있다', async () => {
+      setupSuccessHandlers(3000000)
+      renderBudgetManager()
+
+      await waitFor(() => {
+        expect(screen.getByText(/남은 예산:/)).toBeInTheDocument()
+      })
+
+      // 남은 예산: ₩2,700,000
+      const allSpans = document.querySelectorAll('span.tabular-nums')
+      const remainingSpans = Array.from(allSpans).filter(
+        (el) => el.textContent && el.textContent.includes('₩2,700,000')
+      )
+      expect(remainingSpans.length).toBeGreaterThan(0)
+    })
+
+    it('예산 상황 카드의 사용/예산 금액에 tabular-nums 스타일 span이 있다', async () => {
+      setupSuccessHandlers()
+      renderBudgetManager()
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/사용:/).length).toBeGreaterThan(0)
+      })
+
+      // 사용: ₩250,000 / ₩300,000 (식비 카드)
+      const allSpans = document.querySelectorAll('span.tabular-nums')
+      const usageSpans = Array.from(allSpans).filter(
+        (el) => el.textContent && el.textContent.includes('₩250,000')
+      )
+      expect(usageSpans.length).toBeGreaterThan(0)
+    })
+
+    it('예산 상황 카드의 남은 금액에 tabular-nums 스타일 span이 있다', async () => {
+      setupSuccessHandlers()
+      renderBudgetManager()
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/남은 금액:/).length).toBeGreaterThan(0)
+      })
+
+      // 남은 금액: ₩50,000 (식비 카드)
+      const allSpans = document.querySelectorAll('span.tabular-nums')
+      const remainingSpans = Array.from(allSpans).filter(
+        (el) => el.textContent && el.textContent.includes('₩50,000')
+      )
+      expect(remainingSpans.length).toBeGreaterThan(0)
     })
   })
 

--- a/frontend/src/pages/__tests__/HouseholdListPage.test.tsx
+++ b/frontend/src/pages/__tests__/HouseholdListPage.test.tsx
@@ -136,7 +136,9 @@ describe('HouseholdListPage', () => {
 
       renderHouseholdList()
 
-      expect(screen.getByRole('button', { name: '가구 만들기' })).toBeInTheDocument()
+      // 헤더 버튼 + EmptyState 버튼 두 곳에 표시됨
+      const buttons = screen.getAllByRole('button', { name: '가구 만들기' })
+      expect(buttons.length).toBeGreaterThanOrEqual(1)
     })
 
     it('빈 상태에서 받은 초대 확인 버튼을 표시한다', () => {
@@ -206,7 +208,7 @@ describe('HouseholdListPage', () => {
       expect(screen.getByText('멤버')).toBeInTheDocument()
     })
 
-    it('+ 가구 만들기 버튼을 표시한다', () => {
+    it('헤더에 가구 만들기 버튼을 표시한다', () => {
       storeState = {
         households: mockHouseholds,
         isLoading: false,
@@ -215,12 +217,39 @@ describe('HouseholdListPage', () => {
 
       renderHouseholdList()
 
-      expect(screen.getByRole('button', { name: '+ 가구 만들기' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: '가구 만들기' })).toBeInTheDocument()
+    })
+
+    it('가구 만들기 버튼이 Plus 아이콘 SVG를 포함한다', () => {
+      storeState = {
+        households: mockHouseholds,
+        isLoading: false,
+        error: null,
+      }
+
+      renderHouseholdList()
+
+      const btn = screen.getByRole('button', { name: '가구 만들기' })
+      expect(btn.querySelector('svg')).toBeInTheDocument()
+    })
+
+    it('가구 만들기 버튼에 텍스트 + 문자가 없다', () => {
+      storeState = {
+        households: mockHouseholds,
+        isLoading: false,
+        error: null,
+      }
+
+      renderHouseholdList()
+
+      // textContent에 '+ 가구 만들기'가 아니라 '가구 만들기'만 있어야 함
+      const btn = screen.getByRole('button', { name: '가구 만들기' })
+      expect(btn.textContent?.trim()).toBe('가구 만들기')
     })
   })
 
   describe('가구 만들기 모달', () => {
-    it('+ 가구 만들기 버튼 클릭 시 모달을 표시한다', async () => {
+    it('가구 만들기 버튼 클릭 시 모달을 표시한다', async () => {
       const user = userEvent.setup()
       storeState = {
         households: mockHouseholds,
@@ -230,7 +259,7 @@ describe('HouseholdListPage', () => {
 
       renderHouseholdList()
 
-      await user.click(screen.getByRole('button', { name: '+ 가구 만들기' }))
+      await user.click(screen.getByRole('button', { name: '가구 만들기' }))
 
       expect(screen.getByText('새 가구 만들기')).toBeInTheDocument()
     })
@@ -320,7 +349,7 @@ describe('HouseholdListPage', () => {
 
       renderHouseholdList()
 
-      await user.click(screen.getByRole('button', { name: '+ 가구 만들기' }))
+      await user.click(screen.getByRole('button', { name: '가구 만들기' }))
 
       // 모달에서 가구 이름 입력
       const nameInput = screen.getByLabelText(/가구 이름/)
@@ -348,7 +377,7 @@ describe('HouseholdListPage', () => {
 
       renderHouseholdList()
 
-      await user.click(screen.getByRole('button', { name: '+ 가구 만들기' }))
+      await user.click(screen.getByRole('button', { name: '가구 만들기' }))
 
       const nameInput = screen.getByLabelText(/가구 이름/)
       await user.type(nameInput, '실패 가구')

--- a/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
+++ b/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
@@ -336,6 +336,31 @@ describe('PaymentMethodManager', () => {
     })
   })
 
+  describe('로딩 스켈레톤', () => {
+    it('로딩 중에 bg-warm-200 없이 Skeleton 컴포넌트 카드를 3개 렌더링한다', () => {
+      // 응답을 영구 지연시켜 로딩 상태를 유지한다
+      server.use(
+        http.get('/api/payment-methods', async () => {
+          await new Promise(() => {}) // 절대 resolve 안 함
+          return HttpResponse.json([])
+        })
+      )
+
+      const { container } = renderPage()
+
+      // 로딩 중: 구 방식의 bg-warm-200 클래스가 없어야 한다
+      expect(container.querySelector('.bg-warm-200')).toBeNull()
+
+      // Skeleton 컴포넌트(bg-[var(--skeleton-base)])가 렌더링된다
+      const skeletonElements = container.querySelectorAll('[class*="skeleton-base"]')
+      expect(skeletonElements.length).toBeGreaterThan(0)
+
+      // 로딩 스켈레톤 카드 래퍼 3개가 렌더링된다
+      const skeletonCards = container.querySelectorAll('.space-y-3 > div')
+      expect(skeletonCards.length).toBe(3)
+    })
+  })
+
   describe('빈 상태', () => {
     it('결제수단이 없으면 안내 메시지를 표시한다', async () => {
       server.use(

--- a/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
+++ b/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
@@ -14,12 +14,17 @@ import PaymentMethodManager from '../PaymentMethodManager'
 import { mockPaymentMethods } from '../../mocks/fixtures'
 
 let mockAddToast: ReturnType<typeof vi.fn>
+const mockGoBack = vi.fn()
 
 vi.mock('../../hooks/useToast', () => ({
   useToast: () => ({
     addToast: mockAddToast,
     removeToast: vi.fn(),
   }),
+}))
+
+vi.mock('../../hooks/useGoBack', () => ({
+  useGoBack: () => mockGoBack,
 }))
 
 vi.mock('../../stores/useHouseholdStore', () => ({
@@ -37,9 +42,22 @@ function renderPage() {
 
 beforeEach(() => {
   mockAddToast = vi.fn()
+  mockGoBack.mockReset()
 })
 
 describe('PaymentMethodManager', () => {
+  describe('뒤로가기', () => {
+    it('뒤로가기 버튼 클릭 시 useGoBack을 호출한다', async () => {
+      const user = userEvent.setup()
+      renderPage()
+
+      const backBtn = screen.getByRole('button', { name: '뒤로가기' })
+      await user.click(backBtn)
+
+      expect(mockGoBack).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('기본 렌더링', () => {
     it('결제수단 목록을 표시한다', async () => {
       renderPage()

--- a/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
+++ b/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
@@ -362,7 +362,7 @@ describe('PaymentMethodManager', () => {
   })
 
   describe('빈 상태', () => {
-    it('결제수단이 없으면 안내 메시지를 표시한다', async () => {
+    it('결제수단이 없으면 EmptyState 컴포넌트로 등록 안내를 표시한다', async () => {
       server.use(
         http.get('/api/payment-methods', () => {
           return HttpResponse.json([])
@@ -375,8 +375,35 @@ describe('PaymentMethodManager', () => {
       renderPage()
 
       await waitFor(() => {
-        expect(screen.getByText('결제수단을 추가하면 지출에 태깅할 수 있어요')).toBeInTheDocument()
+        expect(screen.getByText('등록된 결제수단이 없습니다')).toBeInTheDocument()
       })
+      expect(screen.getByText('결제수단을 추가하면 지출 입력 시 태깅할 수 있어요')).toBeInTheDocument()
+    })
+
+    it('빈 상태에서 결제수단 추가 버튼 클릭 시 추가 폼이 열린다', async () => {
+      const user = userEvent.setup()
+      server.use(
+        http.get('/api/payment-methods', () => {
+          return HttpResponse.json([])
+        }),
+        http.get('/api/payment-methods/stats/monthly', () => {
+          return HttpResponse.json([])
+        })
+      )
+
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByText('등록된 결제수단이 없습니다')).toBeInTheDocument()
+      })
+
+      // EmptyState action 버튼은 여러 "결제수단 추가" 버튼 중 첫 번째 (EmptyState 내부)
+      const addButtons = screen.getAllByRole('button', { name: '결제수단 추가' })
+      expect(addButtons.length).toBeGreaterThanOrEqual(1)
+      await user.click(addButtons[0])
+
+      // 추가 폼이 열린다
+      expect(screen.getByPlaceholderText('결제수단 이름')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
+++ b/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
@@ -230,6 +230,47 @@ describe('PaymentMethodManager', () => {
     })
   })
 
+  describe('tabular-nums 스타일', () => {
+    it('실적/목표 금액 span에 tabular-nums 클래스가 있다', async () => {
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('usage-bar-1')).toBeInTheDocument()
+      })
+
+      // usage-bar-1 안의 첫 번째 span: "22만원 / 30만원" 형태
+      const usageBar = screen.getByTestId('usage-bar-1')
+      const amountSpan = usageBar.querySelector('span')
+      expect(amountSpan).not.toBeNull()
+      expect(amountSpan!.className).toContain('tabular-nums')
+    })
+
+    it('잔여/달성 span에 tabular-nums 클래스가 있다', async () => {
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('usage-bar-1')).toBeInTheDocument()
+      })
+
+      // usage-bar-1 안의 두 번째 span: "잔여 N원" 또는 "실적 달성"
+      const usageBar = screen.getByTestId('usage-bar-1')
+      const spans = usageBar.querySelectorAll('span')
+      expect(spans.length).toBeGreaterThanOrEqual(2)
+      expect(spans[1].className).toContain('tabular-nums')
+    })
+
+    it('넛지 p 태그에 tabular-nums 클래스가 있다', async () => {
+      renderPage()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('nudge-1')).toBeInTheDocument()
+      })
+
+      const nudge = screen.getByTestId('nudge-1')
+      expect(nudge.className).toContain('tabular-nums')
+    })
+  })
+
   describe('결제수단 추가', () => {
     it('추가 폼을 열고 새 결제수단을 생성한다', async () => {
       const user = userEvent.setup()

--- a/frontend/src/pages/__tests__/RecurringList.test.tsx
+++ b/frontend/src/pages/__tests__/RecurringList.test.tsx
@@ -325,7 +325,7 @@ describe('RecurringList', () => {
     const deleteBtns = screen.getAllByTitle('삭제')
     await user.click(deleteBtns[0])
 
-    const deleteModal = screen.getByText('정기거래 삭제').closest('div')!
+    const deleteModal = screen.getByRole('dialog')
     expect(deleteModal).toBeInTheDocument()
     await user.click(within(deleteModal).getByRole('button', { name: '취소' }))
 
@@ -350,7 +350,7 @@ describe('RecurringList', () => {
     const deleteBtns = screen.getAllByTitle('삭제')
     await user.click(deleteBtns[0])
 
-    const deleteModal = screen.getByText('정기거래 삭제').closest('div')!
+    const deleteModal = screen.getByRole('dialog')
     expect(deleteModal).toBeInTheDocument()
     await user.click(within(deleteModal).getByRole('button', { name: '삭제' }))
 
@@ -564,7 +564,7 @@ describe('RecurringList', () => {
     const deleteBtns = screen.getAllByTitle('삭제')
     await user.click(deleteBtns[0])
 
-    const deleteModal = screen.getByText('정기거래 삭제').closest('div')!
+    const deleteModal = screen.getByRole('dialog')
     expect(deleteModal).toBeInTheDocument()
     await user.click(within(deleteModal).getByRole('button', { name: '삭제' }))
 

--- a/frontend/src/pages/__tests__/RecurringList.test.tsx
+++ b/frontend/src/pages/__tests__/RecurringList.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { server } from '../../mocks/server'
@@ -67,7 +67,6 @@ function renderRecurringList() {
 describe('RecurringList', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
   })
 
   // ==================== 기본 렌더링 ====================
@@ -289,7 +288,52 @@ describe('RecurringList', () => {
 
   // ==================== 삭제 ====================
 
-  it('삭제 버튼 클릭 시 항목이 삭제된다', async () => {
+  it('삭제 버튼 클릭 시 확인 모달이 표시된다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    const deleteBtns = screen.getAllByTitle('삭제')
+    await user.click(deleteBtns[0])
+
+    // window.confirm이 아닌 모달이 표시되어야 함
+    expect(screen.getByText('정기거래 삭제')).toBeInTheDocument()
+    expect(screen.getByText('정말로 이 정기거래를 삭제하시겠습니까?')).toBeInTheDocument()
+  })
+
+  it('삭제 확인 모달에서 취소 클릭 시 모달이 닫히고 삭제되지 않는다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+    )
+
+    const user = userEvent.setup()
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    const deleteBtns = screen.getAllByTitle('삭제')
+    await user.click(deleteBtns[0])
+
+    const deleteModal = screen.getByText('정기거래 삭제').closest('div')!
+    expect(deleteModal).toBeInTheDocument()
+    await user.click(within(deleteModal).getByRole('button', { name: '취소' }))
+
+    expect(screen.queryByText('정기거래 삭제')).not.toBeInTheDocument()
+    expect(mockAddToast).not.toHaveBeenCalledWith('success', '정기 거래를 삭제했어요')
+  })
+
+  it('삭제 확인 모달에서 삭제 버튼 클릭 시 항목이 삭제된다', async () => {
     server.use(
       http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
       http.get('/api/categories', () => HttpResponse.json([])),
@@ -306,30 +350,13 @@ describe('RecurringList', () => {
     const deleteBtns = screen.getAllByTitle('삭제')
     await user.click(deleteBtns[0])
 
+    const deleteModal = screen.getByText('정기거래 삭제').closest('div')!
+    expect(deleteModal).toBeInTheDocument()
+    await user.click(within(deleteModal).getByRole('button', { name: '삭제' }))
+
     await waitFor(() => {
       expect(mockAddToast).toHaveBeenCalledWith('success', '정기 거래를 삭제했어요')
     })
-  })
-
-  it('삭제 확인을 취소하면 삭제되지 않는다', async () => {
-    vi.spyOn(window, 'confirm').mockReturnValue(false)
-    server.use(
-      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
-      http.get('/api/categories', () => HttpResponse.json([])),
-    )
-
-    const user = userEvent.setup()
-    renderRecurringList()
-
-    await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
-    })
-
-    const deleteBtns = screen.getAllByTitle('삭제')
-    await user.click(deleteBtns[0])
-
-    // 삭제 토스트가 호출되지 않아야 함
-    expect(mockAddToast).not.toHaveBeenCalledWith('success', '정기 거래를 삭제했어요')
   })
 
   // ==================== 수정 ====================
@@ -536,6 +563,10 @@ describe('RecurringList', () => {
 
     const deleteBtns = screen.getAllByTitle('삭제')
     await user.click(deleteBtns[0])
+
+    const deleteModal = screen.getByText('정기거래 삭제').closest('div')!
+    expect(deleteModal).toBeInTheDocument()
+    await user.click(within(deleteModal).getByRole('button', { name: '삭제' }))
 
     await waitFor(() => {
       expect(mockAddToast).toHaveBeenCalledWith('error', '삭제에 실패했어요')

--- a/frontend/src/pages/__tests__/RecurringList.test.tsx
+++ b/frontend/src/pages/__tests__/RecurringList.test.tsx
@@ -560,4 +560,38 @@ describe('RecurringList', () => {
       expect(mockAddToast).toHaveBeenCalledWith('error', '저장에 실패했어요')
     })
   })
+
+  // ==================== tabular-nums ====================
+
+  it('데스크톱 테이블 금액 셀에 tabular-nums 클래스가 있다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+    )
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    // 금액이 포함된 요소 중 tabular-nums 클래스를 가진 것이 있어야 함
+    const amountCells = document.querySelectorAll('td.tabular-nums')
+    expect(amountCells.length).toBeGreaterThan(0)
+  })
+
+  it('모바일 카드 금액 span에 tabular-nums 클래스가 있다', async () => {
+    server.use(
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+      http.get('/api/categories', () => HttpResponse.json([])),
+    )
+    renderRecurringList()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+    })
+
+    // 금액 텍스트를 가진 span 중 tabular-nums 클래스를 가진 것이 있어야 함
+    const amountSpans = document.querySelectorAll('span.tabular-nums')
+    expect(amountSpans.length).toBeGreaterThan(0)
+  })
 })

--- a/frontend/src/pages/__tests__/RecurringList.test.tsx
+++ b/frontend/src/pages/__tests__/RecurringList.test.tsx
@@ -72,10 +72,17 @@ describe('RecurringList', () => {
 
   // ==================== 기본 렌더링 ====================
 
-  it('페이지 헤더에 반복 거래 타이틀을 표시한다', async () => {
+  it('페이지 헤더에 정기거래 타이틀을 표시한다', async () => {
     renderRecurringList()
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: '반복 거래' })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: '정기거래' })).toBeInTheDocument()
+    })
+  })
+
+  it('페이지 헤더에 반복 거래 라는 구 용어가 없다', async () => {
+    renderRecurringList()
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: '반복 거래' })).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -96,12 +96,18 @@ describe('SettingsPage', () => {
       expect(screen.getByText('카테고리')).toBeInTheDocument()
     })
 
+    it('정기거래 메뉴 항목이 있고 반복 거래 라는 구 용어는 없다', () => {
+      renderSettingsPage()
+      expect(screen.getByText('정기거래')).toBeInTheDocument()
+      expect(screen.queryByText('반복 거래')).not.toBeInTheDocument()
+    })
+
     it('10개 메뉴 항목을 표시한다 (약관/개인정보는 독립 메뉴에서 제거됨)', () => {
       renderSettingsPage()
       expect(screen.getByText('카테고리')).toBeInTheDocument()
       expect(screen.getByText('예산 관리')).toBeInTheDocument()
       expect(screen.getByText('결제수단')).toBeInTheDocument()
-      expect(screen.getByText('반복 거래')).toBeInTheDocument()
+      expect(screen.getByText('정기거래')).toBeInTheDocument()
       expect(screen.getByText('공유 가계부')).toBeInTheDocument()
       expect(screen.getByText('화면 모드')).toBeInTheDocument()
       expect(screen.getByText('내 계정')).toBeInTheDocument()


### PR DESCRIPTION
## Summary

더보기에서 진입하는 설정 관련 9개 페이지를 3라운드로 체계적으로 정비했습니다.

### Round 1 — 숫자/금액 포맷 통일
- **BudgetManager**: 최근 지출 표시를 `.toLocaleString()원` → `formatAmount()` 통일
- **BudgetManager / RecurringList / PaymentMethodManager**: 금액 표시 span에 `tabular-nums` 추가 (가계부 홈과 동일한 숫자 자간)

### Round 2 — UX/용어 정비
- **용어 통일**: `'반복 거래'` → `'정기거래'` (RecurringList 헤더 + SettingsPage 메뉴, #606 후속)
- **삭제 모달**: RecurringList `window.confirm()` → 커스텀 모달 (`role="dialog"`, `aria-modal` 포함)
- **뒤로가기 통일**: PaymentMethodManager `<Link to="/settings">` → `useGoBack()` 버튼
- **아이콘 통일**: HouseholdListPage 추가 버튼 텍스트 `+` → `<Plus />` 아이콘 컴포넌트

### Round 3 — 디자인 톤 통일
- **헤더 아이콘**: #614에서 이미 전체 적용됨, 변경 없음
- **스켈레톤**: PaymentMethodManager `animate-pulse + bg-warm-200` 인라인 → `Skeleton` 컴포넌트
- **빈 상태**: PaymentMethodManager 인라인 JSX → `EmptyState` 컴포넌트 (action 포함)
- **카드 border**: PaymentMethodManager `border-[var(--border-default)]` → `/60` opacity 통일

## Test plan
- [ ] 예산 관리: 최근 지출 금액 `₩0,000` 형식 (원 suffix 없음)
- [ ] 전체 금액 숫자: 자간 tabular-nums 적용으로 깔끔한 정렬
- [ ] 더보기 메뉴 + 정기거래 헤더: "정기거래" 표시
- [ ] 정기거래 삭제: 브라우저 confirm 대신 모달 표시, 취소/확인 동작
- [ ] 결제수단: 뒤로가기 버튼 동작 (히스토리 기반)
- [ ] 공유 가계부: 헤더 Plus 아이콘 표시
- [ ] 결제수단: 로딩 → 스켈레톤 카드, 빈 상태 → EmptyState 컴포넌트

🤖 Generated with [Claude Code](https://claude.com/claude-code)