### PR TITLE
fix: AI 분석 설정 목표금액 콤마 포맷 + 날짜 드롭다운 개선

### DIFF
--- a/frontend/src/components/stats/ProfileCollectionFlow.tsx
+++ b/frontend/src/components/stats/ProfileCollectionFlow.tsx
@@ -106,6 +106,27 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
   const [goalDeadline, setGoalDeadline] = useState<string>('')
   const [primaryConcern, setPrimaryConcern] = useState<string | null>(null)
 
+  // 목표 금액 콤마 포맷 처리
+  function handleGoalAmountChange(raw: string) {
+    const digits = raw.replace(/[^0-9]/g, '')
+    setGoalAmount(digits ? Number(digits).toLocaleString('ko-KR') : '')
+  }
+
+  // 날짜 드롭다운: 연도/월 별도 state → 둘 다 선택된 경우에만 "YYYY-MM" 합성
+  const [deadlineYearInput, setDeadlineYearInput] = useState<string>('')
+  const [deadlineMonthInput, setDeadlineMonthInput] = useState<string>('')
+  const currentYear = new Date().getFullYear()
+  const yearOptions = Array.from({ length: 11 }, (_, i) => currentYear + i)
+
+  function handleDeadlineYearChange(year: string) {
+    setDeadlineYearInput(year)
+    setGoalDeadline(year && deadlineMonthInput ? `${year}-${deadlineMonthInput}` : '')
+  }
+  function handleDeadlineMonthChange(month: string) {
+    setDeadlineMonthInput(month)
+    setGoalDeadline(deadlineYearInput && month ? `${deadlineYearInput}-${month}` : '')
+  }
+
   const step1Complete = householdType && housingType && incomeTypes.length > 0 && ageRange
 
   function toggleIncomeType(value: string) {
@@ -203,19 +224,43 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
         </div>
         {financialGoal && financialGoal !== 'none' && (
           <div className="space-y-2 pl-2">
-            <input
-              type="text"
-              placeholder="목표 금액 (만원)"
-              value={goalAmount}
-              onChange={(e) => setGoalAmount(e.target.value)}
-              className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm"
-            />
-            <input
-              type="month"
-              value={goalDeadline}
-              onChange={(e) => setGoalDeadline(e.target.value)}
-              className="w-full px-3 py-2 rounded-lg border border-warm-300 text-sm"
-            />
+            {/* 목표 금액: 콤마 포맷 + 원 단위 표시 */}
+            <div className="flex items-center gap-1.5">
+              <input
+                type="text"
+                inputMode="numeric"
+                placeholder="목표 금액"
+                value={goalAmount}
+                onChange={(e) => handleGoalAmountChange(e.target.value)}
+                className="flex-1 px-3 py-2 rounded-lg border border-warm-300 text-sm"
+              />
+              <span className="text-sm text-warm-600 shrink-0">원</span>
+            </div>
+            {/* 날짜: 연도 + 월 드롭다운 */}
+            <div className="flex gap-2">
+              <select
+                aria-label="목표 연도"
+                value={deadlineYearInput}
+                onChange={(e) => handleDeadlineYearChange(e.target.value)}
+                className="flex-1 px-3 py-2 rounded-lg border border-warm-300 text-sm bg-white"
+              >
+                <option value="">연도</option>
+                {yearOptions.map((y) => (
+                  <option key={y} value={String(y)}>{y}년</option>
+                ))}
+              </select>
+              <select
+                aria-label="목표 월"
+                value={deadlineMonthInput}
+                onChange={(e) => handleDeadlineMonthChange(e.target.value)}
+                className="flex-1 px-3 py-2 rounded-lg border border-warm-300 text-sm bg-white"
+              >
+                <option value="">월</option>
+                {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
+                  <option key={m} value={String(m).padStart(2, '0')}>{m}월</option>
+                ))}
+              </select>
+            </div>
           </div>
         )}
         <div>

--- a/frontend/src/components/stats/__tests__/ProfileCollectionFlow.test.tsx
+++ b/frontend/src/components/stats/__tests__/ProfileCollectionFlow.test.tsx
@@ -2,6 +2,18 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import ProfileCollectionFlow from '../ProfileCollectionFlow'
 
+// Step 2로 이동하는 공통 헬퍼
+async function navigateToStep2(mockComplete = vi.fn().mockResolvedValue(undefined)) {
+  render(<ProfileCollectionFlow onComplete={mockComplete} onAnalysisReady={vi.fn()} />)
+  fireEvent.click(screen.getByText('맞벌이'))
+  fireEvent.click(screen.getByText('전세'))
+  fireEvent.click(screen.getByText('급여'))
+  fireEvent.click(screen.getByText('30대'))
+  fireEvent.click(screen.getByText('다음 →'))
+  await screen.findByText('재무 목표 (선택)')
+  return mockComplete
+}
+
 describe('ProfileCollectionFlow', () => {
   it('Step 1 필수 항목 미선택 시 다음 버튼 비활성화', () => {
     render(<ProfileCollectionFlow onComplete={vi.fn()} onAnalysisReady={vi.fn()} />)
@@ -31,5 +43,105 @@ describe('ProfileCollectionFlow', () => {
       incomeTypes: ['salary'],
       ageRange: '30s',
     }))
+  })
+
+  describe('Step 2 목표 금액 입력', () => {
+    it('재무 목표 선택 시 목표 금액 입력 필드가 나타난다', async () => {
+      await navigateToStep2()
+      fireEvent.click(screen.getByText('내집마련'))
+      expect(screen.getByPlaceholderText('목표 금액')).toBeInTheDocument()
+    })
+
+    it('목표 금액 숫자 입력 시 콤마 포맷으로 표시된다', async () => {
+      await navigateToStep2()
+      fireEvent.click(screen.getByText('내집마련'))
+      fireEvent.change(screen.getByPlaceholderText('목표 금액'), { target: { value: '5000000' } })
+      expect(screen.getByDisplayValue('5,000,000')).toBeInTheDocument()
+    })
+
+    it('목표 금액 입력 영역에 원 단위 표시가 있다', async () => {
+      await navigateToStep2()
+      fireEvent.click(screen.getByText('내집마련'))
+      expect(screen.getByText('원')).toBeInTheDocument()
+    })
+
+    it('비숫자 입력은 무시된다', async () => {
+      await navigateToStep2()
+      fireEvent.click(screen.getByText('내집마련'))
+      fireEvent.change(screen.getByPlaceholderText('목표 금액'), { target: { value: 'abc123' } })
+      expect(screen.getByDisplayValue('123')).toBeInTheDocument()
+    })
+  })
+
+  describe('Step 2 날짜 선택 (연도/월 드롭다운)', () => {
+    it('재무 목표 선택 시 연도 select가 렌더링된다', async () => {
+      await navigateToStep2()
+      fireEvent.click(screen.getByText('내집마련'))
+      expect(screen.getByRole('combobox', { name: '목표 연도' })).toBeInTheDocument()
+    })
+
+    it('재무 목표 선택 시 월 select가 렌더링된다', async () => {
+      await navigateToStep2()
+      fireEvent.click(screen.getByText('내집마련'))
+      expect(screen.getByRole('combobox', { name: '목표 월' })).toBeInTheDocument()
+    })
+
+    it('연도 select에 현재 연도부터 10년 후까지 옵션이 있다', async () => {
+      await navigateToStep2()
+      fireEvent.click(screen.getByText('내집마련'))
+      const yearSelect = screen.getByRole('combobox', { name: '목표 연도' })
+      const currentYear = new Date().getFullYear()
+      expect(yearSelect).toHaveTextContent(String(currentYear))
+      expect(yearSelect).toHaveTextContent(String(currentYear + 10))
+    })
+
+    it('월 select에 1월~12월 옵션이 있다', async () => {
+      await navigateToStep2()
+      fireEvent.click(screen.getByText('내집마련'))
+      const monthSelect = screen.getByRole('combobox', { name: '목표 월' })
+      expect(monthSelect).toHaveTextContent('1월')
+      expect(monthSelect).toHaveTextContent('12월')
+    })
+
+    it('연도와 월 선택 시 YYYY-MM 형식으로 저장된다', async () => {
+      const mockComplete = await navigateToStep2()
+      mockComplete.mockClear()
+      fireEvent.click(screen.getByText('내집마련'))
+      fireEvent.change(screen.getByRole('combobox', { name: '목표 연도' }), { target: { value: '2027' } })
+      fireEvent.change(screen.getByRole('combobox', { name: '목표 월' }), { target: { value: '03' } })
+      fireEvent.click(screen.getByText('분석 시작 →'))
+      await waitFor(() =>
+        expect(mockComplete).toHaveBeenCalledWith(
+          expect.objectContaining({ goalDeadline: '2027-03' }),
+        ),
+      )
+    })
+
+    it('월만 선택하고 연도 미선택 시 goalDeadline은 null로 저장된다', async () => {
+      const mockComplete = await navigateToStep2()
+      mockComplete.mockClear()
+      fireEvent.click(screen.getByText('내집마련'))
+      // 연도는 선택 안 하고 월만 선택
+      fireEvent.change(screen.getByRole('combobox', { name: '목표 월' }), { target: { value: '03' } })
+      fireEvent.click(screen.getByText('분석 시작 →'))
+      await waitFor(() =>
+        expect(mockComplete).toHaveBeenCalledWith(
+          expect.objectContaining({ goalDeadline: null }),
+        ),
+      )
+    })
+
+    it('목표 금액이 정수로 저장된다', async () => {
+      const mockComplete = await navigateToStep2()
+      mockComplete.mockClear()
+      fireEvent.click(screen.getByText('내집마련'))
+      fireEvent.change(screen.getByPlaceholderText('목표 금액'), { target: { value: '5000000' } })
+      fireEvent.click(screen.getByText('분석 시작 →'))
+      await waitFor(() =>
+        expect(mockComplete).toHaveBeenCalledWith(
+          expect.objectContaining({ goalAmount: 5000000 }),
+        ),
+      )
+    })
   })
 })


### PR DESCRIPTION
## Summary

- 목표 금액 입력 시 실시간 콤마 포맷 적용 (`5000000` → `5,000,000`) + "원" 단위 표시
- `<input type="month">` → 연도/월 `<select>` 드롭다운으로 교체 (모바일 화면 넘침 해결)
- 연도/월을 각각 별도 state로 관리, **둘 다 선택된 경우에만** `YYYY-MM` 문자열 합성 (월만 선택 시 현재 연도가 silently 저장되는 버그 방지)

## Test plan

- [x] 목표 금액 숫자 입력 시 콤마 포맷으로 표시됨
- [x] 비숫자 입력은 무시됨
- [x] "원" 단위 레이블 표시 확인
- [x] 연도/월 드롭다운 렌더링 확인
- [x] 연도+월 모두 선택 시 `YYYY-MM` 형식으로 저장
- [x] 월만 선택 후 저장 시 `goalDeadline: null` (연도 silently 설정 버그 수정 검증)
- [x] 목표 금액이 정수로 저장됨 (콤마 제거 검증)
- [x] 전체 1620개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)