### PR TITLE
fix: 예산 저장 후 전체 페이지 리프레시 제거

### DIFF
--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -253,19 +253,40 @@ export default function BudgetManager() {
         if (item.current_budget_id) {
           await budgetApi.deleteBudget(item.current_budget_id)
         }
+        // 해당 row만 초기화 (전체 리프레시 없이)
+        setOverview((prev) =>
+          prev.map((o) =>
+            o.category_id === item.category_id
+              ? { ...o, current_budget_id: null, current_budget_amount: null }
+              : o,
+          ),
+        )
       } else if (item.current_budget_id) {
         // 기존 예산 수정
         await budgetApi.updateBudget(item.current_budget_id, { amount: numAmount })
+        // 금액만 갱신
+        setOverview((prev) =>
+          prev.map((o) =>
+            o.category_id === item.category_id ? { ...o, current_budget_amount: numAmount } : o,
+          ),
+        )
       } else {
         // 새 예산 생성 — 월간, 오늘부터
-        await budgetApi.createBudget({
+        const res = await budgetApi.createBudget({
           category_id: item.category_id,
           amount: numAmount,
           period: 'monthly',
           start_date: new Date().toISOString().split('T')[0],
         })
+        // 새 budget_id + 금액 반영
+        setOverview((prev) =>
+          prev.map((o) =>
+            o.category_id === item.category_id
+              ? { ...o, current_budget_id: res.data.id, current_budget_amount: numAmount }
+              : o,
+          ),
+        )
       }
-      await loadData()
       // 체크마크 0.8초 표시
       setSavedIds((prev) => new Set([...prev, item.category_id]))
       setTimeout(() => {


### PR DESCRIPTION
## 변경 내용

예산 저장(blur) 시 `loadData()` 전체 재조회 대신 해당 카테고리 row만 로컬 상태 업데이트.

**케이스별 처리:**
- 삭제: `current_budget_id: null, current_budget_amount: null`
- 수정: `current_budget_amount: numAmount`
- 생성: `current_budget_id: res.data.id, current_budget_amount: numAmount`

## 개선 효과
저장 시 스크롤 위치 유지, 다른 카테고리 입력 포커스 유지, 깜빡임 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)