### PR TITLE
feat: BudgetManager 리디자인 — 예산상황 통합 + ₩ 포맷 입력

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -57,7 +57,8 @@ jobs:
         # CVE-2026-4539(pygments): dev dep, fix 버전 미출시 — ignore
         # CVE-2026-25645(requests): 2.33.0에서 수정, 하지만 httpx transitive dep으로 직접 업그레이드 불가 — ignore
         # CVE-2025-71176(pytest): dev dep, fix 버전 9.0.3 — pytest-asyncio 0.23 호환 이슈로 major 업그레이드 보류
-        run: uv run pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2025-71176
+        # CVE-2026-3219(pip): fix 버전 미출시 — ignore
+        run: uv run pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2025-71176 --ignore-vuln CVE-2026-3219
 
       - name: 타입 체크 (pyright)
         run: |

--- a/frontend/src/data/changelogs.ts
+++ b/frontend/src/data/changelogs.ts
@@ -18,6 +18,15 @@ export interface Changelog {
 
 export const changelogs: Changelog[] = [
   {
+    version: '0.25.0',
+    date: '2026-04-25',
+    title: '예산 관리 개선',
+    items: [
+      { tag: '개선', text: '예산 현황과 카테고리 편집을 한 화면에서 확인하고 수정할 수 있어요' },
+      { tag: '개선', text: '예산 입력란에 ₩ 기호와 쉼표 포맷이 표시돼요' },
+    ],
+  },
+  {
     version: '0.24.0',
     date: '2026-04-14',
     title: '모아보기 카드 UX 개선',

--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -32,16 +32,31 @@ function extractNumber(value: string): string {
 
 function BudgetManagerSkeleton() {
   return (
-    <div className="space-y-3">
-      {[1, 2, 3, 4].map(i => (
-        <div key={i} className="card-surface p-4 flex items-center justify-between">
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-28" />
-            <Skeleton className="h-3 w-36" />
+    <div className="space-y-6">
+      {/* 헤더 스켈레톤 */}
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-9 w-9 rounded-lg" />
+        <Skeleton className="h-5 w-5 rounded" />
+        <Skeleton className="h-6 w-24" />
+      </div>
+      {/* 월 총 예산 카드 */}
+      <div className="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)]/60 p-5">
+        <Skeleton className="h-5 w-20 mb-4" />
+        <Skeleton className="h-10 w-44" />
+      </div>
+      {/* 카테고리 카드 */}
+      <div className="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)]/60 overflow-hidden">
+        {[1, 2, 3, 4].map(i => (
+          <div key={i} className="px-4 py-3.5 space-y-2 border-b border-[var(--border-subtle)] last:border-0">
+            <div className="flex justify-between">
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-4 w-8" />
+            </div>
+            <Skeleton className="h-1.5 w-full rounded-full" />
+            <Skeleton className="h-9 w-full" />
           </div>
-          <Skeleton className="h-8 w-24" />
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -234,7 +234,7 @@ export default function BudgetManager() {
    * - 정상: leaf-500
    */
   const getProgressColor = (usagePct: number, isExceeded: boolean): string => {
-    if (isExceeded) return 'bg-rose-500'
+    if (isExceeded || usagePct >= 100) return 'bg-rose-500'
     if (usagePct >= 80) return 'bg-yellow-500'
     return 'bg-leaf-500'
   }

--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -2,13 +2,13 @@
  * @file BudgetManager.tsx
  * @description 예산 관리 페이지
  * 카테고리 전체 목록을 한 화면에 표시하고, 각 카테고리 옆에 예산 금액을 바로 입력할 수 있다.
- * 참고용으로 카테고리별 최근 3개월 실제 지출액을 표시한다.
- * 월 총 예산을 설정하면 카테고리별 배분 비율과 여유예산을 확인할 수 있다.
+ * 예산이 설정된 카테고리는 진행바와 지출 금액을 카테고리 행에 바로 표시한다.
+ * 월 총 예산을 설정하면 배분 비율과 여유예산을 확인할 수 있다.
  */
 
 import { useState, useEffect, useMemo } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
-import { ArrowLeft, BarChart3, AlertTriangle, Wallet, PiggyBank } from 'lucide-react'
+import { ArrowLeft, Wallet, PiggyBank } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { TOAST } from '../constants/toastMessages'
 import budgetApi from '../api/budgets'
@@ -108,6 +108,16 @@ export default function BudgetManager() {
   useEffect(() => {
     loadData()
   }, [])
+
+  /**
+   * 카테고리 ID → BudgetAlert 빠른 조회용 맵
+   * alerts 배열이 변경될 때만 재계산
+   */
+  const alertsMap = useMemo(() => {
+    const map = new Map<number, BudgetAlert>()
+    alerts.forEach((a) => map.set(a.category_id, a))
+    return map
+  }, [alerts])
 
   /**
    * 카테고리별 예산 합계 (로컬 입력 기준)
@@ -219,22 +229,14 @@ export default function BudgetManager() {
 
   /**
    * 프로그레스바 색상 결정
+   * - 초과: rose-500
+   * - 경고 (80% 이상): yellow-500
+   * - 정상: leaf-500
    */
-  const getProgressColor = (alert: BudgetAlert): string => {
-    if (alert.is_exceeded) return 'bg-rose-500'
-    if (alert.is_warning) return 'bg-yellow-500'
+  const getProgressColor = (usagePct: number, isExceeded: boolean): string => {
+    if (isExceeded) return 'bg-rose-500'
+    if (usagePct >= 80) return 'bg-yellow-500'
     return 'bg-leaf-500'
-  }
-
-  /**
-   * 카테고리별 총 예산 대비 비율 계산
-   */
-  const getCategoryPercent = (categoryId: number): number | null => {
-    const total = Number(localTotalBudget)
-    if (!total || total <= 0) return null
-    const amount = Number(localAmounts[categoryId] ?? 0)
-    if (amount <= 0) return null
-    return (amount / total) * 100
   }
 
   if (loading) {
@@ -320,69 +322,6 @@ export default function BudgetManager() {
         )}
       </div>
 
-      {/* 예산 상황 카드 */}
-      {alerts.length > 0 && (
-        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-5">
-          <div className="flex items-center gap-2 mb-4">
-            <BarChart3 className="w-5 h-5 text-grape-600" />
-            <h2 className="text-lg font-semibold text-[var(--text-primary)]">예산 상황</h2>
-          </div>
-          <div className="space-y-3">
-            {alerts.map((alert) => (
-              <div
-                key={alert.budget_id}
-                className={`p-4 rounded-lg border ${
-                  alert.is_exceeded
-                    ? 'bg-rose-50 border-rose-200'
-                    : alert.is_warning
-                    ? 'bg-yellow-50 border-yellow-200'
-                    : 'bg-leaf-50 border-leaf-200'
-                }`}
-              >
-                <div className="flex items-center justify-between mb-2">
-                  <span className="font-medium text-[var(--text-primary)]">{alert.category_name}</span>
-                  <span
-                    className={`text-sm font-semibold ${
-                      alert.is_exceeded
-                        ? 'text-rose-600'
-                        : alert.is_warning
-                        ? 'text-yellow-600'
-                        : 'text-leaf-600'
-                    }`}
-                  >
-                    {alert.usage_percentage.toFixed(1)}%
-                  </span>
-                </div>
-                <div className="w-full bg-[var(--border-default)] rounded-full h-2 mb-2">
-                  <div
-                    className={`h-2 rounded-full ${getProgressColor(alert)}`}
-                    style={{ width: `${Math.min(alert.usage_percentage, 100)}%` }}
-                  />
-                </div>
-                <div className="flex justify-between text-xs text-[var(--text-secondary)]">
-                  <span>
-                    사용: <span className="tabular-nums">{formatAmount(alert.spent_amount)}</span> / <span className="tabular-nums">{formatAmount(alert.budget_amount)}</span>
-                  </span>
-                  <span>남은 금액: <span className="tabular-nums">{formatAmount(alert.remaining_amount)}</span></span>
-                </div>
-                {alert.is_exceeded && (
-                  <div className="flex items-center gap-1 mt-2">
-                    <AlertTriangle className="w-3 h-3 text-rose-600" />
-                    <p className="text-xs text-rose-600">예산을 초과했습니다!</p>
-                  </div>
-                )}
-                {alert.is_warning && !alert.is_exceeded && (
-                  <div className="flex items-center gap-1 mt-2">
-                    <AlertTriangle className="w-3 h-3 text-yellow-600" />
-                    <p className="text-xs text-yellow-600">예산의 80%를 사용했습니다</p>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
       {/* 카테고리별 예산 인라인 편집 */}
       {overview.length === 0 ? (
         <EmptyState
@@ -400,52 +339,67 @@ export default function BudgetManager() {
           </div>
           <div className="divide-y divide-[var(--border-subtle)]">
             {overview.map((item) => {
-              const pct = getCategoryPercent(item.category_id)
+              const alert = alertsMap.get(item.category_id)
               return (
-                <div key={item.category_id} className="px-4 py-3.5 space-y-2">
-                  {/* 카테고리 이름 + 비율 */}
+                <div key={item.category_id} className="px-4 py-3.5 space-y-2 border-b border-[var(--border-subtle)] last:border-0">
+                  {/* 1. 카테고리 이름 + 사용률 뱃지 */}
                   <div className="flex items-center justify-between gap-2">
                     <span className="font-medium text-sm text-[var(--text-primary)] truncate">
                       {item.category_name}
                     </span>
-                    {pct != null && (
-                      <span className="text-xs text-grape-500 font-medium shrink-0">
-                        {pct.toFixed(1)}%
+                    {alert && (
+                      <span className={`text-xs font-semibold tabular-nums shrink-0 ${
+                        alert.is_exceeded ? 'text-rose-600' : alert.is_warning ? 'text-yellow-600' : 'text-leaf-600'
+                      }`}>
+                        {alert.usage_percentage.toFixed(0)}%
                       </span>
                     )}
                   </div>
 
-                  {/* 최근 지출 참고 */}
-                  {item.monthly_spending.length > 0 ? (
-                    <p className="text-xs text-[var(--text-muted)]">
-                      {item.monthly_spending
-                        .slice(0, 2)
-                        .map((s) => `${s.month}월 ${formatAmount(s.amount)}`)
-                        .join(' / ')}
-                    </p>
-                  ) : (
-                    <p className="text-xs text-[var(--text-muted)]">최근 지출 내역 없음</p>
+                  {/* 2. 진행바 + 지출 정보 (예산 설정 + 알림 데이터 있는 경우만) */}
+                  {alert && (
+                    <div className="space-y-1">
+                      <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
+                        <div
+                          data-testid={`progress-${item.category_name}`}
+                          className={`h-1.5 rounded-full transition-all ${getProgressColor(alert.usage_percentage, alert.is_exceeded)}`}
+                          style={{ width: `${Math.min(alert.usage_percentage, 100)}%` }}
+                        />
+                      </div>
+                      <div className="flex justify-between text-xs text-[var(--text-muted)]">
+                        <span className="tabular-nums">
+                          {formatAmount(alert.spent_amount)} 사용
+                        </span>
+                        {alert.is_exceeded ? (
+                          <span className="text-rose-600 font-medium tabular-nums">
+                            {formatAmount(Math.abs(alert.remaining_amount))} 초과
+                          </span>
+                        ) : (
+                          <span className="tabular-nums">
+                            {formatAmount(alert.remaining_amount)} 남음
+                          </span>
+                        )}
+                      </div>
+                    </div>
                   )}
 
-                  {/* 예산 입력 + 저장 */}
+                  {/* 3. 예산 입력 + 저장 */}
                   <div className="flex items-center gap-2">
-                    <div className="flex flex-1 items-center gap-1">
-                      <input
-                        type="text"
-                        inputMode="numeric"
-                        value={
-                          focusedCategoryId === item.category_id
-                            ? (localAmounts[item.category_id] ?? '')
-                            : displayBudgetValue(localAmounts[item.category_id] ?? '')
-                        }
-                        onChange={(e) => handleAmountChange(item.category_id, extractNumber(e.target.value))}
-                        onFocus={() => setFocusedCategoryId(item.category_id)}
-                        onBlur={() => setFocusedCategoryId(null)}
-                        className="input-base flex-1 text-right tabular-nums"
-                        placeholder="예산 없음"
-                        aria-label={`${item.category_name} 예산`}
-                      />
-                    </div>
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      value={
+                        focusedCategoryId === item.category_id
+                          ? (localAmounts[item.category_id] ?? '')
+                          : displayBudgetValue(localAmounts[item.category_id] ?? '')
+                      }
+                      onChange={(e) => handleAmountChange(item.category_id, extractNumber(e.target.value))}
+                      onFocus={() => setFocusedCategoryId(item.category_id)}
+                      onBlur={() => setFocusedCategoryId(null)}
+                      className="input-base flex-1 text-right tabular-nums"
+                      placeholder="예산 없음"
+                      aria-label={`${item.category_name} 예산`}
+                    />
                     {isDirty(item) && (
                       <button
                         onClick={() => handleSave(item)}

--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -18,6 +18,18 @@ import { Skeleton } from '../components/skeleton/Skeleton'
 import type { BudgetAlert, CategoryBudgetOverview } from '../types'
 import { formatAmount } from '../utils/format'
 
+/** 숫자 문자열을 ₩0,000 형식으로 표시. 빈 값이면 빈 문자열 반환 */
+function displayBudgetValue(raw: string): string {
+  const num = Number(raw)
+  if (!raw || isNaN(num) || num <= 0) return ''
+  return formatAmount(num)
+}
+
+/** 입력값에서 숫자만 추출 */
+function extractNumber(value: string): string {
+  return value.replace(/[^0-9]/g, '')
+}
+
 function BudgetManagerSkeleton() {
   return (
     <div className="space-y-3">
@@ -52,6 +64,10 @@ export default function BudgetManager() {
   const [totalBudget, setTotalBudget] = useState<number | null>(null)
   const [localTotalBudget, setLocalTotalBudget] = useState<string>('')
   const [savingTotal, setSavingTotal] = useState(false)
+
+  // 입력 포커스 상태 — 포커스 시 raw 숫자, blur 시 ₩ 포맷 표시
+  const [totalBudgetFocused, setTotalBudgetFocused] = useState(false)
+  const [focusedCategoryId, setFocusedCategoryId] = useState<number | null>(null)
 
   /**
    * 데이터 로드 — 카테고리 개요, 알림, 월 총 예산을 동시에 가져온다
@@ -261,17 +277,16 @@ export default function BudgetManager() {
         </div>
         <div className="flex items-center gap-2">
           <input
-            type="number"
+            type="text"
             inputMode="numeric"
-            min="0"
-            step="10000"
-            value={localTotalBudget}
-            onChange={(e) => setLocalTotalBudget(e.target.value)}
-            className="input-base w-44 text-right"
+            value={totalBudgetFocused ? localTotalBudget : displayBudgetValue(localTotalBudget)}
+            onChange={(e) => setLocalTotalBudget(extractNumber(e.target.value))}
+            onFocus={() => setTotalBudgetFocused(true)}
+            onBlur={() => setTotalBudgetFocused(false)}
+            className="input-base w-44 text-right tabular-nums"
             placeholder="미설정"
             aria-label="월 총 예산"
           />
-          <span className="text-sm text-[var(--text-tertiary)]">원</span>
           {isTotalDirty() && (
             <button
               onClick={handleSaveTotal}
@@ -416,17 +431,20 @@ export default function BudgetManager() {
                   <div className="flex items-center gap-2">
                     <div className="flex flex-1 items-center gap-1">
                       <input
-                        type="number"
+                        type="text"
                         inputMode="numeric"
-                        min="0"
-                        step="1000"
-                        value={localAmounts[item.category_id] ?? ''}
-                        onChange={(e) => handleAmountChange(item.category_id, e.target.value)}
-                        className="input-base flex-1 text-right"
+                        value={
+                          focusedCategoryId === item.category_id
+                            ? (localAmounts[item.category_id] ?? '')
+                            : displayBudgetValue(localAmounts[item.category_id] ?? '')
+                        }
+                        onChange={(e) => handleAmountChange(item.category_id, extractNumber(e.target.value))}
+                        onFocus={() => setFocusedCategoryId(item.category_id)}
+                        onBlur={() => setFocusedCategoryId(null)}
+                        className="input-base flex-1 text-right tabular-nums"
                         placeholder="예산 없음"
                         aria-label={`${item.category_name} 예산`}
                       />
-                      <span className="text-xs text-[var(--text-tertiary)] shrink-0">원</span>
                     </div>
                     {isDirty(item) && (
                       <button

--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -232,7 +232,7 @@ export default function BudgetManager() {
           <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
             <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
           </button>
-          <PiggyBank className="w-5 h-5 text-grape-500 flex-shrink-0" />
+          <PiggyBank data-testid="piggybank-icon" className="w-5 h-5 text-grape-500 flex-shrink-0" />
           <h1 className="text-lg font-semibold text-[var(--text-primary)]">예산 관리</h1>
         </div>
         <ErrorState message={error} onRetry={loadData} />

--- a/frontend/src/pages/__tests__/BudgetManager.test.tsx
+++ b/frontend/src/pages/__tests__/BudgetManager.test.tsx
@@ -570,14 +570,11 @@ describe('BudgetManager', () => {
   describe('에러 상태 헤더', () => {
     it('에러 상태에서도 PiggyBank 아이콘이 렌더링된다', async () => {
       setupErrorHandlers()
-      render(<MemoryRouter><BudgetManager /></MemoryRouter>)
+      renderBudgetManager()
       await waitFor(() => {
         expect(screen.getByRole('heading', { name: '예산 관리' })).toBeInTheDocument()
       })
-      const heading = screen.getByRole('heading', { name: '예산 관리' })
-      const headerDiv = heading.closest('div')!
-      const svgs = headerDiv.querySelectorAll('svg')
-      expect(svgs.length).toBeGreaterThanOrEqual(2)
+      expect(screen.getByTestId('piggybank-icon')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/__tests__/BudgetManager.test.tsx
+++ b/frontend/src/pages/__tests__/BudgetManager.test.tsx
@@ -48,6 +48,14 @@ const mockOverview: CategoryBudgetOverview[] = [
     category_id: 2,
     category_name: '교통',
     monthly_spending: [{ year: 2024, month: 1, amount: 50000 }],
+    current_budget_id: 2,
+    current_budget_amount: 100000,
+    alert_threshold: 0.8,
+  },
+  {
+    category_id: 3,
+    category_name: '여가',
+    monthly_spending: [],
     current_budget_id: null,
     current_budget_amount: null,
     alert_threshold: null,
@@ -181,23 +189,26 @@ describe('BudgetManager', () => {
       })
     })
 
-    it('카테고리별 최근 지출 내역을 ₩ 접두사 포맷으로 표시한다', async () => {
+    it('예산이 있는 카테고리의 진행바 사용 금액이 표시된다', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
 
       await waitFor(() => {
-        // 식비 최근 1월 ₩195,000 (formatAmount 사용, 원 접미사 아님)
-        expect(screen.getByText(/1월.*₩195,000/)).toBeInTheDocument()
+        // 식비 지출 ₩250,000 사용 (알림 데이터 기반)
+        expect(screen.getByText(/₩250,000 사용/)).toBeInTheDocument()
       })
     })
 
-    it('최근 지출 표시에 원 접미사를 사용하지 않는다', async () => {
+    it('최근 지출 참고 텍스트가 표시되지 않는다 (진행바로 대체됨)', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
 
       await waitFor(() => {
-        expect(screen.queryByText(/195,000원/)).not.toBeInTheDocument()
+        expect(screen.getByText('식비')).toBeInTheDocument()
       })
+
+      // monthly_spending 기반 "X월 ₩Y" 텍스트는 더 이상 표시되지 않음
+      expect(screen.queryByText(/1월.*₩195,000/)).not.toBeInTheDocument()
     })
 
     it('예산이 있는 카테고리의 입력 필드에 금액이 포맷되어 표시된다', async () => {
@@ -216,7 +227,7 @@ describe('BudgetManager', () => {
       renderBudgetManager()
 
       await waitFor(() => {
-        const input = screen.getByLabelText('교통 예산') as HTMLInputElement
+        const input = screen.getByLabelText('여가 예산') as HTMLInputElement
         expect(input.value).toBe('')
       })
     })
@@ -240,10 +251,10 @@ describe('BudgetManager', () => {
       renderBudgetManager()
 
       await waitFor(() => {
-        expect(screen.getByLabelText('교통 예산')).toBeInTheDocument()
+        expect(screen.getByLabelText('여가 예산')).toBeInTheDocument()
       })
 
-      const input = screen.getByLabelText('교통 예산')
+      const input = screen.getByLabelText('여가 예산')
       await user.type(input, '50000')
 
       expect(screen.getByRole('button', { name: '저장' })).toBeInTheDocument()
@@ -280,7 +291,7 @@ describe('BudgetManager', () => {
           return HttpResponse.json(
             {
               id: 10,
-              category_id: 2,
+              category_id: 3,
               amount: 50000,
               period: 'monthly',
               start_date: '2024-01-01T00:00:00Z',
@@ -297,10 +308,10 @@ describe('BudgetManager', () => {
       renderBudgetManager()
 
       await waitFor(() => {
-        expect(screen.getByLabelText('교통 예산')).toBeInTheDocument()
+        expect(screen.getByLabelText('여가 예산')).toBeInTheDocument()
       })
 
-      const input = screen.getByLabelText('교통 예산')
+      const input = screen.getByLabelText('여가 예산')
       await user.type(input, '50000')
 
       const saveButton = screen.getByRole('button', { name: '저장' })
@@ -384,68 +395,65 @@ describe('BudgetManager', () => {
     })
   })
 
-  describe('예산 상황', () => {
-    it('경고 상황의 사용률을 표시한다', async () => {
+  describe('카테고리 행 — 예산 상황 통합', () => {
+    it('예산 설정 + 지출 있는 카테고리는 진행바가 표시된다', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
-
-      await waitFor(() => {
-        expect(screen.getByText('83.3%')).toBeInTheDocument()
-      })
+      await waitFor(() => screen.getByText('식비'))
+      const progressBar = document.querySelector('[data-testid="progress-식비"]')
+      expect(progressBar).toBeInTheDocument()
     })
 
-    it('초과 상황의 사용률을 표시한다', async () => {
+    it('예산 초과 카테고리는 초과 금액 텍스트가 표시된다', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
-
-      await waitFor(() => {
-        expect(screen.getByText('120.0%')).toBeInTheDocument()
-      })
+      await waitFor(() => screen.getByText('교통'))
+      expect(screen.getByText(/₩20,000 초과/)).toBeInTheDocument()
     })
 
-    it('예산 초과 시 경고 메시지를 표시한다', async () => {
+    it('예산 미설정 카테고리는 진행바가 없다', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
-
-      await waitFor(() => {
-        expect(screen.getByText('예산을 초과했습니다!')).toBeInTheDocument()
-      })
+      await waitFor(() => screen.getByText('여가'))
+      const progressBar = document.querySelector('[data-testid="progress-여가"]')
+      expect(progressBar).not.toBeInTheDocument()
     })
 
-    it('경고 상태일 때 80% 경고 메시지를 표시한다', async () => {
+    it('"예산 상황" 섹션 헤더가 더 이상 렌더링되지 않는다', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
-
-      await waitFor(() => {
-        expect(screen.getByText('예산의 80%를 사용했습니다')).toBeInTheDocument()
-      })
-    })
-
-    it('예산 상황 섹션 제목을 표시한다', async () => {
-      setupSuccessHandlers()
-      renderBudgetManager()
-
-      await waitFor(() => {
-        expect(screen.getByText('예산 상황')).toBeInTheDocument()
-      })
-    })
-
-    it('상황이 없으면 상황 섹션을 표시하지 않는다', async () => {
-      server.use(
-        http.get('/api/budgets/category-overview', () => HttpResponse.json(mockOverview)),
-        http.get('/api/budgets/alerts', () => HttpResponse.json([])),
-        http.get('/api/budgets/total-budget', () =>
-          HttpResponse.json({ total_monthly_budget: null })
-        ),
-      )
-
-      renderBudgetManager()
-
-      await waitFor(() => {
-        expect(screen.getByText('월 총 예산')).toBeInTheDocument()
-      })
-
+      await waitFor(() => screen.getByText('식비'))
       expect(screen.queryByText('예산 상황')).not.toBeInTheDocument()
+    })
+
+    it('경고 상태 카테고리의 사용률 뱃지가 카테고리 행에 표시된다', async () => {
+      setupSuccessHandlers()
+      renderBudgetManager()
+      await waitFor(() => screen.getByText('식비'))
+      // 83.3% → toFixed(0) → "83%"
+      expect(screen.getByText('83%')).toBeInTheDocument()
+    })
+
+    it('초과 상태 카테고리의 사용률 뱃지가 카테고리 행에 표시된다', async () => {
+      setupSuccessHandlers()
+      renderBudgetManager()
+      await waitFor(() => screen.getByText('교통'))
+      // 120.0% → toFixed(0) → "120%"
+      expect(screen.getByText('120%')).toBeInTheDocument()
+    })
+
+    it('예산 설정 카테고리는 사용 금액 텍스트가 표시된다', async () => {
+      setupSuccessHandlers()
+      renderBudgetManager()
+      await waitFor(() => screen.getByText('식비'))
+      expect(screen.getByText(/₩250,000 사용/)).toBeInTheDocument()
+    })
+
+    it('예산 미초과 카테고리는 남은 금액 텍스트가 표시된다', async () => {
+      setupSuccessHandlers()
+      renderBudgetManager()
+      await waitFor(() => screen.getByText('식비'))
+      expect(screen.getByText(/₩50,000 남음/)).toBeInTheDocument()
     })
   })
 
@@ -481,13 +489,13 @@ describe('BudgetManager', () => {
       })
     })
 
-    it('카테고리별 비율을 표시한다', async () => {
+    it('예산 사용률 뱃지를 카테고리 행에 표시한다', async () => {
       setupSuccessHandlers(3000000)
       renderBudgetManager()
 
       await waitFor(() => {
-        // 식비 300,000 / 3,000,000 = 10.0%
-        expect(screen.getByText('10.0%')).toBeInTheDocument()
+        // 식비 83.3% → toFixed(0) → "83%"
+        expect(screen.getByText('83%')).toBeInTheDocument()
       })
     })
   })
@@ -528,23 +536,23 @@ describe('BudgetManager', () => {
         expect(screen.getByText(/남은 예산:/)).toBeInTheDocument()
       })
 
-      // 남은 예산: ₩2,700,000
+      // 남은 예산: ₩3,000,000 - ₩300,000(식비) - ₩100,000(교통) = ₩2,600,000
       const allSpans = document.querySelectorAll('span.tabular-nums')
       const remainingSpans = Array.from(allSpans).filter(
-        (el) => el.textContent && el.textContent.includes('₩2,700,000')
+        (el) => el.textContent && el.textContent.includes('₩2,600,000')
       )
       expect(remainingSpans.length).toBeGreaterThan(0)
     })
 
-    it('예산 상황 카드의 사용/예산 금액에 tabular-nums 스타일 span이 있다', async () => {
+    it('카테고리 행 지출 금액에 tabular-nums 스타일 span이 있다', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
 
       await waitFor(() => {
-        expect(screen.getAllByText(/사용:/).length).toBeGreaterThan(0)
+        expect(screen.getByText(/₩250,000 사용/)).toBeInTheDocument()
       })
 
-      // 사용: ₩250,000 / ₩300,000 (식비 카드)
+      // 사용 금액 span에 tabular-nums 적용 (식비: ₩250,000 사용)
       const allSpans = document.querySelectorAll('span.tabular-nums')
       const usageSpans = Array.from(allSpans).filter(
         (el) => el.textContent && el.textContent.includes('₩250,000')
@@ -552,15 +560,15 @@ describe('BudgetManager', () => {
       expect(usageSpans.length).toBeGreaterThan(0)
     })
 
-    it('예산 상황 카드의 남은 금액에 tabular-nums 스타일 span이 있다', async () => {
+    it('카테고리 행 남은 금액에 tabular-nums 스타일 span이 있다', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
 
       await waitFor(() => {
-        expect(screen.getAllByText(/남은 금액:/).length).toBeGreaterThan(0)
+        expect(screen.getByText(/₩50,000 남음/)).toBeInTheDocument()
       })
 
-      // 남은 금액: ₩50,000 (식비 카드)
+      // 남은 금액 span에 tabular-nums 적용 (식비: ₩50,000 남음)
       const allSpans = document.querySelectorAll('span.tabular-nums')
       const remainingSpans = Array.from(allSpans).filter(
         (el) => el.textContent && el.textContent.includes('₩50,000')
@@ -619,9 +627,9 @@ describe('BudgetManager', () => {
     it('예산 미설정 카테고리 — 입력란 placeholder가 "예산 없음"이다', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
-      await waitFor(() => screen.getByLabelText('식비 예산'))
+      await waitFor(() => screen.getByLabelText('여가 예산'))
       // 카테고리 예산 입력 필드는 예산 유무와 관계없이 placeholder="예산 없음" 표시
-      const input = screen.getByLabelText('식비 예산') as HTMLInputElement
+      const input = screen.getByLabelText('여가 예산') as HTMLInputElement
       expect(input.placeholder).toBe('예산 없음')
     })
   })

--- a/frontend/src/pages/__tests__/BudgetManager.test.tsx
+++ b/frontend/src/pages/__tests__/BudgetManager.test.tsx
@@ -567,6 +567,20 @@ describe('BudgetManager', () => {
     })
   })
 
+  describe('에러 상태 헤더', () => {
+    it('에러 상태에서도 PiggyBank 아이콘이 렌더링된다', async () => {
+      setupErrorHandlers()
+      render(<MemoryRouter><BudgetManager /></MemoryRouter>)
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: '예산 관리' })).toBeInTheDocument()
+      })
+      const heading = screen.getByRole('heading', { name: '예산 관리' })
+      const headerDiv = heading.closest('div')!
+      const svgs = headerDiv.querySelectorAll('svg')
+      expect(svgs.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
   describe('에러 상태', () => {
     it('API 에러 발생 시 에러 상태를 표시한다', async () => {
       setupErrorHandlers()

--- a/frontend/src/pages/__tests__/BudgetManager.test.tsx
+++ b/frontend/src/pages/__tests__/BudgetManager.test.tsx
@@ -607,6 +607,23 @@ describe('BudgetManager', () => {
       await user.tab()
       expect(input.value).toBe('₩300,000')
     })
+
+    it('월 총 예산 입력란 — 인풋 옆에 "원" 텍스트가 없다', async () => {
+      setupSuccessHandlers()
+      renderBudgetManager()
+      await waitFor(() => screen.getByLabelText('월 총 예산'))
+      // 페이지 어디에도 단독 "원" 텍스트 노드가 없어야 함 (₩ 접두사 방식 사용)
+      expect(screen.queryByText('원')).not.toBeInTheDocument()
+    })
+
+    it('예산 미설정 카테고리 — 입력란 placeholder가 "예산 없음"이다', async () => {
+      setupSuccessHandlers()
+      renderBudgetManager()
+      await waitFor(() => screen.getByLabelText('식비 예산'))
+      // 카테고리 예산 입력 필드는 예산 유무와 관계없이 placeholder="예산 없음" 표시
+      const input = screen.getByLabelText('식비 예산') as HTMLInputElement
+      expect(input.placeholder).toBe('예산 없음')
+    })
   })
 
   describe('에러 상태 헤더', () => {

--- a/frontend/src/pages/__tests__/BudgetManager.test.tsx
+++ b/frontend/src/pages/__tests__/BudgetManager.test.tsx
@@ -200,13 +200,14 @@ describe('BudgetManager', () => {
       })
     })
 
-    it('예산이 있는 카테고리의 입력 필드에 금액이 표시된다', async () => {
+    it('예산이 있는 카테고리의 입력 필드에 금액이 포맷되어 표시된다', async () => {
       setupSuccessHandlers()
       renderBudgetManager()
 
       await waitFor(() => {
-        const input = screen.getByLabelText('식비 예산')
-        expect(input).toHaveValue(300000)
+        const input = screen.getByLabelText('식비 예산') as HTMLInputElement
+        // blur 상태에서 ₩ 포맷으로 표시
+        expect(input.value).toBe('₩300,000')
       })
     })
 
@@ -215,8 +216,8 @@ describe('BudgetManager', () => {
       renderBudgetManager()
 
       await waitFor(() => {
-        const input = screen.getByLabelText('교통 예산')
-        expect(input).toHaveValue(null)
+        const input = screen.getByLabelText('교통 예산') as HTMLInputElement
+        expect(input.value).toBe('')
       })
     })
 
@@ -458,13 +459,14 @@ describe('BudgetManager', () => {
       })
     })
 
-    it('저장된 월 총 예산 금액을 표시한다', async () => {
+    it('저장된 월 총 예산 금액을 포맷되어 표시한다', async () => {
       setupSuccessHandlers(3000000)
       renderBudgetManager()
 
       await waitFor(() => {
-        const input = screen.getByLabelText('월 총 예산')
-        expect(input).toHaveValue(3000000)
+        const input = screen.getByLabelText('월 총 예산') as HTMLInputElement
+        // blur 상태에서 ₩ 포맷으로 표시
+        expect(input.value).toBe('₩3,000,000')
       })
     })
 
@@ -564,6 +566,46 @@ describe('BudgetManager', () => {
         (el) => el.textContent && el.textContent.includes('₩50,000')
       )
       expect(remainingSpans.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('금액 입력 포맷', () => {
+    it('월 총 예산 입력란 — blur 시 ₩ 포맷으로 표시된다', async () => {
+      const user = userEvent.setup()
+      setupSuccessHandlers()
+      renderBudgetManager()
+      await waitFor(() => screen.getByLabelText('월 총 예산'))
+
+      const input = screen.getByLabelText('월 총 예산') as HTMLInputElement
+      await user.clear(input)
+      await user.type(input, '200000')
+      await user.tab()
+      expect(input.value).toBe('₩200,000')
+    })
+
+    it('월 총 예산 입력란 — focus 시 raw 숫자로 표시된다', async () => {
+      const user = userEvent.setup()
+      setupSuccessHandlers(500000)
+      renderBudgetManager()
+      await waitFor(() => screen.getByLabelText('월 총 예산'))
+
+      const input = screen.getByLabelText('월 총 예산') as HTMLInputElement
+      await user.click(input)
+      // 포커스 상태에서는 raw 숫자만 표시
+      expect(input.value).toMatch(/^\d+$/)
+    })
+
+    it('카테고리 예산 입력란 — blur 시 ₩ 포맷으로 표시된다', async () => {
+      const user = userEvent.setup()
+      setupSuccessHandlers()
+      renderBudgetManager()
+      await waitFor(() => screen.getByLabelText('식비 예산'))
+
+      const input = screen.getByLabelText('식비 예산') as HTMLInputElement
+      await user.clear(input)
+      await user.type(input, '300000')
+      await user.tab()
+      expect(input.value).toBe('₩300,000')
     })
   })
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@ dependencies = [
     "alembic==1.13.1",
     "pydantic>=2.7.0,<3.0.0",  # fastapi 0.130+이 pydantic>=2.7.0 요구 (#237)
     "pydantic-settings>=2.1.0,<3.0.0",
-    "python-dotenv==1.0.1",
+    "python-dotenv>=1.2.2",  # CVE-2026-28684 픽스 버전 (#237)
     "asyncpg>=0.29.0",
     "aiosqlite>=0.20.0",
-    "python-multipart>=0.0.7",
+    "python-multipart>=0.0.26",  # CVE-2026-40347 픽스 버전 (#237)
     "httpx==0.26.0",
     "anthropic>=0.40.0",
     "python-jose[cryptography]>=3.3.0",
@@ -85,4 +85,3 @@ module = [
     "openai.*",
 ]
 ignore_missing_imports = true
-

--- a/uv.lock
+++ b/uv.lock
@@ -1267,9 +1267,9 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = "==7.4.4" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==0.23.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==4.1.0" },
-    { name = "python-dotenv", specifier = "==1.0.1" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
-    { name = "python-multipart", specifier = ">=0.0.7" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "radon", marker = "extra == 'dev'", specifier = ">=6.0,<7.0" },
     { name = "resend", specifier = ">=2.0,<3.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.8.6" },
@@ -1501,11 +1501,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.0.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115, upload-time = "2024-01-23T06:33:00.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863, upload-time = "2024-01-23T06:32:58.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1529,11 +1529,11 @@ cryptography = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- 예산상황 섹션 제거: 별도 카드 → 카테고리 행에 진행바·사용금액·초과 여부 통합
- ₩0,000 포맷 입력: 월 총 예산 + 카테고리별 모든 입력란에 focus/blur 포맷 전환 적용
- 헤더 아이콘 통일: 에러 상태에서도 PiggyBank 아이콘 표시
- 스켈레톤 업데이트: 통합된 레이아웃에 맞게 스켈레톤 구조 개선

## Test plan
- [ ] 예산 있는 카테고리: 진행바 + 사용금액/남은금액 표시
- [ ] 예산 초과: 빨간 진행바 + "₩X 초과" 텍스트
- [ ] 예산 없는 카테고리: 진행바 없음, 입력만
- [ ] 금액 입력 클릭 시 raw 숫자 표시 (200000)
- [ ] 입력 후 다른 곳 클릭 시 ₩200,000 포맷 표시
- [ ] "예산 상황" 헤더 미표시
- [ ] 에러 상태에서 PiggyBank 아이콘 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)