### PR TITLE
fix: 역머지 워크플로우 에러 로깅 + --auto 제거

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -124,13 +124,17 @@ jobs:
             --body "자동 생성된 역머지 PR입니다. 충돌이 없으면 바로 머지해주세요." \
             2>&1) || true
 
+          echo "gh pr create 결과: ${PR_URL}"
+
           if echo "$PR_URL" | grep -q "already exists"; then
             echo "역머지 PR이 이미 존재합니다."
           elif echo "$PR_URL" | grep -q "https://"; then
             echo "역머지 PR 생성: $PR_URL"
-            # auto-merge 시도
             PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-            gh pr merge "$PR_NUM" --merge --auto 2>/dev/null || echo "auto-merge 설정 실패 (충돌 가능성 — 수동 해결 필요)"
+            # 충돌 없으면 즉시 머지, 있으면 PR 열린 채로 수동 해결
+            gh pr merge "$PR_NUM" --merge 2>&1 || echo "머지 실패 — 충돌 가능성, PR 수동 확인 필요"
+          else
+            echo "역머지 PR 생성 실패 (예상치 못한 오류): ${PR_URL}"
           fi
 
       - name: 텔레그램 알림


### PR DESCRIPTION
- `gh pr create` 실패 시 에러 메시지 출력 추가
- `--auto` 제거하고 즉시 `--merge`로 변경 (브랜치 보호 없이도 동작)