### PR TITLE
fix: 건강점수 모달 3종 버그 수정 (짤림·바깥클릭·텍스트)

### DIFF
--- a/frontend/src/components/stats/FinancialHealthScore.tsx
+++ b/frontend/src/components/stats/FinancialHealthScore.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import type { FinancialScore } from '../../types'
 
 type FinancialHealthScoreProps = {
@@ -96,6 +97,14 @@ function FullScoreCard({ score }: { score: FinancialScore }) {
 function BadgeMode({ score }: { score: FinancialScore }) {
   const [open, setOpen] = useState(false)
 
+  // ESC 키로 모달 닫기
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open])
+
   return (
     <>
       <button
@@ -106,20 +115,19 @@ function BadgeMode({ score }: { score: FinancialScore }) {
         <span className="text-xs font-normal opacity-70">{score.overall}</span>
       </button>
 
-      {open && (
+      {open && createPortal(
         <>
-          {/* 배경 버튼: fixed inset-0으로 전체 화면 커버. 클릭 시 닫기 + HeroSummary 버블링 차단 */}
+          {/* 배경 오버레이: document.body에 Portal로 렌더링 → HeroSummary 버블링 완전 차단 */}
           <button
-            onClick={(e) => { e.stopPropagation(); setOpen(false) }}
-            className="fixed inset-0 z-50 bg-black/40 w-full cursor-default"
+            onClick={() => setOpen(false)}
+            className="fixed inset-0 z-50 bg-black/40 cursor-default w-full h-full"
             aria-label="모달 닫기"
           />
-          {/* 카드 컨테이너: pointer-events-none → 카드 외부 클릭은 backdrop 버튼에 전달 */}
+          {/* 카드 컨테이너: 스크롤 가능, 화면 90% 높이 제한 */}
           <div className="fixed inset-0 z-[51] flex items-end sm:items-center justify-center pointer-events-none">
-            {/* role="presentation" + onClick: 카드 클릭이 HeroSummary로 버블링되지 않도록 차단 */}
             <div
               role="presentation"
-              className="pointer-events-auto relative w-full sm:max-w-sm mx-auto p-4 pb-8"
+              className="pointer-events-auto relative w-full sm:max-w-sm mx-auto p-4 pb-8 max-h-[90vh] overflow-y-auto"
               onClick={e => e.stopPropagation()}
             >
               <div role="dialog" aria-modal="true" aria-label="가계 건강점수">
@@ -157,7 +165,8 @@ function BadgeMode({ score }: { score: FinancialScore }) {
               </div>
             </div>
           </div>
-        </>
+        </>,
+        document.body,
       )}
     </>
   )

--- a/frontend/src/components/stats/__tests__/FinancialHealthScore.test.tsx
+++ b/frontend/src/components/stats/__tests__/FinancialHealthScore.test.tsx
@@ -123,6 +123,15 @@ describe('FinancialHealthScore', () => {
       expect(screen.queryByText('가계 건강 점수')).not.toBeInTheDocument()
     })
 
+    it('ESC 키 누르면 바텀시트가 닫힌다', async () => {
+      const user = userEvent.setup()
+      render(<FinancialHealthScore score={mockScore} variant="badge" />)
+      await user.click(screen.getByRole('button'))
+      expect(screen.getByText('가계 건강 점수')).toBeInTheDocument()
+      await user.keyboard('{Escape}')
+      expect(screen.queryByText('가계 건강 점수')).not.toBeInTheDocument()
+    })
+
     it('score가 null이면 아무것도 표시하지 않는다', () => {
       const { container } = render(<FinancialHealthScore score={null} variant="badge" />)
       expect(container.firstChild).toBeNull()

--- a/frontend/src/utils/__tests__/financialScore.test.ts
+++ b/frontend/src/utils/__tests__/financialScore.test.ts
@@ -269,6 +269,31 @@ describe('calculateFinancialScore — 소비 안정성', () => {
     })
     expect(result.spendingStability).toBeNull()
   })
+
+  it('summary에 "변동계수" 같은 통계 용어가 없어야 한다', () => {
+    const result = calculateFinancialScore({
+      ...BASE_INPUT,
+      monthlyVariableExpenses: [800_000, 900_000, 850_000],
+    })
+    expect(result.breakdown.spendingStability.summary).not.toContain('변동계수')
+  })
+
+  it('변동 없음(CV≈0) → "매달 지출이 고르게 유지" 포함', () => {
+    const result = calculateFinancialScore({
+      ...BASE_INPUT,
+      monthlyVariableExpenses: [1_000_000, 1_000_000, 1_000_000],
+    })
+    expect(result.breakdown.spendingStability.summary).toContain('고르게')
+  })
+
+  it('변동 큼(CV>30%) → "들쭉날쭉" 포함', () => {
+    // 1,000,000 / 2,000,000 / 500,000 → 평균 약 1,166,666, 표준편차 큼
+    const result = calculateFinancialScore({
+      ...BASE_INPUT,
+      monthlyVariableExpenses: [500_000, 2_000_000, 500_000],
+    })
+    expect(result.breakdown.spendingStability.summary).toContain('들쭉날쭉')
+  })
 })
 
 // ── 가중치 재분배 테스트 ──

--- a/frontend/src/utils/financialScore.ts
+++ b/frontend/src/utils/financialScore.ts
@@ -50,7 +50,7 @@ function calcSavingsRate(
   const incomeWan = Math.round(incomeTotal / 10000)
   return {
     score: Math.round(score),
-    summary: `저축 ${savingsWan}만원 / 수입 ${incomeWan}만원 = ${ratio.toFixed(1)}%`,
+    summary: `수입 ${incomeWan}만원 중 ${savingsWan}만원을 저축했어요 (${ratio.toFixed(1)}%)`,
   }
 }
 
@@ -115,18 +115,18 @@ function calcBudgetAdherence(
   const spentWan = Math.round(budgetSpent / 10000)
 
   let paceText: string
-  if (paceRatio <= 0.9) paceText = '여유'
-  else if (paceRatio <= 1.1) paceText = '적정'
-  else if (paceRatio <= 1.3) paceText = '다소 빠름'
-  else paceText = '주의 필요'
+  if (paceRatio <= 0.9) paceText = '여유로워요'
+  else if (paceRatio <= 1.1) paceText = '적당해요'
+  else if (paceRatio <= 1.3) paceText = '조금 빠른 편이에요'
+  else paceText = '주의가 필요해요'
 
   const detail = isCurrentMonth
-    ? `⏱ 월 ${dayOfMonth}일차 기준 페이스 ${paceText}`
-    : `⏱ ${targetMonth}월 전체 기준`
+    ? `${dayOfMonth}일 기준, 지출 속도가 ${paceText}`
+    : `${targetMonth}월 전체 기준`
 
   return {
     score: Math.round(finalScore),
-    summary: `예산 ${budgetWan}만원 중 ${spentWan}만원 사용 (${usagePct}%)`,
+    summary: `이번 달 예산의 ${usagePct}%를 썼어요 (${spentWan}만원 / ${budgetWan}만원)`,
     detail,
   }
 }
@@ -152,7 +152,7 @@ function calcFixedExpenseRatio(
   const incomeWan = Math.round(incomeTotal / 10000)
   return {
     score: Math.round(score),
-    summary: `고정비 ${recurringWan}만원 / 수입 ${incomeWan}만원 = ${ratio.toFixed(1)}%`,
+    summary: `매달 ${recurringWan}만원씩 고정 지출이 나가요 (수입 ${incomeWan}만원의 ${ratio.toFixed(1)}%)`,
   }
 }
 
@@ -183,9 +183,18 @@ function calcSpendingStability(
   else if (cv <= 50) score = 30 + ((50 - cv) / 20) * 30
   else score = Math.max(0, 30 - ((cv - 50) / 50) * 30)
 
+  let stabilityMsg: string
+  if (cv <= 15) {
+    stabilityMsg = '매달 지출이 고르게 유지되고 있어요'
+  } else if (cv <= 30) {
+    stabilityMsg = '지출이 매달 조금씩 다르게 나와요'
+  } else {
+    stabilityMsg = '지출 패턴이 들쭉날쭉한 편이에요'
+  }
+
   return {
     score: Math.round(score),
-    summary: `최근 3개월 변동 지출 변동계수 ${cv.toFixed(1)}%`,
+    summary: stabilityMsg,
   }
 }
 


### PR DESCRIPTION
## Summary

모아보기 건강점수 배지 클릭 시 열리는 모달의 버그 3개를 수정합니다.

- **모달 짤림** - max-h-[90vh] overflow-y-auto 추가, 콘텐츠 길어도 화면 안에서 스크롤
- **바깥 클릭으로 안 닫힘** - createPortal로 document.body에 렌더링, HeroSummary 이벤트 버블링 완전 차단
- **ESC 닫기** - useEffect document 레벨 keydown 리스너로 구현
- **비친화적 텍스트** - 통계 용어(변동계수) 제거, 일반 사용자가 이해할 수 있는 자연어로 전면 개선

## Test plan

- [x] 바깥 클릭(오버레이) 시 모달 닫힘 - 기존 테스트 통과
- [x] ESC 키 닫기 - 신규 테스트 추가 및 통과
- [x] X 버튼 닫기 - 기존 테스트 통과
- [x] 소비 안정성 summary 변동계수 미포함 - 신규 테스트 추가
- [x] CV 구간별 메시지 분기 - 신규 테스트 2개 추가
- [x] 전체 테스트 127파일 1613개 통과

Generated with Claude Code