### PR TITLE
feat: 모아보기 카드 UX 개선 — SectionHeader 통일, 수입 구성 카드, TrendBarChart

### DIFF
--- a/frontend/src/components/stats/BudgetVsActual.tsx
+++ b/frontend/src/components/stats/BudgetVsActual.tsx
@@ -1,111 +1,123 @@
 /**
  * @file BudgetVsActual.tsx
- * @description 월간 예산 대비 지출 상황 — props 방식 (데이터는 InsightsPage에서 주입)
+ * @description 월간 예산 대비 지출 상황 — 접기/펼치기 구조
+ * 접힌 상태: 총예산/총지출 오버뷰 + 단일 프로그레스바 + 초과 배지
+ * 펼친 상태: 전체 카테고리 목록
  */
 
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { ChevronDown, ChevronUp } from 'lucide-react'
 import type { BudgetMonthlyStatsResponse } from '../../types'
 import { formatAmount } from '../../utils/format'
+import SectionHeader from './SectionHeader'
 
 interface BudgetVsActualProps {
   budgetStats: BudgetMonthlyStatsResponse | null
-  maxItems?: number
   monthStr?: string
 }
 
-export default function BudgetVsActual({ budgetStats, maxItems = 5, monthStr }: BudgetVsActualProps) {
+export default function BudgetVsActual({ budgetStats, monthStr }: BudgetVsActualProps) {
   const [expanded, setExpanded] = useState(false)
 
   if (!budgetStats || budgetStats.categories.length === 0) return null
 
-  const totalBudget = budgetStats.total_budget
-  const totalSpent = budgetStats.total_spent
-  const totalUsage = totalBudget && totalBudget > 0 ? (totalSpent / totalBudget) * 100 : null
-
-  const hasMore = budgetStats.categories.length > maxItems
-  const visible = expanded ? budgetStats.categories : budgetStats.categories.slice(0, maxItems)
+  const { total_budget, total_spent, categories } = budgetStats
+  const totalUsage = total_budget && total_budget > 0 ? (total_spent / total_budget) * 100 : null
+  const exceededCount = categories.filter(c => c.is_exceeded).length
 
   return (
-    <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6" data-testid="budget-vs-actual">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-semibold text-[var(--text-primary)]">💰 예산 상황</h2>
-        <Link to="/budgets" className="text-xs text-grape-600 hover:text-grape-700 transition-colors">
-          관리
-        </Link>
-      </div>
+    <div
+      className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6"
+      data-testid="budget-vs-actual"
+    >
+      <SectionHeader
+        icon="💰"
+        title="예산 상황"
+        manageTo="/budgets"
+        expanded={expanded}
+        onToggle={() => setExpanded(p => !p)}
+      />
 
-      {totalBudget != null && (
-        <div className="mb-4 p-3 bg-[var(--surface-elevated)] rounded-xl">
-          <div className="flex justify-between items-center mb-2">
-            <span className="text-sm text-[var(--text-secondary)]">이번 달 총 예산</span>
-            <span className="text-sm font-semibold text-[var(--text-primary)]">{formatAmount(totalBudget)}</span>
-          </div>
-          <div className="flex justify-between items-center mb-2">
-            <span className="text-sm text-[var(--text-secondary)]">총 지출</span>
-            <span className={`text-sm font-semibold ${totalSpent > totalBudget ? 'text-red-600' : 'text-[var(--text-primary)]'}`}>
-              {formatAmount(totalSpent)}
-            </span>
-          </div>
-          {totalUsage != null && (
-            <div>
+      {/* 오버뷰: 총예산/총지출 + 프로그레스바 */}
+      <div className="mt-3">
+        {total_budget != null && total_budget > 0 ? (
+          <>
+            <div className="flex justify-between items-center mb-1.5">
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-[var(--text-secondary)]">
+                  {formatAmount(total_spent)}
+                  <span className="text-[var(--text-muted)]"> / {formatAmount(total_budget)}</span>
+                </span>
+                {exceededCount > 0 && (
+                  <span className="text-xs px-1.5 py-0.5 bg-red-100 text-red-600 rounded-full">
+                    ⚠ {exceededCount}개 초과
+                  </span>
+                )}
+              </div>
+              {totalUsage != null && (
+                <span className="text-xs text-[var(--text-muted)]">{totalUsage.toFixed(1)}%</span>
+              )}
+            </div>
+            {totalUsage != null && (
               <div className="w-full h-1.5 rounded-full overflow-hidden bg-[var(--border-default)]">
                 <div
-                  className={`h-1.5 rounded-full transition-all ${totalUsage > 100 ? 'bg-red-500' : totalUsage >= 80 ? 'bg-amber-500' : 'bg-grape-500'}`}
+                  className={`h-1.5 rounded-full transition-all ${
+                    totalUsage > 100 ? 'bg-red-500' : totalUsage >= 80 ? 'bg-amber-500' : 'bg-grape-500'
+                  }`}
                   style={{ width: `${Math.min(totalUsage, 100)}%` }}
                 />
               </div>
-              <p className="text-xs text-[var(--text-tertiary)] mt-1 text-right">{totalUsage.toFixed(1)}% 사용</p>
-            </div>
-          )}
-        </div>
-      )}
-
-      <div className="space-y-3">
-        {visible.map((cat) => (
-          <div key={cat.category_name}>
-            <div className="flex justify-between items-center mb-1">
-              <div className="flex items-center gap-2">
-                <Link
-                  to={monthStr ? `/?month=${monthStr}&category=${cat.category_name}` : `/?category=${cat.category_name}`}
-                  className="text-sm font-medium text-[var(--text-primary)] hover:text-grape-600 transition-colors"
-                >
-                  {cat.category_name}
-                </Link>
-                {cat.is_exceeded && (
-                  <span className="text-xs px-1.5 py-0.5 bg-red-100 text-red-600 rounded-full">초과</span>
-                )}
-              </div>
-              <div className="text-right">
-                <span className={`text-sm font-semibold ${cat.is_exceeded ? 'text-red-600' : 'text-[var(--text-primary)]'}`}>
-                  {formatAmount(cat.spent_amount)}
-                </span>
-                <span className="text-xs text-[var(--text-muted)]"> / {formatAmount(cat.budget_amount)}</span>
-              </div>
-            </div>
-            <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
-              <div
-                className={`h-1.5 rounded-full transition-all ${cat.is_exceeded ? 'bg-red-500' : cat.usage_percentage >= 80 ? 'bg-amber-500' : 'bg-grape-500'}`}
-                style={{ width: `${Math.min(cat.usage_percentage, 100)}%` }}
-              />
-            </div>
-            <p className="text-xs text-[var(--text-muted)] mt-0.5 text-right">{cat.usage_percentage.toFixed(1)}%</p>
+            )}
+          </>
+        ) : (
+          <div className="py-2">
+            <p className="text-sm text-[var(--text-muted)]">예산이 설정되지 않았습니다</p>
+            <Link
+              to="/budgets"
+              className="text-xs text-grape-600 hover:text-grape-700 font-medium mt-1 inline-block"
+            >
+              설정하기 →
+            </Link>
           </div>
-        ))}
+        )}
       </div>
 
-      {hasMore && (
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="flex items-center justify-center gap-1 w-full mt-3 py-1.5 text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
-        >
-          {expanded ? (
-            <>접기 <ChevronUp className="w-3.5 h-3.5" /></>
-          ) : (
-            <>더보기 ({budgetStats.categories.length - maxItems}) <ChevronDown className="w-3.5 h-3.5" /></>
-          )}
-        </button>
+      {/* 펼침: 전체 카테고리 목록 */}
+      {expanded && (
+        <div className="mt-4 space-y-3">
+          {categories.map((cat) => (
+            <div key={cat.category_name}>
+              <div className="flex justify-between items-center mb-1">
+                <div className="flex items-center gap-2">
+                  <Link
+                    to={monthStr ? `/?month=${monthStr}&category=${cat.category_name}` : `/?category=${cat.category_name}`}
+                    className="text-sm font-medium text-[var(--text-primary)] hover:text-grape-600 transition-colors"
+                  >
+                    {cat.category_name}
+                  </Link>
+                  {cat.is_exceeded && (
+                    <span className="text-xs px-1.5 py-0.5 bg-red-100 text-red-600 rounded-full">초과</span>
+                  )}
+                </div>
+                <div className="text-right">
+                  <span className={`text-sm font-semibold ${cat.is_exceeded ? 'text-red-600' : 'text-[var(--text-primary)]'}`}>
+                    {formatAmount(cat.spent_amount)}
+                  </span>
+                  <span className="text-xs text-[var(--text-muted)]"> / {formatAmount(cat.budget_amount)}</span>
+                </div>
+              </div>
+              <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
+                <div
+                  className={`h-1.5 rounded-full transition-all ${
+                    cat.is_exceeded ? 'bg-red-500' : cat.usage_percentage >= 80 ? 'bg-amber-500' : 'bg-grape-500'
+                  }`}
+                  style={{ width: `${Math.min(cat.usage_percentage, 100)}%` }}
+                />
+              </div>
+              <p className="text-xs text-[var(--text-muted)] mt-0.5 text-right">{cat.usage_percentage.toFixed(1)}%</p>
+            </div>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/frontend/src/components/stats/CardUsageSummary.tsx
+++ b/frontend/src/components/stats/CardUsageSummary.tsx
@@ -1,69 +1,111 @@
 /**
  * @file CardUsageSummary.tsx
  * @description 결제수단(카드) 실적 요약 섹션 (#305)
- * monthly_target이 있는 결제수단만 프로그레스 바로 표시한다.
- * BudgetVsActual과 유사한 스타일을 사용한다.
+ * monthly_target이 있는 결제수단만 표시한다.
+ * 기본 접힘 상태에서 달성/진행 오버뷰를 보여주고, 펼치면 카드별 상세 프로그레스를 표시한다.
  */
 
-import { Link } from 'react-router-dom'
+import { useState } from 'react'
 import { formatAmount } from '../../utils/format'
 import type { PaymentMethodUsage } from '../../types'
+import SectionHeader from './SectionHeader'
 
 interface CardUsageSummaryProps {
   usage: PaymentMethodUsage[]
 }
 
+// 접힌 상태에서 표시하는 오버뷰 (달성/진행 현황)
+function UsageOverview({ targetUsage }: { targetUsage: PaymentMethodUsage[] }) {
+  const achievedCount = targetUsage.filter(u => (u.usage_percentage ?? 0) >= 100).length
+  const inProgressCount = targetUsage.length - achievedCount
+
+  // 카드가 1개일 때: 카드 이름 + 달성률 표시, 달성 건수도 함께 표시
+  if (targetUsage.length === 1) {
+    const item = targetUsage[0]
+    const pct = item.usage_percentage ?? 0
+    const achieved = pct >= 100
+    return (
+      <p className="text-sm text-[var(--text-secondary)] mt-2">
+        {item.name}{' '}
+        <span className={achieved ? 'text-leaf-600 font-medium' : ''}>{pct.toFixed(1)}%</span>
+        {achieved
+          ? <span className="text-leaf-600"> · 달성 1개</span>
+          : item.remaining != null
+            ? ` · 잔여 ${formatAmount(item.remaining)}`
+            : null}
+      </p>
+    )
+  }
+
+  return (
+    <p className="text-sm text-[var(--text-secondary)] mt-2">
+      {achievedCount > 0 && <span className="text-leaf-600">달성 {achievedCount}개</span>}
+      {achievedCount > 0 && inProgressCount > 0 && ' · '}
+      {inProgressCount > 0 && `진행 중 ${inProgressCount}개`}
+    </p>
+  )
+}
+
 export default function CardUsageSummary({ usage }: CardUsageSummaryProps) {
+  const [expanded, setExpanded] = useState(false)
   // monthly_target이 있는 항목만 표시
   const targetUsage = usage.filter((u) => u.monthly_target != null)
 
   if (targetUsage.length === 0) return null
 
   return (
-    <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6" data-testid="card-usage-summary">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-semibold text-[var(--text-primary)]">💳 카드 실적</h2>
-        <Link to="/payment-methods" className="text-xs text-grape-600 hover:text-grape-700 transition-colors">
-          관리
-        </Link>
-      </div>
+    <div
+      className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6"
+      data-testid="card-usage-summary"
+    >
+      <SectionHeader
+        icon="💳"
+        title="카드 실적"
+        manageTo="/payment-methods"
+        expanded={expanded}
+        onToggle={() => setExpanded(p => !p)}
+      />
 
-      <div className="space-y-3">
-        {targetUsage.map((item) => {
-          const pct = item.usage_percentage ?? 0
-          return (
-            <div key={item.id}>
-              <div className="flex justify-between items-center mb-1">
-                <span className="text-sm font-medium text-[var(--text-primary)]">{item.name}</span>
-                <div className="text-right">
-                  <span className={`text-sm font-semibold ${pct >= 100 ? 'text-leaf-600' : 'text-[var(--text-primary)]'}`}>
-                    {formatAmount(item.spent_amount)}
-                  </span>
-                  <span className="text-xs text-[var(--text-muted)]"> / {formatAmount(item.monthly_target!)}</span>
+      {/* 접힌 오버뷰 */}
+      {!expanded && <UsageOverview targetUsage={targetUsage} />}
+
+      {/* 펼침: 카드별 상세 */}
+      {expanded && (
+        <div className="mt-4 space-y-3">
+          {targetUsage.map((item) => {
+            const pct = item.usage_percentage ?? 0
+            return (
+              <div key={item.id}>
+                <div className="flex justify-between items-center mb-1">
+                  <span className="text-sm font-medium text-[var(--text-primary)]">{item.name}</span>
+                  <div className="text-right">
+                    <span className={`text-sm font-semibold ${pct >= 100 ? 'text-leaf-600' : 'text-[var(--text-primary)]'}`}>
+                      {formatAmount(item.spent_amount)}
+                    </span>
+                    <span className="text-xs text-[var(--text-muted)]"> / {formatAmount(item.monthly_target!)}</span>
+                  </div>
+                </div>
+                <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
+                  <div
+                    className={`h-1.5 rounded-full transition-all ${
+                      pct >= 100 ? 'bg-leaf-500' : pct >= 80 ? 'bg-grape-500' : 'bg-grape-400'
+                    }`}
+                    style={{ width: `${Math.min(pct, 100)}%` }}
+                  />
+                </div>
+                <div className="flex justify-between items-center mt-0.5">
+                  <span className="text-xs text-[var(--text-muted)]">{pct.toFixed(1)}%</span>
+                  {item.remaining != null && (
+                    <span className={`text-xs ${pct >= 100 ? 'text-leaf-600 font-medium' : 'text-[var(--text-muted)]'}`}>
+                      {pct >= 100 ? '✅ 실적 달성' : `잔여 ${formatAmount(item.remaining)}`}
+                    </span>
+                  )}
                 </div>
               </div>
-              <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
-                <div
-                  className={`h-1.5 rounded-full transition-all ${
-                    pct >= 100 ? 'bg-leaf-500' : pct >= 80 ? 'bg-grape-500' : 'bg-grape-400'
-                  }`}
-                  style={{ width: `${Math.min(pct, 100)}%` }}
-                />
-              </div>
-              <div className="flex justify-between items-center mt-0.5">
-                <span className="text-xs text-[var(--text-muted)]">
-                  {pct.toFixed(1)}%
-                </span>
-                {item.remaining != null && (
-                  <span className={`text-xs ${pct >= 100 ? 'text-leaf-600 font-medium' : 'text-[var(--text-muted)]'}`}>
-                    {pct >= 100 ? '✅ 실적 달성' : `잔여 ${formatAmount(item.remaining)}`}
-                  </span>
-                )}
-              </div>
-            </div>
-          )
-        })}
-      </div>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/stats/CardUsageSummary.tsx
+++ b/frontend/src/components/stats/CardUsageSummary.tsx
@@ -29,7 +29,7 @@ function UsageOverview({ targetUsage }: { targetUsage: PaymentMethodUsage[] }) {
         {item.name}{' '}
         <span className={achieved ? 'text-leaf-600 font-medium' : ''}>{pct.toFixed(1)}%</span>
         {achieved
-          ? <span className="text-leaf-600"> · 달성 1개</span>
+          ? ' · ✅ 실적 달성'
           : item.remaining != null
             ? ` · 잔여 ${formatAmount(item.remaining)}`
             : null}

--- a/frontend/src/components/stats/MonthlyComparison.tsx
+++ b/frontend/src/components/stats/MonthlyComparison.tsx
@@ -47,9 +47,10 @@ function TrendBarChart({
             tickLine={false}
           />
           <Tooltip
-            formatter={(value: number, name: string) => [
-              `${Math.round(value / 10000).toLocaleString()}만원`,
-              name,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            formatter={(value: any, name: any) => [
+              `${Math.round(Number(value) / 10000).toLocaleString()}만원`,
+              name as string,
             ]}
           />
           <Bar dataKey="수입" fill="#4ade80" radius={[2, 2, 0, 0]} />

--- a/frontend/src/components/stats/MonthlyComparison.tsx
+++ b/frontend/src/components/stats/MonthlyComparison.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { ChevronDown, ChevronUp } from 'lucide-react'
-import { LineChart, Line } from 'recharts'
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts'
 import type { ComparisonResponse, PeriodTotal } from '../../types'
+import SectionHeader from './SectionHeader'
 
 type MonthlyComparisonProps = {
   expenseComparison: ComparisonResponse | null
@@ -11,15 +11,59 @@ type MonthlyComparisonProps = {
   savingsRatePrevious?: number
 }
 
-/** 스파크라인 — 높이 24px, 너비 64px, 축 없음 */
-function Sparkline({ data }: { data: PeriodTotal[] }) {
-  if (data.length < 2) return null
-  const chartData = data.map(d => ({ value: d.total }))
+/** 3개월 트렌드 BarChart — 수입/지출 비교 막대 */
+function TrendBarChart({
+  expenseTrend,
+  incomeTrend,
+}: {
+  expenseTrend: PeriodTotal[]
+  incomeTrend: PeriodTotal[]
+}) {
+  if (expenseTrend.length < 2) {
+    return (
+      <p className="text-sm text-[var(--text-tertiary)] py-4 text-center">
+        비교할 이전 데이터가 없습니다
+      </p>
+    )
+  }
+
+  const incomeMap = new Map(incomeTrend.map(d => [d.label, d.total]))
+  const chartData = expenseTrend.map(d => ({
+    name: d.label,
+    수입: incomeMap.get(d.label) ?? 0,
+    지출: d.total,
+  }))
+
   return (
-    <div data-testid="sparkline">
-      <LineChart width={64} height={24} data={chartData}>
-        <Line type="monotone" dataKey="value" stroke="currentColor" strokeWidth={1.5} dot={false} />
-      </LineChart>
+    <div data-testid="trend-bar-chart">
+      <ResponsiveContainer width="100%" height={120}>
+        <BarChart data={chartData} barCategoryGap="30%">
+          <XAxis dataKey="name" tick={{ fontSize: 11 }} axisLine={false} tickLine={false} />
+          <YAxis
+            tickFormatter={(v) => `${Math.round(v / 10000)}만`}
+            tick={{ fontSize: 10 }}
+            width={32}
+            axisLine={false}
+            tickLine={false}
+          />
+          <Tooltip
+            formatter={(value: number, name: string) => [
+              `${Math.round(value / 10000).toLocaleString()}만원`,
+              name,
+            ]}
+          />
+          <Bar dataKey="수입" fill="#4ade80" radius={[2, 2, 0, 0]} />
+          <Bar dataKey="지출" fill="#a855f7" radius={[2, 2, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+      <div className="flex justify-center gap-4 mt-1">
+        <span className="flex items-center gap-1 text-xs text-[var(--text-muted)]">
+          <span className="w-2 h-2 rounded-full bg-leaf-400" /> 수입
+        </span>
+        <span className="flex items-center gap-1 text-xs text-[var(--text-muted)]">
+          <span className="w-2 h-2 rounded-full bg-grape-500" /> 지출
+        </span>
+      </div>
     </div>
   )
 }
@@ -43,11 +87,9 @@ type ComparisonRowProps = {
   changeAmount: number
   /** true = 증가가 긍정(수입/저축률), false = 감소가 긍정(지출) */
   positiveIsGreen: boolean
-  trend: PeriodTotal[]
-  showTrend: boolean
 }
 
-function ComparisonRow({ label, current, previous, changeAmount, positiveIsGreen, trend, showTrend }: ComparisonRowProps) {
+function ComparisonRow({ label, current, previous, changeAmount, positiveIsGreen }: ComparisonRowProps) {
   const isPositive = changeAmount > 0
   const isGood = positiveIsGreen ? isPositive : !isPositive
   const changeColor =
@@ -67,12 +109,6 @@ function ComparisonRow({ label, current, previous, changeAmount, positiveIsGreen
         <span className="text-sm font-semibold tabular-nums text-[var(--text-primary)]">{formatCompact(current)}</span>
         <span className={`text-xs tabular-nums ml-1 ${changeColor}`}>{formatChange(changeAmount)}</span>
       </div>
-      {/* 스파크라인: 펼쳐진 상태에서만 */}
-      {showTrend && trend.length >= 2 && (
-        <div className={`${changeColor} opacity-70 shrink-0`}>
-          <Sparkline data={trend} />
-        </div>
-      )}
     </div>
   )
 }
@@ -127,18 +163,13 @@ export default function MonthlyComparison({
       className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6"
     >
       {/* 헤더 */}
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-semibold text-[var(--text-primary)]">📊 지난달과 비교</h2>
-        <button
-          onClick={() => setExpanded(prev => !prev)}
-          className="flex items-center gap-0.5 text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
-          aria-label={expanded ? '접기' : '펼치기'}
-        >
-          {expanded
-            ? <><ChevronUp className="w-3.5 h-3.5" /> 접기</>
-            : <><ChevronDown className="w-3.5 h-3.5" /> 펼치기</>
-          }
-        </button>
+      <div className="mb-4">
+        <SectionHeader
+          icon="📊"
+          title="지난달과 비교"
+          expanded={expanded}
+          onToggle={() => setExpanded(prev => !prev)}
+        />
       </div>
 
       {/* 2열 비교 행 */}
@@ -150,8 +181,6 @@ export default function MonthlyComparison({
             previous={incomeComparison.previous.total}
             changeAmount={incomeComparison.change.amount}
             positiveIsGreen={true}
-            trend={incomeComparison.trend}
-            showTrend={expanded}
           />
         )}
         {expenseComparison && (
@@ -161,8 +190,6 @@ export default function MonthlyComparison({
             previous={expenseComparison.previous.total}
             changeAmount={expenseComparison.change.amount}
             positiveIsGreen={false}
-            trend={expenseComparison.trend}
-            showTrend={expanded}
           />
         )}
         {savingsRateCurrent !== undefined && savingsRateChange !== null && savingsRatePrevious !== undefined && (
@@ -174,35 +201,58 @@ export default function MonthlyComparison({
         )}
       </div>
 
-      {/* 펼친 상태: 카테고리 변화 TOP3 + 스파크라인 */}
-      {expanded && topCategoryChanges.length > 0 && (
-        <div className="mt-4 pt-3 border-t border-[var(--border-default)]">
-          <p className="text-xs font-medium text-[var(--text-tertiary)] mb-2">
-            카테고리 변화 TOP {topCategoryChanges.length}
-          </p>
-          <div className="space-y-1.5">
-            {topCategoryChanges.map(c => {
-              const isIncrease = (c.change_percentage ?? 0) > 0
-              return (
-                <div key={c.category} className="flex items-center justify-between text-sm">
-                  <div className="flex items-center gap-1.5">
-                    <span>{isIncrease ? '🔺' : '🔻'}</span>
-                    <span className="text-[var(--text-primary)]">{c.category}</span>
-                  </div>
-                  <div className="flex items-center gap-2 tabular-nums">
-                    <span className={isIncrease ? 'text-red-600' : 'text-leaf-600'}>
-                      {isIncrease ? '+' : ''}
-                      {c.change_percentage?.toFixed(0)}%
-                    </span>
-                    <span className="text-xs text-[var(--text-tertiary)]">
-                      ({formatChange(c.change_amount)})
-                    </span>
-                  </div>
-                </div>
-              )
-            })}
+      {/* 펼친 상태: TrendBarChart + 카테고리 변화 TOP3 */}
+      {expanded && (
+        <>
+          {/* 3개월 트렌드 BarChart */}
+          <div className="mt-4 pt-3 border-t border-[var(--border-default)]">
+            <TrendBarChart
+              expenseTrend={expenseComparison?.trend ?? []}
+              incomeTrend={incomeComparison?.trend ?? []}
+            />
           </div>
-        </div>
+
+          {/* 카테고리 변화 TOP3 with 미니 horizontal bar */}
+          {topCategoryChanges.length > 0 && (
+            <div className="mt-4 pt-3 border-t border-[var(--border-default)]">
+              <p className="text-xs font-medium text-[var(--text-tertiary)] mb-2">
+                카테고리 변화 TOP {topCategoryChanges.length}
+              </p>
+              <div className="space-y-2">
+                {topCategoryChanges.map(c => {
+                  const isIncrease = (c.change_percentage ?? 0) > 0
+                  const maxPct = Math.max(...topCategoryChanges.map(x => Math.abs(x.change_percentage ?? 0)))
+                  const barWidth = maxPct > 0 ? (Math.abs(c.change_percentage ?? 0) / maxPct) * 100 : 0
+                  return (
+                    <div key={c.category} className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <div className="flex items-center gap-1.5">
+                          <span>{isIncrease ? '🔺' : '🔻'}</span>
+                          <span className="text-[var(--text-primary)]">{c.category}</span>
+                        </div>
+                        <div className="flex items-center gap-2 tabular-nums">
+                          <span className={isIncrease ? 'text-red-600' : 'text-leaf-600'}>
+                            {isIncrease ? '+' : ''}{c.change_percentage?.toFixed(0)}%
+                          </span>
+                          <span className="text-xs text-[var(--text-tertiary)]">
+                            ({formatChange(c.change_amount)})
+                          </span>
+                        </div>
+                      </div>
+                      {/* 미니 horizontal bar */}
+                      <div className="h-1 rounded-full bg-[var(--border-default)] overflow-hidden">
+                        <div
+                          className={`h-full rounded-full ${isIncrease ? 'bg-red-400' : 'bg-leaf-400'} transition-all`}
+                          style={{ width: `${barWidth}%` }}
+                        />
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/stats/RecurringManageSection.tsx
+++ b/frontend/src/components/stats/RecurringManageSection.tsx
@@ -9,7 +9,7 @@
 
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import SectionHeader from './SectionHeader'
 import { formatAmount } from '../../utils/format'
 import type { RecurringTransaction } from '../../types'
 
@@ -112,13 +112,8 @@ export default function RecurringManageSection({ items, monthStr, executedAmount
   if (items.length === 0) {
     return (
       <div id="section-recurring" className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">🔄 정기거래</h2>
-          <Link to="/recurring" className="text-xs text-grape-600 hover:text-grape-700 transition-colors">
-            관리
-          </Link>
-        </div>
-        <p className="text-sm text-[var(--text-muted)] text-center py-2">
+        <SectionHeader icon="🔄" title="정기거래" manageTo="/recurring" expanded={false} collapsible={false} />
+        <p className="text-sm text-[var(--text-muted)] text-center py-2 mt-3">
           정기거래를 등록하면 고정비 현황을 볼 수 있어요
         </p>
         <div className="text-center mt-2">
@@ -135,28 +130,30 @@ export default function RecurringManageSection({ items, monthStr, executedAmount
 
   return (
     <div id="section-recurring" className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6">
-      {/* 헤더: 타이틀 + 고정비 총액 강조 */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-base font-semibold text-[var(--text-primary)]">🔄 정기거래</h2>
-          {monthlyExpenseTotal > 0 && (
-            <p className="text-xs text-[var(--text-muted)] leading-tight">
-              이번 달 고정비{' '}
-              <span className="font-medium text-[var(--text-secondary)]">{formatAmount(monthlyExpenseTotal)}</span>
-            </p>
-          )}
-        </div>
-        <Link to="/recurring" className="text-xs text-grape-600 hover:text-grape-700 transition-colors">
-          관리
-        </Link>
-      </div>
+      {/* 헤더: 타이틀 + chevron 토글 + 고정비 총액 서브텍스트 */}
+      <SectionHeader
+        icon="🔄"
+        title="정기거래"
+        manageTo="/recurring"
+        expanded={expanded}
+        onToggle={() => setExpanded(prev => !prev)}
+      >
+        {monthlyExpenseTotal > 0 && (
+          <p className="text-xs text-[var(--text-muted)] mt-0.5 leading-tight">
+            이번 달 고정비{' '}
+            <span className="font-medium text-[var(--text-secondary)]">{formatAmount(monthlyExpenseTotal)}</span>
+          </p>
+        )}
+      </SectionHeader>
 
       {/* 접힌 상태: 상태 칩 오버뷰 */}
       {!expanded && (
-        <OverviewChips items={items} monthStr={monthStr} executedAmountMap={executedAmountMap} />
+        <div className="mt-2">
+          <OverviewChips items={items} monthStr={monthStr} executedAmountMap={executedAmountMap} />
+        </div>
       )}
 
-      {/* 목록 (아코디언) */}
+      {/* 펼침: 항목별 상세 목록 (기존 렌더 로직 유지) */}
       {expanded && (
         <div className="mt-3">
           {items.map((item, idx) => {
@@ -203,26 +200,6 @@ export default function RecurringManageSection({ items, monthStr, executedAmount
           })}
         </div>
       )}
-
-      {/* 요약 푸터 + 접기/펼치기 */}
-      <div className={`flex items-center justify-between pt-2 mt-2 ${expanded ? 'border-t border-[var(--border-default)]' : ''}`}>
-        <p className="text-xs text-[var(--text-muted)]">
-          활성 {items.length}건
-          {monthlyExpenseTotal > 0 && (
-            <> · 이번 달 지출 <span className="font-medium text-[var(--text-secondary)]">{formatAmount(monthlyExpenseTotal)}</span></>
-          )}
-        </p>
-        <button
-          onClick={() => setExpanded(prev => !prev)}
-          className="flex items-center gap-0.5 text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
-          aria-label={expanded ? '접기' : '펼치기'}
-        >
-          {expanded
-            ? <><ChevronUp className="w-3.5 h-3.5" /> 접기</>
-            : <><ChevronDown className="w-3.5 h-3.5" /> 펼치기</>
-          }
-        </button>
-      </div>
     </div>
   )
 }

--- a/frontend/src/components/stats/SavingsSection.tsx
+++ b/frontend/src/components/stats/SavingsSection.tsx
@@ -1,50 +1,164 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { formatAmount } from '../../utils/format'
 import type { CategoryAmount } from '../../types'
+import SectionHeader from './SectionHeader'
 
 type SavingsSectionProps = {
   savingsTotal: number | undefined      // undefined = is_savings 미설정
   incomeTotal: number
   savingsCategories: CategoryAmount[]   // is_savings=true 카테고리만 필터링된 목록
+  recurringTotal?: number               // 고정비(정기거래 지출 합계), 미전달 시 0
+  expenseTotal?: number                 // 총지출, 미전달 시 0
 }
 
-export default function SavingsSection({ savingsTotal, incomeTotal, savingsCategories }: SavingsSectionProps) {
+/** 수입 배분 stacked bar (순수 CSS flex 비율) */
+function IncomeFlowBar({
+  savingsPct,
+  fixedPct,
+  variablePct,
+  remainingPct,
+  incomeTotal,
+}: {
+  savingsPct: number
+  fixedPct: number
+  variablePct: number
+  remainingPct: number
+  incomeTotal: number
+}) {
+  const isOverspent = remainingPct < 0
+
+  if (isOverspent) {
+    const total = savingsPct + fixedPct + variablePct || 1
+    return (
+      <div data-testid="income-flow-bar" className="space-y-1">
+        <div className="flex h-2 rounded-full overflow-hidden w-full">
+          <div className="bg-leaf-500 transition-all" style={{ width: `${(savingsPct / total) * 100}%` }} />
+          <div className="bg-warm-400 transition-all" style={{ width: `${(fixedPct / total) * 100}%` }} />
+          <div className="bg-grape-400 transition-all" style={{ width: `${(variablePct / total) * 100}%` }} />
+        </div>
+        <p className="text-xs text-red-600 text-right">
+          초과 {formatAmount(Math.abs(Math.round((remainingPct / 100) * incomeTotal)))}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div data-testid="income-flow-bar" className="flex h-2 rounded-full overflow-hidden w-full">
+      <div className="bg-leaf-500 transition-all" style={{ width: `${savingsPct}%` }} />
+      <div className="bg-warm-400 transition-all" style={{ width: `${fixedPct}%` }} />
+      <div className="bg-grape-400 transition-all" style={{ width: `${variablePct}%` }} />
+      <div className="bg-[var(--border-default)] transition-all" style={{ width: `${remainingPct}%` }} />
+    </div>
+  )
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="flex items-center gap-1 text-xs text-[var(--text-muted)]">
+      <span className={`w-2 h-2 rounded-full ${color}`} />
+      {label}
+    </span>
+  )
+}
+
+export default function SavingsSection({
+  savingsTotal,
+  incomeTotal,
+  savingsCategories,
+  recurringTotal = 0,
+  expenseTotal = 0,
+}: SavingsSectionProps) {
   // 카테고리와 총액이 모두 있어야 유효한 데이터로 판단
   const hasData = savingsCategories.length > 0 && savingsTotal !== undefined
+  // 카테고리 2개 이상이면 접기/펼치기 가능, 1개 이하면 항상 펼침
+  const collapsible = savingsCategories.length >= 2
+  const [expanded, setExpanded] = useState(false)
+
+  const showBar = incomeTotal > 0 && savingsTotal !== undefined
+  const savingsPct = showBar ? (savingsTotal / incomeTotal) * 100 : 0
+  const fixedPct = showBar ? (recurringTotal / incomeTotal) * 100 : 0
+  const rawVariablePct = showBar ? ((expenseTotal - savingsTotal - recurringTotal) / incomeTotal) * 100 : 0
+  const variablePct = Math.max(0, rawVariablePct)
+  const remainingPct = showBar ? ((incomeTotal - expenseTotal) / incomeTotal) * 100 : 0
+  const savingsRate = incomeTotal > 0 && savingsTotal !== undefined
+    ? (savingsTotal / incomeTotal) * 100
+    : undefined
 
   return (
     <div id="section-savings" className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6">
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="text-base font-semibold text-[var(--text-primary)]">🏦 저축</h2>
-        <Link to="/categories" className="text-xs text-grape-600 hover:text-grape-700 transition-colors">
-          관리
-        </Link>
-      </div>
+      <SectionHeader
+        icon="📊"
+        title="수입 구성"
+        manageTo="/categories"
+        expanded={expanded}
+        onToggle={() => setExpanded(p => !p)}
+        collapsible={collapsible}
+      />
 
       {hasData ? (
-        <>
-          <p className="text-xl font-bold text-[var(--text-primary)]">
-            {formatAmount(savingsTotal!)}
-          </p>
-          {incomeTotal > 0 && (
-            <p className="text-sm text-[var(--text-tertiary)] mt-0.5">
-              수입의 {((savingsTotal! / incomeTotal) * 100).toFixed(1)}%
-            </p>
+        <div className="mt-3">
+          <div className="flex items-baseline gap-2 mb-2">
+            <span className="text-xl font-bold text-[var(--text-primary)]">
+              {formatAmount(savingsTotal!)}
+            </span>
+            {savingsRate !== undefined && (
+              <span className="text-sm text-[var(--text-muted)]">
+                수입의 {savingsRate.toFixed(1)}%
+              </span>
+            )}
+          </div>
+
+          {showBar && (
+            <>
+              <IncomeFlowBar
+                savingsPct={savingsPct}
+                fixedPct={fixedPct}
+                variablePct={variablePct}
+                remainingPct={remainingPct}
+                incomeTotal={incomeTotal}
+              />
+              <div className="flex flex-wrap gap-x-3 gap-y-1 mt-1.5">
+                <LegendDot color="bg-leaf-500" label="저축" />
+                <LegendDot color="bg-warm-400" label="고정비" />
+                <LegendDot color="bg-grape-400" label="변동비" />
+                <LegendDot color="bg-[var(--border-default)]" label="여유" />
+              </div>
+            </>
           )}
-          {/* 카테고리 2개 이상일 때만 breakdown 표시 — 1개면 총액으로 충분 */}
-          {savingsCategories.length >= 2 && (
-            <div className="mt-3 space-y-1.5">
+
+          {(expanded || !collapsible) && (
+            <div className="mt-3 space-y-2 pt-3 border-t border-[var(--border-default)]">
               {savingsCategories.map(c => (
                 <div key={c.category} className="flex items-center justify-between">
                   <span className="text-sm text-[var(--text-secondary)]">{c.category}</span>
                   <span className="text-sm tabular-nums text-[var(--text-primary)]">{formatAmount(c.amount)}</span>
                 </div>
               ))}
+              {showBar && (
+                <>
+                  <div className="flex items-center justify-between text-sm text-[var(--text-secondary)]">
+                    <span>고정비</span>
+                    <span className="tabular-nums">{formatAmount(recurringTotal)}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm text-[var(--text-secondary)]">
+                    <span>변동비</span>
+                    <span className="tabular-nums">{formatAmount(Math.max(0, expenseTotal - savingsTotal! - recurringTotal))}</span>
+                  </div>
+                  {remainingPct >= 0 && (
+                    <div className="flex items-center justify-between text-sm text-[var(--text-secondary)]">
+                      <span>여유</span>
+                      <span className="tabular-nums text-leaf-600">{formatAmount(incomeTotal - expenseTotal)}</span>
+                    </div>
+                  )}
+                </>
+              )}
             </div>
           )}
-        </>
+        </div>
       ) : (
-        <div className="text-center py-4">
+        <div className="text-center py-4 mt-3">
           <p className="text-sm text-[var(--text-tertiary)]">저축 카테고리를 설정하면 저축 현황을 볼 수 있어요</p>
           <Link to="/categories" className="text-sm font-medium text-grape-600 hover:text-grape-700 mt-1 inline-block">
             카테고리 설정 →

--- a/frontend/src/components/stats/SectionHeader.tsx
+++ b/frontend/src/components/stats/SectionHeader.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { ChevronDown } from 'lucide-react'
+
+type SectionHeaderProps = {
+  icon: string
+  title: string
+  manageTo?: string
+  expanded: boolean
+  onToggle: () => void
+  collapsible?: boolean
+  children?: ReactNode
+}
+
+export default function SectionHeader({
+  icon,
+  title,
+  manageTo,
+  expanded,
+  onToggle,
+  collapsible = true,
+  children,
+}: SectionHeaderProps) {
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        {collapsible ? (
+          <button
+            type="button"
+            className="flex items-center gap-2 flex-1 text-left"
+            onClick={onToggle}
+            aria-label={expanded ? '접기' : '펼치기'}
+          >
+            <h2 className="text-base font-semibold text-[var(--text-primary)]">
+              {icon} {title}
+            </h2>
+          </button>
+        ) : (
+          <h2 className="text-base font-semibold text-[var(--text-primary)] flex-1">
+            {icon} {title}
+          </h2>
+        )}
+
+        <div className="flex items-center gap-2 shrink-0">
+          {manageTo && (
+            <Link
+              to={manageTo}
+              className="text-xs text-grape-600 hover:text-grape-700 transition-colors"
+              onClick={(e) => e.stopPropagation()}
+            >
+              관리
+            </Link>
+          )}
+          {collapsible && (
+            <span
+              className={`transition-transform duration-200 ${expanded ? 'rotate-180' : ''} pointer-events-none`}
+              aria-hidden
+            >
+              <ChevronDown className="w-4 h-4 text-[var(--text-tertiary)]" />
+            </span>
+          )}
+        </div>
+      </div>
+      {children}
+    </>
+  )
+}

--- a/frontend/src/components/stats/SectionHeader.tsx
+++ b/frontend/src/components/stats/SectionHeader.tsx
@@ -7,7 +7,7 @@ type SectionHeaderProps = {
   title: string
   manageTo?: string
   expanded: boolean
-  onToggle: () => void
+  onToggle?: () => void
   collapsible?: boolean
   children?: ReactNode
 }
@@ -28,7 +28,7 @@ export default function SectionHeader({
           <button
             type="button"
             className="flex items-center gap-2 flex-1 text-left"
-            onClick={onToggle}
+            onClick={() => onToggle?.()}
             aria-label={expanded ? '접기' : '펼치기'}
           >
             <h2 className="text-base font-semibold text-[var(--text-primary)]">

--- a/frontend/src/components/stats/__tests__/BudgetVsActual.test.tsx
+++ b/frontend/src/components/stats/__tests__/BudgetVsActual.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import BudgetVsActual from '../BudgetVsActual'
 import type { BudgetMonthlyStatsResponse } from '../../../types'
@@ -14,6 +15,16 @@ const mockBudgetStats: BudgetMonthlyStatsResponse = {
     { category_name: '쇼핑', budget_amount: 100000, spent_amount: 70000, remaining_amount: 30000, usage_percentage: 70, is_exceeded: false },
     { category_name: '통신', budget_amount: 50000, spent_amount: 15000, remaining_amount: 35000, usage_percentage: 30, is_exceeded: false },
     { category_name: '의료', budget_amount: 50000, spent_amount: 5000, remaining_amount: 45000, usage_percentage: 10, is_exceeded: false },
+  ],
+}
+
+const mockWithExceeded: BudgetMonthlyStatsResponse = {
+  month: '2026-04',
+  total_budget: 500000,
+  total_spent: 540000,
+  categories: [
+    { category_name: '식비', budget_amount: 200000, spent_amount: 220000, remaining_amount: -20000, usage_percentage: 110, is_exceeded: true },
+    { category_name: '교통', budget_amount: 100000, spent_amount: 80000, remaining_amount: 20000, usage_percentage: 80, is_exceeded: false },
   ],
 }
 
@@ -47,8 +58,33 @@ describe('BudgetVsActual', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('카테고리 목록을 표시한다', () => {
+  it('기본 접힌 상태에서는 카테고리 목록을 표시하지 않는다', () => {
     renderComponent()
+    expect(screen.queryByText('식비')).not.toBeInTheDocument()
+  })
+
+  it('펼치기 클릭 시 전체 카테고리 목록을 표시한다', async () => {
+    renderComponent()
+    await userEvent.click(screen.getByRole('button', { name: '펼치기' }))
     expect(screen.getByText('식비')).toBeInTheDocument()
+    expect(screen.getByText('교통')).toBeInTheDocument()
+  })
+
+  it('접힌 상태에서 총예산과 총지출 오버뷰를 표시한다', () => {
+    renderComponent()
+    // mockBudgetStats: total_budget: 500000, total_spent: 320000
+    expect(screen.getByText(/500,000/)).toBeInTheDocument()
+    expect(screen.getByText(/320,000/)).toBeInTheDocument()
+  })
+
+  it('초과 카테고리가 있으면 초과 배지를 표시한다', () => {
+    renderComponent({ budgetStats: mockWithExceeded })
+    expect(screen.getByText(/초과/)).toBeInTheDocument()
+  })
+
+  it('total_budget이 null이면 예산 미설정 안내를 표시한다', () => {
+    const statsNoTotal = { ...mockBudgetStats, total_budget: null as unknown as number }
+    renderComponent({ budgetStats: statsNoTotal })
+    expect(screen.getByText(/예산이 설정되지 않았습니다/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/stats/__tests__/CardUsageSummary.test.tsx
+++ b/frontend/src/components/stats/__tests__/CardUsageSummary.test.tsx
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import CardUsageSummary from '../CardUsageSummary'
 import type { PaymentMethodUsage } from '../../../types'
@@ -56,16 +57,52 @@ describe('CardUsageSummary', () => {
     expect(screen.getByRole('link', { name: '관리' })).toBeInTheDocument()
   })
 
-  it('각 결제수단의 이름과 사용액을 표시한다', () => {
+  it('펼쳤을 때 각 결제수단의 이름과 사용액을 표시한다', async () => {
     renderComponent()
+    await userEvent.click(screen.getByRole('button', { name: '펼치기' }))
     expect(screen.getByText('삼성카드')).toBeInTheDocument()
     expect(screen.getByText('국민카드')).toBeInTheDocument()
   })
 
-  it('달성률을 표시한다', () => {
+  it('펼쳤을 때 달성률을 표시한다', async () => {
     renderComponent()
+    await userEvent.click(screen.getByRole('button', { name: '펼치기' }))
     expect(screen.getByText('73.3%')).toBeInTheDocument()
     expect(screen.getByText('30.0%')).toBeInTheDocument()
+  })
+
+  // 기본 접힌 상태 검증
+  it('기본 접힌 상태에서 카드별 상세 프로그레스를 표시하지 않는다', () => {
+    renderComponent()
+    expect(screen.queryByText('73.3%')).not.toBeInTheDocument()
+  })
+
+  it('접힌 상태에서 달성/진행 오버뷰를 표시한다', () => {
+    renderComponent()
+    // mockUsage: 2개 카드, 둘 다 미달성 (사용 percentage < 100)
+    expect(screen.getByText(/진행 중 2개/)).toBeInTheDocument()
+  })
+
+  it('달성한 카드가 있으면 달성 건수를 오버뷰에 표시한다', () => {
+    const achievedUsage: PaymentMethodUsage[] = [
+      { id: 1, name: '삼성카드', type: 'credit_card', monthly_target: 300000,
+        spent_amount: 310000, usage_percentage: 103.3, remaining: 0 },
+    ]
+    renderComponent(achievedUsage)
+    expect(screen.getByText(/달성 1개/)).toBeInTheDocument()
+  })
+
+  it('펼치기 클릭 시 카드별 상세 프로그레스가 표시된다', async () => {
+    renderComponent()
+    await userEvent.click(screen.getByRole('button', { name: '펼치기' }))
+    expect(screen.getByText('삼성카드')).toBeInTheDocument()
+    expect(screen.getByText('73.3%')).toBeInTheDocument()
+  })
+
+  it('카드 1개일 때 접힌 오버뷰에 해당 카드 이름과 달성률을 표시한다', () => {
+    renderComponent([mockUsage[0]])  // 삼성카드만 (usage_percentage: 73.3)
+    expect(screen.getByText(/삼성카드/)).toBeInTheDocument()
+    expect(screen.getByText(/73.3%/)).toBeInTheDocument()
   })
 
   it('빈 데이터면 null을 반환한다', () => {

--- a/frontend/src/components/stats/__tests__/CardUsageSummary.test.tsx
+++ b/frontend/src/components/stats/__tests__/CardUsageSummary.test.tsx
@@ -87,9 +87,21 @@ describe('CardUsageSummary', () => {
     const achievedUsage: PaymentMethodUsage[] = [
       { id: 1, name: '삼성카드', type: 'credit_card', monthly_target: 300000,
         spent_amount: 310000, usage_percentage: 103.3, remaining: 0 },
+      { id: 2, name: '국민카드', type: 'credit_card', monthly_target: 200000,
+        spent_amount: 60000, usage_percentage: 30.0, remaining: 140000 },
     ]
     renderComponent(achievedUsage)
     expect(screen.getByText(/달성 1개/)).toBeInTheDocument()
+    expect(screen.getByText(/진행 중 1개/)).toBeInTheDocument()
+  })
+
+  it('카드 1개 달성 시 "✅ 실적 달성"을 오버뷰에 표시한다', () => {
+    const achievedUsage: PaymentMethodUsage[] = [
+      { id: 1, name: '삼성카드', type: 'credit_card', monthly_target: 300000,
+        spent_amount: 310000, usage_percentage: 103.3, remaining: 0 },
+    ]
+    renderComponent(achievedUsage)
+    expect(screen.getByText(/실적 달성/)).toBeInTheDocument()
   })
 
   it('펼치기 클릭 시 카드별 상세 프로그레스가 표시된다', async () => {

--- a/frontend/src/components/stats/__tests__/MonthlyComparison.test.tsx
+++ b/frontend/src/components/stats/__tests__/MonthlyComparison.test.tsx
@@ -71,14 +71,29 @@ describe('MonthlyComparison', () => {
     expect(screen.getByText('식비')).toBeInTheDocument()
   })
 
-  it('trend 데이터가 2개 미만이면 스파크라인을 렌더하지 않는다', () => {
+  it('trend 데이터가 2개 이상이면 TrendBarChart를 렌더한다', async () => {
+    const user = userEvent.setup()
+    render(
+      <MonthlyComparison
+        expenseComparison={mockComparison}
+        incomeComparison={mockIncomeComparison}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /펼치기/ }))
+    expect(screen.getByTestId('trend-bar-chart')).toBeInTheDocument()
+  })
+
+  it('trend 데이터가 2개 미만이면 TrendBarChart를 렌더하지 않는다', async () => {
+    const user = userEvent.setup()
     render(
       <MonthlyComparison
         expenseComparison={{ ...mockComparison, trend: [{ label: '4월', total: 1_200_000 }] }}
         incomeComparison={{ ...mockIncomeComparison, trend: [{ label: '4월', total: 3_500_000 }] }}
       />
     )
-    expect(screen.queryAllByTestId('sparkline')).toHaveLength(0)
+    await user.click(screen.getByRole('button', { name: /펼치기/ }))
+    expect(screen.queryByTestId('trend-bar-chart')).not.toBeInTheDocument()
+    expect(screen.getByText(/비교할 이전 데이터가 없습니다/)).toBeInTheDocument()
   })
 
   it('savingsRateCurrent 미제공 시 저축률 행을 표시하지 않는다', () => {

--- a/frontend/src/components/stats/__tests__/RecurringManageSection.test.tsx
+++ b/frontend/src/components/stats/__tests__/RecurringManageSection.test.tsx
@@ -66,16 +66,15 @@ describe('RecurringManageSection', () => {
 
   // ── 항목 상태 표시 ──────────────────────────────────────────────
 
-  it('활성 건수와 이번 달 지출 합계를 표시한다', () => {
+  it('이번 달 고정비 합계를 헤더에 표시한다', () => {
     const executedMap = new Map([[1, 17000], [2, 14900]])
     const items = [
       makeItem({ id: 1, amount: 17000, type: 'expense', next_due_date: '2026-05-15' }),
       makeItem({ id: 2, amount: 14900, type: 'expense', next_due_date: '2026-05-28' }),
     ]
     wrap(<RecurringManageSection items={items} monthStr={MONTH_STR} executedAmountMap={executedMap} />)
-    expect(screen.getByText(/활성 2건/)).toBeInTheDocument()
-    // 헤더 + 푸터 양쪽에 표시될 수 있으므로 getAllByText 사용
-    expect(screen.getAllByText(/31,900/).length).toBeGreaterThan(0)
+    // 하단 푸터 없음, 헤더 서브텍스트에만 고정비 총액 표시
+    expect(screen.getByText(/31,900/)).toBeInTheDocument()
   })
 
   it('실행된 항목은 실제 금액과 완료를 표시한다', async () => {

--- a/frontend/src/components/stats/__tests__/SavingsSection.test.tsx
+++ b/frontend/src/components/stats/__tests__/SavingsSection.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import SavingsSection from '../SavingsSection'
 
@@ -34,13 +35,6 @@ describe('SavingsSection', () => {
     expect(screen.getByText(/15\.1%/)).toBeInTheDocument()
   })
 
-  it('카테고리별 내역을 표시한다', () => {
-    renderSection()
-    expect(screen.getByText('적금')).toBeInTheDocument()
-    expect(screen.getByText('투자')).toBeInTheDocument()
-    expect(screen.getByText('보험')).toBeInTheDocument()
-  })
-
   it('savingsCategories가 없으면 설정 유도 메시지를 표시한다', () => {
     renderSection({ savingsCategories: [], savingsTotal: undefined })
     expect(screen.getByText(/저축 카테고리를 설정하면/)).toBeInTheDocument()
@@ -52,13 +46,69 @@ describe('SavingsSection', () => {
     expect(screen.getByRole('link', { name: '관리' })).toBeInTheDocument()
   })
 
-  it('저축 카테고리가 1개이면 카테고리 목록 없이 총액만 표시한다', () => {
+  it('저축 카테고리가 1개이면 breakdown을 항상 표시한다 (chevron 없음)', () => {
     renderSection({
-      savingsCategories: [{ category: '저축/투자', amount: 300_000 }],
-      savingsTotal: 300_000,
+      savingsCategories: [{ category: '적금', amount: 300000 }],
+      savingsTotal: 300000,
     })
-    expect(screen.getByText('₩300,000')).toBeInTheDocument()
-    // 카테고리 breakdown 목록이 없어야 함
-    expect(screen.queryByText('저축/투자')).not.toBeInTheDocument()
+    // collapsible=false → 접기/펼치기 버튼 없음
+    expect(screen.queryByRole('button', { name: /펼치기|접기/ })).not.toBeInTheDocument()
+    // breakdown은 항상 표시
+    expect(screen.getByText('적금')).toBeInTheDocument()
+  })
+
+  // 카드명 변경 확인
+  it('카드 제목이 "수입 구성"이다', () => {
+    renderSection()
+    expect(screen.getByRole('heading', { name: /수입 구성/ })).toBeInTheDocument()
+  })
+
+  // stacked bar 렌더 확인
+  it('수입이 있을 때 stacked bar를 표시한다', () => {
+    renderSection({ recurringTotal: 800000, expenseTotal: 1800000 })
+    expect(screen.getByTestId('income-flow-bar')).toBeInTheDocument()
+  })
+
+  // incomeTotal === 0 케이스
+  it('수입이 0이면 stacked bar를 표시하지 않는다', () => {
+    renderSection({ incomeTotal: 0, recurringTotal: 0, expenseTotal: 0 })
+    expect(screen.queryByTestId('income-flow-bar')).not.toBeInTheDocument()
+  })
+
+  // collapsible 분기 — 카테고리 2개 이상: 펼치기 가능
+  it('카테고리 2개 이상이면 펼치기 버튼을 표시한다', () => {
+    renderSection()  // mockSavingsCategories가 3개
+    expect(screen.getByRole('button', { name: '펼치기' })).toBeInTheDocument()
+  })
+
+  // 카테고리 1개: 항상 펼침, 버튼 없음
+  it('카테고리 1개이면 펼치기 버튼을 표시하지 않는다', () => {
+    renderSection({
+      savingsCategories: [{ category: '적금', amount: 300000 }],
+      savingsTotal: 300000,
+    })
+    expect(screen.queryByRole('button', { name: /펼치기|접기/ })).not.toBeInTheDocument()
+  })
+
+  // 기본 접힘 상태 (2개 이상인 경우)
+  it('기본 접힌 상태에서는 카테고리 breakdown을 표시하지 않는다', () => {
+    renderSection()
+    expect(screen.queryByText('적금')).not.toBeInTheDocument()
+  })
+
+  it('펼치기 클릭 시 카테고리 breakdown을 표시한다', async () => {
+    renderSection()
+    await userEvent.click(screen.getByRole('button', { name: '펼치기' }))
+    expect(screen.getByText('적금')).toBeInTheDocument()
+  })
+
+  // 기존 '카테고리별 내역을 표시한다' 교체
+  it('펼쳤을 때 카테고리별 내역을 표시한다', async () => {
+    renderSection()
+    await userEvent.click(screen.getByRole('button', { name: '펼치기' }))
+    // mockSavingsCategories: 적금, 투자, 보험
+    expect(screen.getByText('적금')).toBeInTheDocument()
+    expect(screen.getByText('투자')).toBeInTheDocument()
+    expect(screen.getByText('보험')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/stats/__tests__/SectionHeader.test.tsx
+++ b/frontend/src/components/stats/__tests__/SectionHeader.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import SectionHeader from '../SectionHeader'
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>)
+
+describe('SectionHeader', () => {
+  it('타이틀과 이모지를 렌더한다', () => {
+    wrap(<SectionHeader icon="💰" title="예산 상황" expanded={false} onToggle={vi.fn()} />)
+    expect(screen.getByRole('heading', { name: /예산 상황/ })).toBeInTheDocument()
+  })
+
+  it('접힌 상태에서 aria-label="펼치기" 버튼을 표시한다', () => {
+    wrap(<SectionHeader icon="💰" title="예산 상황" expanded={false} onToggle={vi.fn()} />)
+    expect(screen.getByRole('button', { name: '펼치기' })).toBeInTheDocument()
+  })
+
+  it('펼친 상태에서 aria-label="접기" 버튼을 표시한다', () => {
+    wrap(<SectionHeader icon="💰" title="예산 상황" expanded={true} onToggle={vi.fn()} />)
+    expect(screen.getByRole('button', { name: '접기' })).toBeInTheDocument()
+  })
+
+  it('헤더 클릭 시 onToggle이 호출된다', async () => {
+    const onToggle = vi.fn()
+    wrap(<SectionHeader icon="💰" title="예산 상황" expanded={false} onToggle={onToggle} />)
+    await userEvent.click(screen.getByRole('button', { name: '펼치기' }))
+    expect(onToggle).toHaveBeenCalledOnce()
+  })
+
+  it('collapsible=false이면 토글 버튼이 없다', () => {
+    wrap(<SectionHeader icon="💰" title="예산 상황" expanded={false} onToggle={vi.fn()} collapsible={false} />)
+    expect(screen.queryByRole('button', { name: /펼치기|접기/ })).toBeNull()
+  })
+
+  it('collapsible=false이면 헤더 영역 클릭 시 onToggle이 호출되지 않는다', async () => {
+    const onToggle = vi.fn()
+    wrap(<SectionHeader icon="💰" title="예산 상황" expanded={false} onToggle={onToggle} collapsible={false} />)
+    await userEvent.click(screen.getByRole('heading', { name: /예산 상황/ }))
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  it('manageTo가 있으면 관리 링크를 표시한다', () => {
+    wrap(<SectionHeader icon="💰" title="예산 상황" expanded={false} onToggle={vi.fn()} manageTo="/budgets" />)
+    expect(screen.getByRole('link', { name: '관리' })).toHaveAttribute('href', '/budgets')
+  })
+
+  it('관리 링크 클릭 시 onToggle이 호출되지 않는다', async () => {
+    const onToggle = vi.fn()
+    wrap(<SectionHeader icon="💰" title="예산 상황" expanded={false} onToggle={onToggle} manageTo="/budgets" />)
+    await userEvent.click(screen.getByRole('link', { name: '관리' }))
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/data/changelogs.ts
+++ b/frontend/src/data/changelogs.ts
@@ -18,6 +18,16 @@ export interface Changelog {
 
 export const changelogs: Changelog[] = [
   {
+    version: '0.24.0',
+    date: '2026-04-14',
+    title: '모아보기 카드 UX 개선',
+    items: [
+      { tag: '개선', text: '예산/정기거래/카드실적/지난달 비교 카드에 접기/펼치기 통일' },
+      { tag: '신규', text: '저축 카드 → 수입 구성으로 업그레이드 (수입 배분 구조 시각화)' },
+      { tag: '개선', text: '지난달과 비교 그래프를 3개월 트렌드 차트로 교체' },
+    ],
+  },
+  {
     version: '0.23.0',
     date: '2026-04-14',
     title: 'AI 분석 개인화 + 가계부 점수 리디자인',

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -718,6 +718,8 @@ export default function InsightsPage() {
               savingsTotal={savingsTotal}
               incomeTotal={incomeStats?.total ?? 0}
               savingsCategories={savingsCategories}
+              recurringTotal={recurringTotal}
+              expenseTotal={expenseStats?.total ?? 0}
             />
           )}
 


### PR DESCRIPTION
## Summary

- 모아보기 5개 카드(예산 상황, 정기거래, 카드실적, 수입 구성, 지난달 비교)에 공통 `SectionHeader` 컴포넌트 적용 — 접기/펼치기 패턴 통일
- 저축 카드 → 수입 구성 카드로 업그레이드: 저축/고정비/변동비/여유 4구간 stacked bar 시각화
- 지난달 비교의 스파크라인 제거 → 3개월 트렌드 BarChart(Recharts)로 교체

## Changes

- `SectionHeader` 신규 컴포넌트 (collapsible, manageTo, aria-label 지원)
- `BudgetVsActual`: 오버뷰(총예산/총지출 + 프로그레스바 + 초과 배지) + 펼침(전체 카테고리)
- `RecurringManageSection`: 하단 푸터 제거, 헤더 chevron으로 통일
- `CardUsageSummary`: 오버뷰(달성/진행 현황) + 펼침(카드별 상세)
- `SavingsSection`: "수입 구성" 리네이밍, `recurringTotal`/`expenseTotal` props 추가, stacked bar 구현
- `MonthlyComparison`: 스파크라인 제거, `TrendBarChart` 추가, 카테고리 변화에 미니 horizontal bar 추가
- `InsightsPage`: `SavingsSection`에 수입 배분 props 전달
- `changelogs.ts`: v0.23.0 업데이트 항목 추가

## Test Plan

- [x] 전체 테스트 1574개 통과 (1 skipped)
- [x] TypeScript 빌드 성공
- [x] ESLint 오류 0개
- [ ] 브라우저에서 `/insights` 접속 → 모든 카드 기본 접힘 상태 확인
- [ ] 각 카드 chevron 탭 → 펼침/접힘 동작 확인
- [ ] "관리" 링크 탭 → 해당 관리 페이지 이동 (접기 트리거 안 됨)
- [ ] 수입 구성 카드: stacked bar 렌더 + 카드명 확인
- [ ] 지난달 비교: TrendBarChart 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)