### PR TITLE
feat: 정기거래 UX 개편 — 카드 레이아웃 + 결제수단 연결

### DIFF
--- a/backend/alembic/versions/0447179ae24d_merge_household_profile_and_recurring_.py
+++ b/backend/alembic/versions/0447179ae24d_merge_household_profile_and_recurring_.py
@@ -1,0 +1,25 @@
+"""merge_household_profile_and_recurring_payment_method
+
+Revision ID: 0447179ae24d
+Revises: 9e4524bd33ae, b2c3d4e5f6a7
+Create Date: 2026-04-26 13:35:06.761028
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "0447179ae24d"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = ("9e4524bd33ae", "b2c3d4e5f6a7")  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/backend/alembic/versions/9e4524bd33ae_add_payment_method_to_recurring.py
+++ b/backend/alembic/versions/9e4524bd33ae_add_payment_method_to_recurring.py
@@ -1,0 +1,36 @@
+"""recurring_transactions에 payment_method_id 추가
+
+Revision ID: 9e4524bd33ae
+Revises: z9a0b1c2d3e4
+Create Date: 2026-04-26
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "9e4524bd33ae"  # pragma: allowlist secret
+down_revision = "z9a0b1c2d3e4"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("recurring_transactions") as batch_op:
+        batch_op.add_column(sa.Column("payment_method_id", sa.Integer(), nullable=True))
+        # SQLite는 FK constraint 이름 지원이 제한적이므로 조건부 처리
+        if op.get_bind().dialect.name != "sqlite":
+            batch_op.create_foreign_key(
+                "fk_recurring_payment_method",
+                "payment_methods",
+                ["payment_method_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("recurring_transactions") as batch_op:
+        if op.get_bind().dialect.name != "sqlite":
+            batch_op.drop_constraint("fk_recurring_payment_method", type_="foreignkey")
+        batch_op.drop_column("payment_method_id")

--- a/backend/app/api/recurring.py
+++ b/backend/app/api/recurring.py
@@ -104,6 +104,7 @@ async def create_recurring(
         amount=data.amount,
         description=data.description,
         category_id=data.category_id,
+        payment_method_id=data.payment_method_id,
         frequency=data.frequency,
         interval=data.interval,
         day_of_month=data.day_of_month,
@@ -121,9 +122,18 @@ async def create_recurring(
         source_record.recurring_transaction_id = recurring.id
 
     await db.commit()
-    await db.refresh(recurring)
     logger.info("정기 거래 생성: user=%s, description=%s, amount=%s", current_user.id, data.description, data.amount)
-    return recurring
+    # 관계 로드를 위해 selectinload 포함하여 재조회
+    result = await db.execute(
+        select(RecurringTransaction)
+        .where(RecurringTransaction.id == recurring.id)
+        .options(
+            selectinload(RecurringTransaction.category),
+            selectinload(RecurringTransaction.payment_method),
+        )
+    )
+    recurring = result.scalar_one()
+    return RecurringTransactionResponse.from_orm_extended(recurring)
 
 
 @router.get("", response_model=list[RecurringTransactionResponse])
@@ -142,9 +152,12 @@ async def get_recurring_list(
     if type is not None:
         query = query.where(RecurringTransaction.type == type)
 
-    query = query.order_by(RecurringTransaction.next_due_date.asc()).options(selectinload(RecurringTransaction.category))
+    query = query.order_by(RecurringTransaction.next_due_date.asc()).options(
+        selectinload(RecurringTransaction.category),
+        selectinload(RecurringTransaction.payment_method),
+    )
     result = await db.execute(query)
-    return [RecurringTransactionResponse.from_orm_with_emoji(r) for r in result.scalars().all()]
+    return [RecurringTransactionResponse.from_orm_extended(r) for r in result.scalars().all()]
 
 
 @router.get("/pending", response_model=list[RecurringTransactionResponse])
@@ -165,9 +178,12 @@ async def get_pending_recurring(
         RecurringTransaction.is_active.is_(True),
     )
 
-    query = query.order_by(RecurringTransaction.next_due_date.asc()).options(selectinload(RecurringTransaction.category))
+    query = query.order_by(RecurringTransaction.next_due_date.asc()).options(
+        selectinload(RecurringTransaction.category),
+        selectinload(RecurringTransaction.payment_method),
+    )
     result = await db.execute(query)
-    return [RecurringTransactionResponse.from_orm_with_emoji(r) for r in result.scalars().all()]
+    return [RecurringTransactionResponse.from_orm_extended(r) for r in result.scalars().all()]
 
 
 @router.get("/{recurring_id}", response_model=RecurringTransactionResponse)
@@ -178,7 +194,7 @@ async def get_recurring(
 ) -> object:
     """정기 거래 상세 조회"""
     recurring = await _get_user_recurring(recurring_id, current_user, db)
-    return recurring
+    return RecurringTransactionResponse.from_orm_extended(recurring)
 
 
 @router.put("/{recurring_id}", response_model=RecurringTransactionResponse)
@@ -197,7 +213,7 @@ async def update_recurring(
 
     await db.commit()
     await db.refresh(recurring)
-    return recurring
+    return RecurringTransactionResponse.from_orm_extended(recurring)
 
 
 @router.delete("/{recurring_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -275,8 +291,15 @@ async def _get_user_recurring(
     current_user: User,
     db: AsyncSession,
 ) -> RecurringTransaction:
-    """사용자의 정기 거래 조회 (본인 또는 가구 멤버)"""
-    result = await db.execute(select(RecurringTransaction).where(RecurringTransaction.id == recurring_id))
+    """사용자의 정기 거래 조회 (본인 또는 가구 멤버) — category, payment_method 관계 포함"""
+    result = await db.execute(
+        select(RecurringTransaction)
+        .where(RecurringTransaction.id == recurring_id)
+        .options(
+            selectinload(RecurringTransaction.category),
+            selectinload(RecurringTransaction.payment_method),
+        )
+    )
     recurring = result.scalar_one_or_none()
 
     if not recurring:

--- a/backend/app/api/recurring.py
+++ b/backend/app/api/recurring.py
@@ -212,7 +212,16 @@ async def update_recurring(
         setattr(recurring, key, value)
 
     await db.commit()
-    await db.refresh(recurring)
+    # refresh 대신 relationship 포함해서 재조회 (db.refresh는 관계를 로드하지 않음)
+    result = await db.execute(
+        select(RecurringTransaction)
+        .options(
+            selectinload(RecurringTransaction.category),
+            selectinload(RecurringTransaction.payment_method),
+        )
+        .where(RecurringTransaction.id == recurring.id)
+    )
+    recurring = result.scalar_one()
     return RecurringTransactionResponse.from_orm_extended(recurring)
 
 

--- a/backend/app/models/recurring_transaction.py
+++ b/backend/app/models/recurring_transaction.py
@@ -40,6 +40,11 @@ class RecurringTransaction(Base):  # type: ignore[misc]
     amount = Column(Numeric(12, 2), nullable=False)
     description = Column(String, nullable=False)
     category_id = Column(Integer, ForeignKey("categories.id", ondelete="SET NULL"), nullable=True)
+    payment_method_id = Column(
+        Integer,
+        ForeignKey("payment_methods.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     frequency = Column(String(10), nullable=False)  # monthly | weekly | yearly | custom
     interval = Column(Integer, nullable=True)  # custom일 때 N일
     day_of_month = Column(Integer, nullable=True)  # 1-31
@@ -55,6 +60,7 @@ class RecurringTransaction(Base):  # type: ignore[misc]
     # Relationships
     user = relationship("User")
     category = relationship("Category")
+    payment_method = relationship("PaymentMethod")
     household = relationship("Household")
     expenses = relationship("Expense", back_populates="recurring_transaction")
     incomes = relationship("Income", back_populates="recurring_transaction")

--- a/backend/app/schemas/recurring_transaction.py
+++ b/backend/app/schemas/recurring_transaction.py
@@ -55,6 +55,7 @@ class RecurringTransactionResponse(RecurringTransactionBase):
     is_active: bool
     created_at: datetime
     updated_at: datetime
+    payment_method_id: int | None = None  # 모달 편집 시 pre-populate용
     category_emoji: str | None = None  # 카테고리 이모지
     category_name: str | None = None  # 카테고리명
     payment_method_name: str | None = None  # 결제수단명

--- a/backend/app/schemas/recurring_transaction.py
+++ b/backend/app/schemas/recurring_transaction.py
@@ -35,12 +35,14 @@ class RecurringTransactionBase(BaseModel):
 class RecurringTransactionCreate(RecurringTransactionBase):
     household_id: int | None = None
     source_id: int | None = None  # 원본 거래 ID (기존 거래에서 등록 시)
+    payment_method_id: int | None = None
 
 
 class RecurringTransactionUpdate(BaseModel):
     amount: float | None = Field(None, gt=0)
     description: str | None = None
     category_id: int | None = None
+    payment_method_id: int | None = None
     is_active: bool | None = None
     end_date: date | None = None
 
@@ -53,16 +55,21 @@ class RecurringTransactionResponse(RecurringTransactionBase):
     is_active: bool
     created_at: datetime
     updated_at: datetime
-    category_emoji: str | None = None  # 카테고리 이모지 (category relationship에서 추출)
+    category_emoji: str | None = None  # 카테고리 이모지
+    category_name: str | None = None  # 카테고리명
+    payment_method_name: str | None = None  # 결제수단명
 
     model_config = {"from_attributes": True}
 
     @classmethod
-    def from_orm_with_emoji(cls, obj: object) -> "RecurringTransactionResponse":
-        """ORM 객체에서 category.emoji를 추출하여 category_emoji 필드에 매핑"""
+    def from_orm_extended(cls, obj: object) -> "RecurringTransactionResponse":
+        """ORM 객체에서 category, payment_method 관계를 추출"""
         data = cls.model_validate(obj)
         category = getattr(obj, "category", None)
         data.category_emoji = getattr(category, "emoji", None) if category else None
+        data.category_name = getattr(category, "name", None) if category else None
+        payment_method = getattr(obj, "payment_method", None)
+        data.payment_method_name = getattr(payment_method, "name", None) if payment_method else None
         return data
 
 

--- a/backend/tests/integration/test_api_recurring.py
+++ b/backend/tests/integration/test_api_recurring.py
@@ -715,8 +715,19 @@ async def test_create_with_payment_method(authenticated_client, test_household, 
 
 @pytest.mark.asyncio
 async def test_list_includes_payment_method_name(authenticated_client, test_household, db_session):
-    """목록 응답에 payment_method_name 포함"""
+    """목록 응답에 payment_method_name이 실제로 포함되어 반환된다"""
     from datetime import date
+
+    from app.models.payment_method import PaymentMethod
+
+    pm = PaymentMethod(
+        household_id=test_household.id,
+        name="국민카드",
+        type="credit_card",
+        is_active=True,
+    )
+    db_session.add(pm)
+    await db_session.flush()
 
     rt = RecurringTransaction(
         user_id=1,
@@ -728,6 +739,7 @@ async def test_list_includes_payment_method_name(authenticated_client, test_hous
         day_of_month=25,
         start_date=date(2026, 1, 1),
         next_due_date=date(2026, 5, 25),
+        payment_method_id=pm.id,
     )
     db_session.add(rt)
     await db_session.commit()
@@ -735,8 +747,11 @@ async def test_list_includes_payment_method_name(authenticated_client, test_hous
     response = await authenticated_client.get("/api/recurring")
     assert response.status_code == 200
     data = response.json()
-    assert "payment_method_name" in data[0]
-    assert "category_name" in data[0]
+    # 실제 값 검증
+    netflix = next((item for item in data if item["description"] == "넷플릭스"), None)
+    assert netflix is not None
+    assert netflix["payment_method_name"] == "국민카드"
+    assert "category_name" in netflix
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_api_recurring.py
+++ b/backend/tests/integration/test_api_recurring.py
@@ -692,6 +692,54 @@ async def test_execute_with_override_amount(authenticated_client, db_session, te
 
 
 @pytest.mark.asyncio
+async def test_create_with_payment_method(authenticated_client, test_household, db_session):
+    """payment_method_id 포함 정기거래 생성"""
+    from app.models.payment_method import PaymentMethod
+
+    pm = PaymentMethod(
+        household_id=test_household.id,
+        name="삼성카드",
+        type="credit_card",
+        is_active=True,
+    )
+    db_session.add(pm)
+    await db_session.commit()
+    await db_session.refresh(pm)
+
+    payload = _monthly_payload(payment_method_id=pm.id)
+    response = await authenticated_client.post("/api/recurring", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["payment_method_name"] == "삼성카드"
+
+
+@pytest.mark.asyncio
+async def test_list_includes_payment_method_name(authenticated_client, test_household, db_session):
+    """목록 응답에 payment_method_name 포함"""
+    from datetime import date
+
+    rt = RecurringTransaction(
+        user_id=1,
+        household_id=test_household.id,
+        type="expense",
+        amount=17000,
+        description="넷플릭스",
+        frequency="monthly",
+        day_of_month=25,
+        start_date=date(2026, 1, 1),
+        next_due_date=date(2026, 5, 25),
+    )
+    db_session.add(rt)
+    await db_session.commit()
+
+    response = await authenticated_client.get("/api/recurring")
+    assert response.status_code == 200
+    data = response.json()
+    assert "payment_method_name" in data[0]
+    assert "category_name" in data[0]
+
+
+@pytest.mark.asyncio
 async def test_execute_without_body_uses_default_amount(authenticated_client, db_session, test_user: User, test_household: Household):
     """바디 없이 실행하면 기본 금액으로 거래가 생성된다"""
     from sqlalchemy import select

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -22,6 +22,10 @@ export default defineConfig([
       globals: globals.browser,
     },
     rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { varsIgnorePattern: '^_', argsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_' },
+      ],
       'react-refresh/only-export-components': [
         'warn',
         { allowExportNames: ['useAuth', 'useToast'] },

--- a/frontend/src/components/recurring/RecurringModal.tsx
+++ b/frontend/src/components/recurring/RecurringModal.tsx
@@ -6,7 +6,7 @@
  */
 
 import { X } from 'lucide-react'
-import type { Category } from '../../types'
+import type { Category, PaymentMethod } from '../../types'
 import FrequencyFields from './FrequencyFields'
 
 /** 모달 폼 데이터 타입 */
@@ -15,6 +15,7 @@ export interface RecurringFormData {
   amount: string
   description: string
   category_id: string
+  payment_method_id: string  // 빈 문자열 = 없음
   frequency: 'monthly' | 'weekly' | 'yearly' | 'custom'
   day_of_month: string
   day_of_week: string
@@ -33,6 +34,8 @@ interface RecurringModalProps {
   onFormChange: (data: RecurringFormData) => void
   /** 카테고리 목록 (타입 필터링 전) */
   categories: Category[]
+  /** 결제수단 목록 */
+  paymentMethods: PaymentMethod[]
   /** 제출 중 여부 */
   submitting: boolean
   /** 폼 제출 핸들러 */
@@ -48,6 +51,7 @@ export default function RecurringModal({
   formData,
   onFormChange,
   categories,
+  paymentMethods,
   submitting,
   onSubmit,
   onClose,
@@ -141,6 +145,26 @@ export default function RecurringModal({
               <option value="">선택 안 함</option>
               {filteredCategories.map((c) => (
                 <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* 결제수단 */}
+          <div>
+            <label htmlFor="reclist-payment-method" className="block text-sm font-medium text-[var(--text-secondary)] mb-2">
+              결제수단
+            </label>
+            <select
+              id="reclist-payment-method"
+              value={formData.payment_method_id}
+              onChange={(e) => updateField('payment_method_id', e.target.value)}
+              className={INPUT_CLASSES}
+            >
+              <option value="">없음</option>
+              {paymentMethods.map((pm) => (
+                <option key={pm.id} value={String(pm.id)}>
+                  {pm.name}
+                </option>
               ))}
             </select>
           </div>

--- a/frontend/src/components/recurring/__tests__/RecurringModal.test.tsx
+++ b/frontend/src/components/recurring/__tests__/RecurringModal.test.tsx
@@ -8,13 +8,14 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import RecurringModal from '../RecurringModal'
 import type { RecurringFormData } from '../RecurringModal'
-import type { Category } from '../../../types'
+import type { Category, PaymentMethod } from '../../../types'
 
 const emptyForm: RecurringFormData = {
   type: 'expense',
   amount: '',
   description: '',
   category_id: '',
+  payment_method_id: '',
   frequency: 'monthly',
   day_of_month: '25',
   day_of_week: '0',
@@ -30,11 +31,17 @@ const mockCategories: Category[] = [
   { id: 3, name: '기타', type: 'both', description: null, sort_order: 3, is_savings: false, is_system: true, exclude_auto_payment: false, emoji: null, created_at: '2026-01-01T00:00:00Z' },
 ]
 
+const mockPaymentMethods: PaymentMethod[] = [
+  { id: 1, household_id: 1, created_by: 1, name: '신용카드', type: 'credit_card', monthly_target: null, is_default: true, is_system: false, is_active: true, display_order: 1, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+  { id: 2, household_id: 1, created_by: 1, name: '현금', type: 'cash', monthly_target: null, is_default: false, is_system: false, is_active: true, display_order: 2, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+]
+
 const defaultProps = {
   editingId: null,
   formData: emptyForm,
   onFormChange: vi.fn(),
   categories: mockCategories,
+  paymentMethods: mockPaymentMethods,
   submitting: false,
   onSubmit: vi.fn((e: React.FormEvent) => e.preventDefault()),
   onClose: vi.fn(),

--- a/frontend/src/components/recurring/__tests__/RecurringModal.test.tsx
+++ b/frontend/src/components/recurring/__tests__/RecurringModal.test.tsx
@@ -245,4 +245,15 @@ describe('RecurringModal', () => {
     const dialog = screen.getByRole('dialog')
     expect(dialog).toHaveAttribute('aria-modal', 'true')
   })
+
+  // ==================== 결제수단 드롭다운 ====================
+
+  describe('결제수단 드롭다운', () => {
+    it('결제수단 드롭다운에 paymentMethods 옵션이 표시된다', () => {
+      render(<RecurringModal {...defaultProps} />)
+      expect(screen.getByLabelText('결제수단')).toBeInTheDocument()
+      expect(screen.getByText('없음')).toBeInTheDocument()
+      expect(screen.getByText('신용카드')).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/stats/__tests__/RecurringManageSection.test.tsx
+++ b/frontend/src/components/stats/__tests__/RecurringManageSection.test.tsx
@@ -17,6 +17,9 @@ const makeItem = (overrides: Partial<RecurringTransaction>): RecurringTransactio
   next_due_date: '2026-05-15', is_active: true,
   created_at: '2026-01-15T00:00:00Z', updated_at: '2026-01-15T00:00:00Z',
   category_emoji: null,
+  category_name: null,
+  payment_method_id: null,
+  payment_method_name: null,
   ...overrides,
 })
 

--- a/frontend/src/components/transaction/__tests__/TodayRecurringCard.test.tsx
+++ b/frontend/src/components/transaction/__tests__/TodayRecurringCard.test.tsx
@@ -18,6 +18,9 @@ const makeItem = (overrides: Partial<RecurringTransaction>): RecurringTransactio
   next_due_date: '2026-01-01', is_active: true,
   created_at: '2026-01-15T00:00:00Z', updated_at: '2026-01-15T00:00:00Z',
   category_emoji: null,
+  category_name: null,
+  payment_method_id: null,
+  payment_method_name: null,
   ...overrides,
 })
 

--- a/frontend/src/data/changelogs.ts
+++ b/frontend/src/data/changelogs.ts
@@ -18,6 +18,17 @@ export interface Changelog {
 
 export const changelogs: Changelog[] = [
   {
+    version: '0.26.0',
+    date: '2026-04-26',
+    title: '정기거래 UX 개편',
+    items: [
+      { tag: '개선', text: '정기거래 목록이 카드 형태로 바뀌었어요 — 카테고리, 결제수단, 다음 날짜를 한눈에 확인할 수 있어요' },
+      { tag: '개선', text: '⋮ 메뉴에서 수정, 삭제, 지금 등록을 바로 할 수 있어요' },
+      { tag: '개선', text: '일시정지한 정기거래는 접혀서 표시돼요' },
+      { tag: '신규', text: '정기거래 등록/수정 시 결제수단을 선택할 수 있어요' },
+    ],
+  },
+  {
     version: '0.25.0',
     date: '2026-04-25',
     title: '예산 관리 개선',

--- a/frontend/src/mocks/fixtures.ts
+++ b/frontend/src/mocks/fixtures.ts
@@ -305,7 +305,10 @@ export const mockRecurringTransactions: RecurringTransaction[] = [
     next_due_date: '2026-02-15',
     is_active: true,
     created_at: '2026-01-15T00:00:00Z', updated_at: '2026-01-15T00:00:00Z',
-    category_emoji: null,
+    category_emoji: '🎬',
+    category_name: '구독',
+    payment_method_id: 1,
+    payment_method_name: '삼성카드',
   },
   {
     id: 2, user_id: 1, household_id: 1, type: 'income',
@@ -317,6 +320,9 @@ export const mockRecurringTransactions: RecurringTransaction[] = [
     is_active: true,
     created_at: '2026-01-25T00:00:00Z', updated_at: '2026-01-25T00:00:00Z',
     category_emoji: null,
+    category_name: null,
+    payment_method_id: null,
+    payment_method_name: null,
   },
   {
     id: 3, user_id: 1, household_id: 1, type: 'expense',
@@ -328,6 +334,9 @@ export const mockRecurringTransactions: RecurringTransaction[] = [
     is_active: true,
     created_at: '2026-01-28T00:00:00Z', updated_at: '2026-01-28T00:00:00Z',
     category_emoji: null,
+    category_name: null,
+    payment_method_id: null,
+    payment_method_name: null,
   },
   {
     id: 4, user_id: 1, household_id: 1, type: 'expense',
@@ -339,6 +348,9 @@ export const mockRecurringTransactions: RecurringTransaction[] = [
     is_active: false,
     created_at: '2026-01-10T00:00:00Z', updated_at: '2026-01-10T00:00:00Z',
     category_emoji: null,
+    category_name: null,
+    payment_method_id: null,
+    payment_method_name: null,
   },
 ]
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -336,6 +336,10 @@ export const handlers = [
       is_active: true,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
+      category_emoji: null,
+      category_name: null,
+      payment_method_id: body.payment_method_id ?? null,
+      payment_method_name: null,
     }
     return HttpResponse.json(newItem, { status: 201 })
   }),

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -1,26 +1,29 @@
 /**
  * @file RecurringList.tsx
- * @description 정기거래 관리 페이지
+ * @description 정기거래 관리 페이지 — 카드 레이아웃 + 낙관적 토글 + ⋮ 드롭다운 메뉴 + D-day 표현
  * 목록 표시 + 필터만 담당하며, 모달은 RecurringModal로 분리되어 있다.
  */
 
 import { useState, useEffect } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
-import { ArrowLeft, Plus, Pencil, Trash2, Pause, Play, Zap, Repeat } from 'lucide-react'
+import {
+  ArrowLeft, Plus, Pencil, Trash2,
+  ToggleLeft, ToggleRight, PlusCircle,
+  MoreVertical, Loader2, Check, ChevronDown, Repeat,
+} from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { TOAST } from '../constants/toastMessages'
 import { recurringApi } from '../api/recurring'
 import { categoryApi } from '../api/categories'
+import { paymentMethodApi } from '../api/paymentMethods'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
-import { Skeleton } from '../components/skeleton/Skeleton'
 import RecurringModal from '../components/recurring/RecurringModal'
 import type { RecurringFormData } from '../components/recurring/RecurringModal'
-import type { RecurringTransaction, RecurringTransactionCreate, Category } from '../types'
+import type { RecurringTransaction, RecurringTransactionCreate, Category, PaymentMethod } from '../types'
 import { formatAmount, getLocalDateString } from '../utils/format'
 import { trackEvent } from '../utils/analytics'
-import { formatFrequency } from '../utils/recurringUtils'
 
 /* 빈 폼 데이터 */
 const emptyForm: RecurringFormData = {
@@ -37,18 +40,172 @@ const emptyForm: RecurringFormData = {
   end_date: '',
 }
 
+/** next_due_date를 사람이 읽기 쉬운 형식으로 변환 */
+function formatDueDate(nextDueDateStr: string): { text: string; isUrgent: boolean } {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  // 타임존 이슈 방지: 날짜 문자열 직접 파싱
+  const [y, m, d] = nextDueDateStr.split('-').map(Number)
+  const due = new Date(y, m - 1, d)
+  const diffDays = Math.round((due.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+
+  if (diffDays === 0) return { text: '오늘', isUrgent: true }
+  if (diffDays === 1) return { text: '내일', isUrgent: true }
+  if (diffDays > 1 && diffDays <= 7) return { text: `${diffDays}일 후`, isUrgent: true }
+  if (diffDays > 7) return { text: `매월 ${d}일`, isUrgent: false }
+  if (diffDays === -1) return { text: '어제', isUrgent: false }
+  return { text: `${Math.abs(diffDays)}일 전`, isUrgent: false }
+}
+
 function RecurringListSkeleton() {
   return (
-    <div className="space-y-3">
-      {[1, 2, 3, 4].map(i => (
-        <div key={i} className="card-surface p-4 flex items-center justify-between">
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-32" />
-            <Skeleton className="h-3 w-20" />
+    <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 overflow-hidden">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="p-4 flex items-center gap-3 border-b border-[var(--border-subtle)] last:border-0">
+          <div className="w-10 h-10 rounded-xl bg-[var(--surface-elevated)] animate-pulse shrink-0" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 w-32 rounded bg-[var(--surface-elevated)] animate-pulse" />
+            <div className="h-3 w-20 rounded bg-[var(--surface-elevated)] animate-pulse" />
           </div>
-          <Skeleton className="h-8 w-16" />
+          <div className="text-right space-y-2">
+            <div className="h-4 w-16 rounded bg-[var(--surface-elevated)] animate-pulse" />
+            <div className="h-3 w-12 rounded bg-[var(--surface-elevated)] animate-pulse" />
+          </div>
+          <div className="flex gap-1">
+            <div className="w-8 h-8 rounded-lg bg-[var(--surface-elevated)] animate-pulse" />
+            <div className="w-8 h-8 rounded-lg bg-[var(--surface-elevated)] animate-pulse" />
+          </div>
         </div>
       ))}
+    </div>
+  )
+}
+
+interface RecurringCardProps {
+  r: RecurringTransaction
+  openMenuId: number | null
+  deletingId: number | null
+  togglingIds: Set<number>
+  executingIds: Set<number>
+  executedIds: Set<number>
+  showExecute: boolean
+  onToggle: (r: RecurringTransaction) => void
+  onMenuOpen: (id: number | null) => void
+  onEdit: (r: RecurringTransaction) => void
+  onDeleteRequest: (id: number) => void
+  onDeleteConfirm: (id: number) => void
+  onDeleteCancel: () => void
+  onExecute: (r: RecurringTransaction) => void
+}
+
+function RecurringCard({
+  r, openMenuId, deletingId, togglingIds, executingIds, executedIds, showExecute,
+  onToggle, onMenuOpen, onEdit, onDeleteRequest, onDeleteConfirm, onDeleteCancel, onExecute,
+}: RecurringCardProps) {
+  const { text: dueText, isUrgent } = formatDueDate(r.next_due_date)
+  const secondaryInfo = [r.category_name, r.payment_method_name].filter(Boolean).join(' · ')
+
+  return (
+    <div>
+      <div className="p-4 flex items-center gap-3">
+        {/* 이모지 */}
+        <div className="w-10 h-10 rounded-xl bg-[var(--surface-elevated)] flex items-center justify-center shrink-0 text-xl">
+          {r.category_emoji ?? (r.type === 'expense' ? '💸' : '💰')}
+        </div>
+        {/* 설명 + 2차 정보 */}
+        <div className="flex-1 min-w-0">
+          <p className="font-medium text-[var(--text-primary)] truncate">{r.description}</p>
+          <p className="text-xs text-[var(--text-tertiary)] mt-0.5 truncate">
+            {secondaryInfo || '카테고리 없음'}
+          </p>
+        </div>
+        {/* 금액 + D-day */}
+        <div className="text-right shrink-0">
+          <p className={`font-semibold text-sm ${r.type === 'income' ? 'text-leaf-600' : 'text-[var(--text-primary)]'}`}>
+            {r.type === 'income' ? '+' : ''}{formatAmount(r.amount)}
+          </p>
+          <p className={`text-xs mt-0.5 ${isUrgent ? 'text-amber-500 font-medium' : 'text-[var(--text-tertiary)]'}`}>
+            {dueText}
+          </p>
+        </div>
+        {/* 토글 + ⋮ */}
+        <div className="flex items-center gap-0.5 shrink-0">
+          <button
+            onClick={() => onToggle(r)}
+            disabled={togglingIds.has(r.id)}
+            className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-50"
+            title={r.is_active ? '일시정지' : '다시 시작'}
+            data-testid={`toggle-${r.id}`}
+          >
+            {r.is_active
+              ? <ToggleRight className="w-5 h-5 text-leaf-500" />
+              : <ToggleLeft className="w-5 h-5 text-[var(--text-tertiary)]" />}
+          </button>
+          <div className="relative">
+            <button
+              onClick={() => onMenuOpen(openMenuId === r.id ? null : r.id)}
+              className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
+              data-testid={`menu-${r.id}`}
+              aria-label="더보기"
+            >
+              {executingIds.has(r.id) ? (
+                <Loader2 className="w-4 h-4 animate-spin text-[var(--text-muted)]" />
+              ) : executedIds.has(r.id) ? (
+                <Check className="w-4 h-4 text-leaf-500" />
+              ) : (
+                <MoreVertical className="w-4 h-4 text-[var(--text-tertiary)]" />
+              )}
+            </button>
+            {openMenuId === r.id && (
+              <div className="absolute right-0 top-8 z-10 bg-[var(--surface-card)] rounded-xl shadow-lg border border-[var(--border-default)] py-1 min-w-36">
+                {showExecute && (
+                  <button
+                    onClick={() => onExecute(r)}
+                    className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]"
+                  >
+                    <PlusCircle className="w-4 h-4" />
+                    지금 등록
+                  </button>
+                )}
+                <button
+                  onClick={() => { onMenuOpen(null); onEdit(r) }}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]"
+                >
+                  <Pencil className="w-4 h-4" />
+                  수정
+                </button>
+                <button
+                  onClick={() => { onMenuOpen(null); onDeleteRequest(r.id) }}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-rose-500 hover:bg-rose-50"
+                >
+                  <Trash2 className="w-4 h-4" />
+                  삭제
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      {/* 삭제 확인 인라인 */}
+      {deletingId === r.id && (
+        <div className="px-4 py-3 bg-rose-50/50 flex items-center justify-between border-t border-rose-100">
+          <p className="text-sm text-[var(--text-secondary)]">'{r.description}'을 삭제할까요?</p>
+          <div className="flex gap-2">
+            <button
+              onClick={onDeleteCancel}
+              className="px-3 py-1.5 text-xs rounded-lg bg-[var(--surface-hover)] text-[var(--text-secondary)]"
+            >
+              취소
+            </button>
+            <button
+              onClick={() => onDeleteConfirm(r.id)}
+              className="px-3 py-1.5 text-xs rounded-lg bg-rose-500 text-white font-medium"
+            >
+              삭제
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -72,8 +229,16 @@ export default function RecurringList() {
   const [formData, setFormData] = useState<RecurringFormData>(emptyForm)
   const [submitting, setSubmitting] = useState(false)
 
-  /* 삭제 확인 모달 */
-  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null)
+  /* 카드 인터랙션 상태 */
+  const [openMenuId, setOpenMenuId] = useState<number | null>(null)
+  const [deletingId, setDeletingId] = useState<number | null>(null)
+  const [togglingIds, setTogglingIds] = useState<Set<number>>(new Set())
+  const [executingIds, setExecutingIds] = useState<Set<number>>(new Set())
+  const [executedIds, setExecutedIds] = useState<Set<number>>(new Set())
+  const [showInactive, setShowInactive] = useState(false)
+  // Task 5에서 RecurringModal에 전달 예정
+  const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([])
+  void paymentMethods  // suppress unused warning until Task 5 wires this into modal
 
   /* 데이터 로드 */
   const loadData = async () => {
@@ -85,13 +250,15 @@ export default function RecurringList() {
       const params: { type?: string; household_id: number } = { household_id: activeHouseholdId }
       if (typeFilter !== 'all') params.type = typeFilter
 
-      const [recurringRes, categoriesRes] = await Promise.all([
+      const [recurringRes, categoriesRes, pmRes] = await Promise.all([
         recurringApi.getAll(params),
         categoryApi.getAll(),
+        paymentMethodApi.getAll(activeHouseholdId),
       ])
 
       setItems(recurringRes.data)
       setCategories(categoriesRes.data)
+      setPaymentMethods(pmRes.data.filter((pm: PaymentMethod) => pm.is_active))
     } catch {
       setError('데이터를 불러오는데 실패했습니다')
     } finally {
@@ -102,6 +269,19 @@ export default function RecurringList() {
   useEffect(() => {
     loadData()
   }, [typeFilter, activeHouseholdId])
+
+  /* ⋮ 메뉴 외부 클릭 닫기 (setTimeout 0 필수: 버튼 클릭 이벤트 bubbling 완료 후 리스너 등록) */
+  useEffect(() => {
+    if (openMenuId === null) return
+    const handleClickOutside = () => setOpenMenuId(null)
+    const timer = setTimeout(() => {
+      document.addEventListener('click', handleClickOutside)
+    }, 0)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('click', handleClickOutside)
+    }
+  }, [openMenuId])
 
   /* 모달 열기: 추가 */
   const openAdd = () => {
@@ -187,45 +367,60 @@ export default function RecurringList() {
     }
   }
 
-  /* 삭제: 확인 모달 표시 */
-  const requestDelete = (id: number) => {
-    setDeleteTargetId(id)
+  /* 토글 (낙관적 업데이트) */
+  const handleToggle = async (r: RecurringTransaction) => {
+    // 낙관적 업데이트: API 응답 전에 UI 즉시 반영
+    setItems((prev) => prev.map((item) => item.id === r.id ? { ...item, is_active: !item.is_active } : item))
+    setTogglingIds((prev) => new Set([...prev, r.id]))
+    try {
+      await recurringApi.update(r.id, { is_active: !r.is_active })
+    } catch {
+      // 실패 시 롤백
+      setItems((prev) => prev.map((item) => item.id === r.id ? { ...item, is_active: r.is_active } : item))
+      addToast('error', TOAST.RECURRING_TOGGLE_FAILED)
+    } finally {
+      setTogglingIds((prev) => { const s = new Set(prev); s.delete(r.id); return s })
+    }
   }
 
-  /* 삭제: 실제 삭제 실행 */
-  const handleDelete = async () => {
-    if (deleteTargetId === null) return
+  /* 즉시 실행 (인라인 피드백) */
+  const handleExecute = async (r: RecurringTransaction) => {
+    setOpenMenuId(null)
+    setExecutingIds((prev) => new Set([...prev, r.id]))
     try {
-      await recurringApi.delete(deleteTargetId)
+      await recurringApi.execute(r.id)
+      // 잠깐 체크마크 표시 후 제거
+      setExecutedIds((prev) => new Set([...prev, r.id]))
+      setTimeout(() => {
+        setExecutedIds((prev) => { const s = new Set(prev); s.delete(r.id); return s })
+      }, 800)
+      addToast('success', TOAST.RECURRING_EXECUTED)
+    } catch {
+      addToast('error', TOAST.RECURRING_EXECUTE_FAILED)
+    } finally {
+      setExecutingIds((prev) => { const s = new Set(prev); s.delete(r.id); return s })
+    }
+  }
+
+  /* 삭제: 로컬 상태 업데이트 (재로드 없이) */
+  const handleDelete = async (id: number) => {
+    try {
+      await recurringApi.delete(id)
+      setItems((prev) => prev.filter((item) => item.id !== id))
+      setDeletingId(null)
       addToast('success', TOAST.RECURRING_DELETED)
-      setDeleteTargetId(null)
-      loadData()
     } catch {
       addToast('error', TOAST.DELETE_FAILED)
     }
   }
 
-  /* 바로 등록 (즉시 실행) */
-  const handleExecute = async (r: RecurringTransaction) => {
-    try {
-      await recurringApi.execute(r.id)
-      addToast('success', TOAST.RECURRING_EXECUTED)
-      loadData()
-    } catch {
-      addToast('error', TOAST.RECURRING_EXECUTE_FAILED)
-    }
-  }
-
-  /* 일시정지/재개 */
-  const toggleActive = async (r: RecurringTransaction) => {
-    try {
-      await recurringApi.update(r.id, { is_active: !r.is_active })
-      addToast('success', TOAST.STATUS_CHANGED)
-      loadData()
-    } catch {
-      addToast('error', TOAST.RECURRING_TOGGLE_FAILED)
-    }
-  }
+  /* 렌더링 직전 활성/비활성 분리 + 날짜 기준 정렬 */
+  const activeItems = items
+    .filter((r) => r.is_active)
+    .sort((a, b) => (a.day_of_month ?? 0) - (b.day_of_month ?? 0))
+  const inactiveItems = items
+    .filter((r) => !r.is_active)
+    .sort((a, b) => (a.day_of_month ?? 0) - (b.day_of_month ?? 0))
 
   if (error) {
     return (
@@ -309,102 +504,53 @@ export default function RecurringList() {
         </div>
       ) : (
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 overflow-hidden">
-          {/* 데스크톱: 테이블 */}
-          <div className="hidden md:block">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-[var(--border-subtle)] bg-[var(--surface-elevated)]/50">
-                  <th className="text-left px-5 py-3 text-[var(--text-tertiary)] font-medium">설명</th>
-                  <th className="text-right px-5 py-3 text-[var(--text-tertiary)] font-medium">금액</th>
-                  <th className="text-left px-5 py-3 text-[var(--text-tertiary)] font-medium">주기</th>
-                  <th className="text-left px-5 py-3 text-[var(--text-tertiary)] font-medium">다음 예정일</th>
-                  <th className="text-center px-5 py-3 text-[var(--text-tertiary)] font-medium">상태</th>
-                  <th className="text-right px-5 py-3 text-[var(--text-tertiary)] font-medium">작업</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[var(--border-subtle)]">
-                {items.map((r) => (
-                  <tr key={r.id} className={`hover:bg-[var(--surface-hover)]/50 ${!r.is_active ? 'opacity-50' : ''}`}>
-                    <td className="px-5 py-3">
-                      <div className="flex items-center gap-2">
-                        <span className={`w-2 h-2 rounded-full ${r.type === 'expense' ? 'bg-grape-500' : 'bg-leaf-500'}`} />
-                        <span className="font-medium text-[var(--text-primary)]">{r.description}</span>
-                      </div>
-                    </td>
-                    <td className={`px-5 py-3 text-right font-semibold tabular-nums ${r.type === 'expense' ? 'text-[var(--text-primary)]' : 'text-leaf-600'}`}>
-                      {r.type === 'income' ? '+' : ''}{formatAmount(r.amount)}
-                    </td>
-                    <td className="px-5 py-3 text-[var(--text-secondary)]">{formatFrequency(r)}</td>
-                    <td className="px-5 py-3 text-[var(--text-secondary)]">{r.next_due_date}</td>
-                    <td className="px-5 py-3 text-center">
-                      <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${
-                        r.is_active ? 'bg-leaf-100 text-leaf-600' : 'bg-[var(--surface-hover)] text-[var(--text-tertiary)]'
-                      }`}>
-                        {r.is_active ? '사용 중' : '중지'}
-                      </span>
-                    </td>
-                    <td className="px-5 py-3">
-                      <div className="flex items-center justify-end gap-1">
-                        {r.is_active && (
-                          <button onClick={() => handleExecute(r)} className="p-2 rounded-md hover:bg-leaf-50 text-[var(--text-tertiary)] hover:text-leaf-600" title="바로 등록">
-                            <Zap className="w-4 h-4" />
-                          </button>
-                        )}
-                        <button onClick={() => toggleActive(r)} className="p-2 rounded-md hover:bg-[var(--surface-hover)] text-[var(--text-tertiary)]" title={r.is_active ? '중지' : '다시 시작'}>
-                          {r.is_active ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
-                        </button>
-                        <button onClick={() => openEdit(r)} className="p-2 rounded-md hover:bg-[var(--surface-hover)] text-[var(--text-tertiary)]" title="수정">
-                          <Pencil className="w-4 h-4" />
-                        </button>
-                        <button onClick={() => requestDelete(r.id)} className="p-2 rounded-md hover:bg-red-50 text-[var(--text-tertiary)] hover:text-red-600" title="삭제">
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          {/* 활성 정기거래 */}
+          {activeItems.length === 0 ? (
+            <div className="p-8 text-center text-sm text-[var(--text-tertiary)]">
+              활성 정기거래가 없습니다
+            </div>
+          ) : (
+            <div className="divide-y divide-[var(--border-subtle)]">
+              {activeItems.map((r) => (
+                <RecurringCard
+                  key={r.id} r={r} openMenuId={openMenuId} deletingId={deletingId}
+                  togglingIds={togglingIds} executingIds={executingIds} executedIds={executedIds}
+                  showExecute={true}
+                  onToggle={handleToggle} onMenuOpen={setOpenMenuId} onEdit={openEdit}
+                  onDeleteRequest={setDeletingId} onDeleteConfirm={handleDelete}
+                  onDeleteCancel={() => setDeletingId(null)} onExecute={handleExecute}
+                />
+              ))}
+            </div>
+          )}
 
-          {/* 모바일 카드 뷰 */}
-          <div className="md:hidden divide-y divide-[var(--border-subtle)]">
-            {items.map((r) => (
-              <div key={r.id} className={`p-4 ${!r.is_active ? 'opacity-50' : ''}`}>
-                <div className="flex items-start justify-between">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <span className={`w-2 h-2 rounded-full flex-shrink-0 ${r.type === 'expense' ? 'bg-grape-500' : 'bg-leaf-500'}`} />
-                    <span className="font-medium text-[var(--text-primary)] truncate">{r.description}</span>
-                  </div>
-                  <span className={`font-semibold whitespace-nowrap ml-2 tabular-nums ${r.type === 'expense' ? 'text-[var(--text-primary)]' : 'text-leaf-600'}`}>
-                    {r.type === 'income' ? '+' : ''}{formatAmount(r.amount)}
-                  </span>
+          {/* 비활성(일시정지) 정기거래 — 접기/펼치기 */}
+          {inactiveItems.length > 0 && (
+            <div className="border-t border-[var(--border-subtle)]">
+              <button
+                onClick={() => setShowInactive(!showInactive)}
+                className="w-full flex items-center justify-between px-4 py-3 text-sm text-[var(--text-tertiary)] hover:bg-[var(--surface-hover)] transition-colors"
+                data-testid="inactive-toggle"
+              >
+                <span>일시정지 {inactiveItems.length}건</span>
+                <ChevronDown className={`w-4 h-4 transition-transform ${showInactive ? 'rotate-180' : ''}`} />
+              </button>
+              {showInactive && (
+                <div className="divide-y divide-[var(--border-subtle)] opacity-60">
+                  {inactiveItems.map((r) => (
+                    <RecurringCard
+                      key={r.id} r={r} openMenuId={openMenuId} deletingId={deletingId}
+                      togglingIds={togglingIds} executingIds={executingIds} executedIds={executedIds}
+                      showExecute={false}
+                      onToggle={handleToggle} onMenuOpen={setOpenMenuId} onEdit={openEdit}
+                      onDeleteRequest={setDeletingId} onDeleteConfirm={handleDelete}
+                      onDeleteCancel={() => setDeletingId(null)} onExecute={handleExecute}
+                    />
+                  ))}
                 </div>
-                <div className="flex items-center justify-between mt-2">
-                  <div className="text-sm text-[var(--text-tertiary)] space-x-3">
-                    <span>{formatFrequency(r)}</span>
-                    <span>다음: {r.next_due_date}</span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    {r.is_active && (
-                      <button onClick={() => handleExecute(r)} className="p-1 text-[var(--text-muted)] hover:text-leaf-600" title="바로 등록">
-                        <Zap className="w-4 h-4" />
-                      </button>
-                    )}
-                    <button onClick={() => toggleActive(r)} className="p-1 text-[var(--text-muted)]">
-                      {r.is_active ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
-                    </button>
-                    <button onClick={() => openEdit(r)} className="p-1 text-[var(--text-muted)]">
-                      <Pencil className="w-4 h-4" />
-                    </button>
-                    <button onClick={() => requestDelete(r.id)} className="p-1 text-[var(--text-muted)]">
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -419,42 +565,6 @@ export default function RecurringList() {
           onSubmit={handleSubmit}
           onClose={() => setShowModal(false)}
         />
-      )}
-
-      {/* 삭제 확인 모달 */}
-      {deleteTargetId !== null && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="delete-recurring-modal-title"
-            className="bg-[var(--surface-card)] rounded-2xl shadow-xl max-w-md w-full p-6"
-          >
-            <h3
-              id="delete-recurring-modal-title"
-              className="text-lg font-semibold text-[var(--text-primary)] mb-2"
-            >
-              정기거래 삭제
-            </h3>
-            <p className="text-[var(--text-secondary)] mb-6">
-              정말로 이 정기거래를 삭제하시겠습니까?
-            </p>
-            <div className="flex gap-3 justify-end">
-              <button
-                onClick={() => setDeleteTargetId(null)}
-                className="px-4 py-2 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-lg transition-colors"
-              >
-                취소
-              </button>
-              <button
-                onClick={handleDelete}
-                className="px-4 py-2 text-sm font-medium text-white bg-rose-600 rounded-lg hover:bg-rose-700 transition-colors"
-              >
-                삭제
-              </button>
-            </div>
-          </div>
-        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -31,6 +31,7 @@ const emptyForm: RecurringFormData = {
   amount: '',
   description: '',
   category_id: '',
+  payment_method_id: '',
   frequency: 'monthly',
   day_of_month: '25',
   day_of_week: '0',
@@ -237,8 +238,7 @@ export default function RecurringList() {
   const [executingIds, setExecutingIds] = useState<Set<number>>(new Set())
   const [executedIds, setExecutedIds] = useState<Set<number>>(new Set())
   const [showInactive, setShowInactive] = useState(false)
-  // Task 5에서 RecurringModal에 전달 예정 (_prefix: 아직 JSX에서 미사용)
-  const [_paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([])
+  const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([])
 
   /* 데이터 로드 */
   const loadData = async () => {
@@ -298,6 +298,7 @@ export default function RecurringList() {
       amount: String(r.amount),
       description: r.description,
       category_id: r.category_id ? String(r.category_id) : '',
+      payment_method_id: r.payment_method_id ? String(r.payment_method_id) : '',
       frequency: r.frequency,
       day_of_month: String(r.day_of_month ?? 25),
       day_of_week: String(r.day_of_week ?? 0),
@@ -309,7 +310,7 @@ export default function RecurringList() {
     setShowModal(true)
   }
 
-  /* 저장 (추가 / 수정) */
+  /* 저장 (추가 / 수정) — API 응답으로 로컬 상태 업데이트 (재로드 없음) */
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!formData.description.trim()) {
@@ -324,19 +325,23 @@ export default function RecurringList() {
     setSubmitting(true)
     try {
       if (editingId) {
-        await recurringApi.update(editingId, {
+        // 수정: API 응답 데이터로 해당 항목만 교체
+        const res = await recurringApi.update(editingId, {
           amount: Number(formData.amount),
           description: formData.description,
           category_id: formData.category_id ? Number(formData.category_id) : null,
+          payment_method_id: formData.payment_method_id ? Number(formData.payment_method_id) : null,
           end_date: formData.end_date || null,
         })
-        addToast('success', TOAST.RECURRING_UPDATED)
+        setItems((prev) => prev.map((item) => item.id === editingId ? res.data : item))
       } else {
+        // 생성: API 응답 데이터를 목록에 추가
         const payload: RecurringTransactionCreate = {
           type: formData.type,
           amount: Number(formData.amount),
           description: formData.description,
           category_id: formData.category_id ? Number(formData.category_id) : null,
+          payment_method_id: formData.payment_method_id ? Number(formData.payment_method_id) : null,
           frequency: formData.frequency,
           start_date: formData.start_date,
           end_date: formData.end_date || null,
@@ -354,12 +359,12 @@ export default function RecurringList() {
         if (formData.frequency === 'custom') {
           payload.interval = Number(formData.interval)
         }
-        await recurringApi.create(payload)
-        addToast('success', TOAST.RECURRING_ADDED)
+        const res = await recurringApi.create(payload)
+        setItems((prev) => [...prev, res.data])
         trackEvent('recurring_added')
       }
       setShowModal(false)
-      loadData()
+      addToast('success', editingId ? TOAST.RECURRING_UPDATED : TOAST.RECURRING_ADDED)
     } catch {
       addToast('error', TOAST.SAVE_FAILED)
     } finally {
@@ -561,6 +566,7 @@ export default function RecurringList() {
           formData={formData}
           onFormChange={setFormData}
           categories={categories}
+          paymentMethods={paymentMethods}
           submitting={submitting}
           onSubmit={handleSubmit}
           onClose={() => setShowModal(false)}

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -419,7 +419,8 @@ export default function RecurringList() {
     }
   }
 
-  /* 렌더링 직전 활성/비활성 분리 + 날짜 기준 정렬 */
+  /* 렌더링 직전 활성/비활성 분리 + 날짜 기준 정렬
+   * next_due_date(YYYY-MM-DD) 기준 정렬: day_of_month는 monthly 외 weekly/custom에서 null이므로 부정확 */
   const activeItems = items
     .filter((r) => r.is_active)
     .sort((a, b) => a.next_due_date.localeCompare(b.next_due_date))

--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -144,7 +144,8 @@ function RecurringCard({
           <div className="relative">
             <button
               onClick={() => onMenuOpen(openMenuId === r.id ? null : r.id)}
-              className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
+              disabled={executingIds.has(r.id)}
+              className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               data-testid={`menu-${r.id}`}
               aria-label="더보기"
             >
@@ -236,9 +237,8 @@ export default function RecurringList() {
   const [executingIds, setExecutingIds] = useState<Set<number>>(new Set())
   const [executedIds, setExecutedIds] = useState<Set<number>>(new Set())
   const [showInactive, setShowInactive] = useState(false)
-  // Task 5에서 RecurringModal에 전달 예정
-  const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([])
-  void paymentMethods  // suppress unused warning until Task 5 wires this into modal
+  // Task 5에서 RecurringModal에 전달 예정 (_prefix: 아직 JSX에서 미사용)
+  const [_paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([])
 
   /* 데이터 로드 */
   const loadData = async () => {
@@ -417,10 +417,10 @@ export default function RecurringList() {
   /* 렌더링 직전 활성/비활성 분리 + 날짜 기준 정렬 */
   const activeItems = items
     .filter((r) => r.is_active)
-    .sort((a, b) => (a.day_of_month ?? 0) - (b.day_of_month ?? 0))
+    .sort((a, b) => a.next_due_date.localeCompare(b.next_due_date))
   const inactiveItems = items
     .filter((r) => !r.is_active)
-    .sort((a, b) => (a.day_of_month ?? 0) - (b.day_of_month ?? 0))
+    .sort((a, b) => a.next_due_date.localeCompare(b.next_due_date))
 
   if (error) {
     return (

--- a/frontend/src/pages/__tests__/RecurringList.test.tsx
+++ b/frontend/src/pages/__tests__/RecurringList.test.tsx
@@ -1,10 +1,10 @@
 /**
  * @file RecurringList.test.tsx
- * @description 정기거래 관리 페이지 테스트
+ * @description 정기거래 관리 페이지 테스트 — 카드 레이아웃 + ⋮ 메뉴 + 낙관적 토글
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { server } from '../../mocks/server'
@@ -27,15 +27,15 @@ const mockItems: RecurringTransaction[] = [
   {
     id: 1, user_id: 1, household_id: 1,
     type: 'expense', amount: 17000, description: '넷플릭스',
-    category_id: null, frequency: 'monthly', interval: null,
+    category_id: 1, frequency: 'monthly', interval: null,
     day_of_month: 25, day_of_week: null, month_of_year: null,
     start_date: '2026-01-25', end_date: null,
     next_due_date: '2026-02-25', is_active: true,
     created_at: '2026-01-25T00:00:00Z', updated_at: '2026-01-25T00:00:00Z',
-    category_emoji: null,
-    category_name: null,
-    payment_method_id: null,
-    payment_method_name: null,
+    category_emoji: '🎬',
+    category_name: '구독',
+    payment_method_id: 1,
+    payment_method_name: '삼성카드',
   },
   {
     id: 2, user_id: 1, household_id: 1,
@@ -115,18 +115,20 @@ describe('RecurringList', () => {
     expect(screen.getAllByText('급여').length).toBeGreaterThan(0)
   })
 
-  it('주기를 한국어로 표시한다', async () => {
+  it('주기를 한국어로 표시한다 — next_due_date가 미래이면 "매월 N일"로 표시된다', async () => {
+    // next_due_date가 오늘로부터 14일 후로 설정하면 formatDueDate가 "N일 후"를 반환하고,
+    // 30일 이상 후이면 "매월 N일"을 반환한다
+    const future = new Date()
+    future.setDate(future.getDate() + 35)
+    const futureStr = `${future.getFullYear()}-${String(future.getMonth() + 1).padStart(2, '0')}-${String(future.getDate()).padStart(2, '0')}`
+    server.use(
+      http.get('/api/recurring', () =>
+        HttpResponse.json([{ ...mockItems[0], next_due_date: futureStr }])
+      )
+    )
     renderRecurringList()
     await waitFor(() => {
-      expect(screen.getAllByText('매월 25일').length).toBeGreaterThan(0)
-    })
-  })
-
-  it('활성/정지 상태 뱃지를 표시한다', async () => {
-    renderRecurringList()
-    await waitFor(() => {
-      const badges = screen.getAllByText('사용 중')
-      expect(badges.length).toBeGreaterThan(0)
+      expect(screen.getByText(`매월 ${future.getDate()}일`)).toBeInTheDocument()
     })
   })
 
@@ -214,9 +216,9 @@ describe('RecurringList', () => {
     expect(screen.queryByText('정기거래 추가')).not.toBeInTheDocument()
   })
 
-  // ==================== 바로 등록 (execute) ====================
+  // ==================== 바로 등록 (⋮ 메뉴 → 지금 등록) ====================
 
-  it('활성 항목에서 바로 등록 버튼을 클릭하면 실행된다', async () => {
+  it('활성 항목에서 ⋮ 메뉴를 열고 지금 등록을 클릭하면 실행된다', async () => {
     server.use(
       http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
       http.get('/api/categories', () => HttpResponse.json([])),
@@ -237,8 +239,8 @@ describe('RecurringList', () => {
       expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
     })
 
-    const executeBtns = screen.getAllByTitle('바로 등록')
-    await user.click(executeBtns[0])
+    await user.click(screen.getByTestId('menu-1'))
+    await user.click(screen.getByText('지금 등록'))
 
     await waitFor(() => {
       expect(mockAddToast).toHaveBeenCalledWith('success', '정기 거래를 실행했어요')
@@ -247,7 +249,7 @@ describe('RecurringList', () => {
 
   // ==================== 활성화/비활성화 토글 ====================
 
-  it('활성 항목에서 중지 버튼을 클릭하면 비활성화된다', async () => {
+  it('활성 항목 토글 버튼 클릭 시 비활성화된다', async () => {
     server.use(
       http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
       http.get('/api/categories', () => HttpResponse.json([])),
@@ -260,20 +262,20 @@ describe('RecurringList', () => {
     renderRecurringList()
 
     await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+      expect(screen.getByTestId('toggle-1')).toBeInTheDocument()
     })
 
-    const pauseBtns = screen.getAllByTitle('중지')
-    await user.click(pauseBtns[0])
+    await user.click(screen.getByTestId('toggle-1'))
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('success', '상태를 변경했어요')
+      expect(mockAddToast).not.toHaveBeenCalledWith('error', '변경에 실패했어요')
     })
   })
 
-  it('비활성 항목에서 다시 시작 버튼을 클릭하면 활성화된다', async () => {
+  it('비활성 항목 토글 버튼 클릭 시 활성화된다', async () => {
+    // 활성 1개 + 비활성 1개 반환 (비활성 섹션이 생기도록)
     server.use(
-      http.get('/api/recurring', () => HttpResponse.json([mockItems[2]])),
+      http.get('/api/recurring', () => HttpResponse.json([mockItems[0], mockItems[2]])),
       http.get('/api/categories', () => HttpResponse.json([])),
       http.put('/api/recurring/3', () =>
         HttpResponse.json({ ...mockItems[2], is_active: true })
@@ -283,21 +285,22 @@ describe('RecurringList', () => {
     const user = userEvent.setup()
     renderRecurringList()
 
-    await waitFor(() => {
-      expect(screen.getAllByText('정지된 거래').length).toBeGreaterThan(0)
-    })
+    // 일시정지 섹션 버튼이 나타날 때까지 대기 후 클릭
+    await waitFor(() => screen.getByTestId('inactive-toggle'))
+    await user.click(screen.getByTestId('inactive-toggle'))
 
-    const playBtns = screen.getAllByTitle('다시 시작')
-    await user.click(playBtns[0])
+    // 비활성 항목 토글 클릭
+    await waitFor(() => screen.getByTestId('toggle-3'))
+    await user.click(screen.getByTestId('toggle-3'))
 
     await waitFor(() => {
-      expect(mockAddToast).toHaveBeenCalledWith('success', '상태를 변경했어요')
+      expect(mockAddToast).not.toHaveBeenCalledWith('error', '변경에 실패했어요')
     })
   })
 
-  // ==================== 삭제 ====================
+  // ==================== 삭제 (⋮ 메뉴 → 인라인 확인 UI) ====================
 
-  it('삭제 버튼 클릭 시 확인 모달이 표시된다', async () => {
+  it('⋮ 메뉴에서 삭제 클릭 시 인라인 확인 UI가 표시된다', async () => {
     server.use(
       http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
       http.get('/api/categories', () => HttpResponse.json([])),
@@ -307,18 +310,17 @@ describe('RecurringList', () => {
     renderRecurringList()
 
     await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+      expect(screen.getByTestId('menu-1')).toBeInTheDocument()
     })
 
-    const deleteBtns = screen.getAllByTitle('삭제')
-    await user.click(deleteBtns[0])
+    await user.click(screen.getByTestId('menu-1'))
+    await user.click(screen.getByText('삭제'))
 
-    // window.confirm이 아닌 모달이 표시되어야 함
-    expect(screen.getByText('정기거래 삭제')).toBeInTheDocument()
-    expect(screen.getByText('정말로 이 정기거래를 삭제하시겠습니까?')).toBeInTheDocument()
+    expect(screen.getByText(/삭제할까요/)).toBeInTheDocument()
+    expect(screen.getByText('취소')).toBeInTheDocument()
   })
 
-  it('삭제 확인 모달에서 취소 클릭 시 모달이 닫히고 삭제되지 않는다', async () => {
+  it('삭제 확인 UI에서 취소 클릭 시 UI가 닫히고 삭제되지 않는다', async () => {
     server.use(
       http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
       http.get('/api/categories', () => HttpResponse.json([])),
@@ -328,21 +330,20 @@ describe('RecurringList', () => {
     renderRecurringList()
 
     await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+      expect(screen.getByTestId('menu-1')).toBeInTheDocument()
     })
 
-    const deleteBtns = screen.getAllByTitle('삭제')
-    await user.click(deleteBtns[0])
+    await user.click(screen.getByTestId('menu-1'))
+    await user.click(screen.getByText('삭제'))
 
-    const deleteModal = screen.getByRole('dialog')
-    expect(deleteModal).toBeInTheDocument()
-    await user.click(within(deleteModal).getByRole('button', { name: '취소' }))
+    expect(screen.getByText(/삭제할까요/)).toBeInTheDocument()
+    await user.click(screen.getByText('취소'))
 
-    expect(screen.queryByText('정기거래 삭제')).not.toBeInTheDocument()
+    expect(screen.queryByText(/삭제할까요/)).not.toBeInTheDocument()
     expect(mockAddToast).not.toHaveBeenCalledWith('success', '정기 거래를 삭제했어요')
   })
 
-  it('삭제 확인 모달에서 삭제 버튼 클릭 시 항목이 삭제된다', async () => {
+  it('삭제 확인 UI에서 삭제 버튼 클릭 시 항목이 삭제된다', async () => {
     server.use(
       http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
       http.get('/api/categories', () => HttpResponse.json([])),
@@ -353,15 +354,16 @@ describe('RecurringList', () => {
     renderRecurringList()
 
     await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+      expect(screen.getByTestId('menu-1')).toBeInTheDocument()
     })
 
-    const deleteBtns = screen.getAllByTitle('삭제')
-    await user.click(deleteBtns[0])
+    await user.click(screen.getByTestId('menu-1'))
+    await user.click(screen.getByText('삭제'))
 
-    const deleteModal = screen.getByRole('dialog')
-    expect(deleteModal).toBeInTheDocument()
-    await user.click(within(deleteModal).getByRole('button', { name: '삭제' }))
+    expect(screen.getByText(/삭제할까요/)).toBeInTheDocument()
+    // 인라인 확인 UI의 삭제 버튼 (rose-500 스타일의 작은 버튼)
+    const deleteButtons = screen.getAllByText('삭제')
+    await user.click(deleteButtons[deleteButtons.length - 1])
 
     await waitFor(() => {
       expect(mockAddToast).toHaveBeenCalledWith('success', '정기 거래를 삭제했어요')
@@ -370,7 +372,7 @@ describe('RecurringList', () => {
 
   // ==================== 수정 ====================
 
-  it('수정 버튼 클릭 시 수정 모달이 열린다', async () => {
+  it('⋮ 메뉴에서 수정 클릭 시 수정 모달이 열린다', async () => {
     server.use(
       http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
       http.get('/api/categories', () => HttpResponse.json([])),
@@ -380,11 +382,11 @@ describe('RecurringList', () => {
     renderRecurringList()
 
     await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+      expect(screen.getByTestId('menu-1')).toBeInTheDocument()
     })
 
-    const editBtns = screen.getAllByTitle('수정')
-    await user.click(editBtns[0])
+    await user.click(screen.getByTestId('menu-1'))
+    await user.click(screen.getByText('수정'))
 
     expect(screen.getByText('정기거래 수정')).toBeInTheDocument()
   })
@@ -459,8 +461,8 @@ describe('RecurringList', () => {
       expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
     })
 
-    const executeBtns = screen.getAllByTitle('바로 등록')
-    await user.click(executeBtns[0])
+    await user.click(screen.getByTestId('menu-1'))
+    await user.click(screen.getByText('지금 등록'))
 
     await waitFor(() => {
       expect(mockAddToast).toHaveBeenCalledWith('error', '정기거래 등록에 실패했어요')
@@ -480,11 +482,10 @@ describe('RecurringList', () => {
     renderRecurringList()
 
     await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+      expect(screen.getByTestId('toggle-1')).toBeInTheDocument()
     })
 
-    const pauseBtns = screen.getAllByTitle('중지')
-    await user.click(pauseBtns[0])
+    await user.click(screen.getByTestId('toggle-1'))
 
     await waitFor(() => {
       expect(mockAddToast).toHaveBeenCalledWith('error', '변경에 실패했어요')
@@ -502,6 +503,8 @@ describe('RecurringList', () => {
           id: 99, type: 'expense', amount: 10000, description: '테스트',
           frequency: 'monthly', day_of_month: 25, is_active: true,
           next_due_date: '2026-04-25',
+          category_emoji: null, category_name: null,
+          payment_method_id: null, payment_method_name: null,
         }, { status: 201 })
       ),
     )
@@ -538,15 +541,13 @@ describe('RecurringList', () => {
     renderRecurringList()
 
     await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+      expect(screen.getByTestId('menu-1')).toBeInTheDocument()
     })
 
-    const editBtns = screen.getAllByTitle('수정')
-    await user.click(editBtns[0])
-
+    await user.click(screen.getByTestId('menu-1'))
+    await user.click(screen.getByText('수정'))
     expect(screen.getByText('정기거래 수정')).toBeInTheDocument()
 
-    // 수정 모달의 저장 버튼 클릭
     await user.click(screen.getByText('수정하기'))
 
     await waitFor(() => {
@@ -567,15 +568,15 @@ describe('RecurringList', () => {
     renderRecurringList()
 
     await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+      expect(screen.getByTestId('menu-1')).toBeInTheDocument()
     })
 
-    const deleteBtns = screen.getAllByTitle('삭제')
-    await user.click(deleteBtns[0])
+    await user.click(screen.getByTestId('menu-1'))
+    await user.click(screen.getByText('삭제'))
 
-    const deleteModal = screen.getByRole('dialog')
-    expect(deleteModal).toBeInTheDocument()
-    await user.click(within(deleteModal).getByRole('button', { name: '삭제' }))
+    expect(screen.getByText(/삭제할까요/)).toBeInTheDocument()
+    const deleteButtons = screen.getAllByText('삭제')
+    await user.click(deleteButtons[deleteButtons.length - 1])
 
     await waitFor(() => {
       expect(mockAddToast).toHaveBeenCalledWith('error', '삭제에 실패했어요')
@@ -608,37 +609,117 @@ describe('RecurringList', () => {
     })
   })
 
-  // ==================== tabular-nums ====================
+  // ==================== 카드 레이아웃 ====================
 
-  it('데스크톱 테이블 금액 셀에 tabular-nums 클래스가 있다', async () => {
-    server.use(
-      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
-      http.get('/api/categories', () => HttpResponse.json([])),
-    )
-    renderRecurringList()
-
-    await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+  describe('카드 레이아웃', () => {
+    it('이모지와 설명이 표시된다', async () => {
+      renderRecurringList()
+      await waitFor(() => expect(screen.getByText('넷플릭스')).toBeInTheDocument())
+      expect(screen.getByText('🎬')).toBeInTheDocument()
     })
 
-    // 금액이 포함된 요소 중 tabular-nums 클래스를 가진 것이 있어야 함
-    const amountCells = document.querySelectorAll('td.tabular-nums')
-    expect(amountCells.length).toBeGreaterThan(0)
+    it('카테고리명과 결제수단이 표시된다', async () => {
+      renderRecurringList()
+      await waitFor(() => expect(screen.getByText(/구독 · 삼성카드/)).toBeInTheDocument())
+    })
+
+    it('D-day가 표시된다 — next_due_date가 오늘이면 "오늘"', async () => {
+      const today = new Date()
+      const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+      server.use(
+        http.get('/api/recurring', () =>
+          HttpResponse.json([{ ...mockItems[0], next_due_date: todayStr }])
+        )
+      )
+      renderRecurringList()
+      await waitFor(() => expect(screen.getByText('오늘')).toBeInTheDocument())
+    })
   })
 
-  it('모바일 카드 금액 span에 tabular-nums 클래스가 있다', async () => {
-    server.use(
-      http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
-      http.get('/api/categories', () => HttpResponse.json([])),
-    )
-    renderRecurringList()
+  // ==================== ⋮ 메뉴 ====================
 
-    await waitFor(() => {
-      expect(screen.getAllByText('넷플릭스').length).toBeGreaterThan(0)
+  describe('⋮ 메뉴', () => {
+    it('⋮ 버튼 클릭 시 메뉴가 열린다', async () => {
+      const user = userEvent.setup()
+      renderRecurringList()
+      await waitFor(() => screen.getByTestId('menu-1'))
+      await user.click(screen.getByTestId('menu-1'))
+      expect(screen.getByText('지금 등록')).toBeInTheDocument()
+      expect(screen.getByText('수정')).toBeInTheDocument()
+      expect(screen.getByText('삭제')).toBeInTheDocument()
     })
 
-    // 금액 텍스트를 가진 span 중 tabular-nums 클래스를 가진 것이 있어야 함
-    const amountSpans = document.querySelectorAll('span.tabular-nums')
-    expect(amountSpans.length).toBeGreaterThan(0)
+    it('"삭제" 클릭 시 인라인 확인 UI가 나타난다', async () => {
+      const user = userEvent.setup()
+      renderRecurringList()
+      await waitFor(() => screen.getByTestId('menu-1'))
+      await user.click(screen.getByTestId('menu-1'))
+      await user.click(screen.getByText('삭제'))
+      expect(screen.getByText(/삭제할까요/)).toBeInTheDocument()
+      expect(screen.getByText('취소')).toBeInTheDocument()
+    })
+
+    it('"취소" 클릭 시 인라인 확인 UI가 닫힌다', async () => {
+      const user = userEvent.setup()
+      renderRecurringList()
+      await waitFor(() => screen.getByTestId('menu-1'))
+      await user.click(screen.getByTestId('menu-1'))
+      await user.click(screen.getByText('삭제'))
+      await user.click(screen.getByText('취소'))
+      expect(screen.queryByText(/삭제할까요/)).not.toBeInTheDocument()
+    })
+  })
+
+  // ==================== 토글 ====================
+
+  describe('토글', () => {
+    it('활성 항목 토글 클릭 시 낙관적으로 상태가 반전된다', async () => {
+      server.use(
+        http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+        http.put('/api/recurring/1', async () => {
+          await new Promise((resolve) => setTimeout(resolve, 200))
+          return HttpResponse.json({ ...mockItems[0], is_active: false })
+        })
+      )
+      const user = userEvent.setup()
+      renderRecurringList()
+      await waitFor(() => screen.getByTestId('toggle-1'))
+      // 클릭 전: 활성 상태 (title="일시정지")
+      expect(screen.getByTestId('toggle-1')).toHaveAttribute('title', '일시정지')
+      await user.click(screen.getByTestId('toggle-1'))
+      // 낙관적 업데이트: 클릭 직후 활성 항목이 비활성 섹션으로 이동 → 일시정지 섹션 버튼 표시
+      await waitFor(() => {
+        expect(screen.getByTestId('inactive-toggle')).toBeInTheDocument()
+      })
+    })
+
+    it('토글 API 실패 시 원래 상태로 롤백된다', async () => {
+      server.use(
+        http.get('/api/recurring', () => HttpResponse.json([mockItems[0]])),
+        http.put('/api/recurring/1', () => HttpResponse.error())
+      )
+      const user = userEvent.setup()
+      renderRecurringList()
+      await waitFor(() => screen.getByTestId('toggle-1'))
+      expect(screen.getByTestId('toggle-1')).toHaveAttribute('title', '일시정지')
+      await user.click(screen.getByTestId('toggle-1'))
+      await waitFor(() => {
+        expect(screen.getByTestId('toggle-1')).toHaveAttribute('title', '일시정지')
+      })
+    })
+  })
+
+  // ==================== 일시정지 섹션 ====================
+
+  describe('일시정지 섹션', () => {
+    it('일시정지 항목이 있으면 섹션 버튼이 표시된다', async () => {
+      // 활성 항목 + 비활성 항목을 모두 반환해야 일시정지 섹션이 나타남
+      server.use(
+        http.get('/api/recurring', () => HttpResponse.json([mockItems[0], mockItems[2]]))
+      )
+      renderRecurringList()
+      await waitFor(() => expect(screen.getByTestId('inactive-toggle')).toBeInTheDocument())
+      expect(screen.getByText(/일시정지/)).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/pages/__tests__/RecurringList.test.tsx
+++ b/frontend/src/pages/__tests__/RecurringList.test.tsx
@@ -33,6 +33,9 @@ const mockItems: RecurringTransaction[] = [
     next_due_date: '2026-02-25', is_active: true,
     created_at: '2026-01-25T00:00:00Z', updated_at: '2026-01-25T00:00:00Z',
     category_emoji: null,
+    category_name: null,
+    payment_method_id: null,
+    payment_method_name: null,
   },
   {
     id: 2, user_id: 1, household_id: 1,
@@ -43,6 +46,9 @@ const mockItems: RecurringTransaction[] = [
     next_due_date: '2026-02-25', is_active: true,
     created_at: '2026-01-25T00:00:00Z', updated_at: '2026-01-25T00:00:00Z',
     category_emoji: null,
+    category_name: null,
+    payment_method_id: null,
+    payment_method_name: null,
   },
   {
     id: 3, user_id: 1, household_id: 1,
@@ -53,6 +59,9 @@ const mockItems: RecurringTransaction[] = [
     next_due_date: '2026-02-01', is_active: false,
     created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
     category_emoji: null,
+    category_name: null,
+    payment_method_id: null,
+    payment_method_name: null,
   },
 ]
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -374,6 +374,9 @@ export interface RecurringTransaction {
   created_at: string
   updated_at: string
   category_emoji: string | null
+  category_name: string | null
+  payment_method_id: number | null
+  payment_method_name: string | null
 }
 
 export interface RecurringTransactionCreate {
@@ -390,6 +393,7 @@ export interface RecurringTransactionCreate {
   end_date?: string | null
   household_id?: number | null
   source_id?: number | null
+  payment_method_id?: number | null
 }
 
 export interface ExecuteResponse {


### PR DESCRIPTION
## 변경 내용

### 백엔드
- `recurring_transactions`에 `payment_method_id` FK 컬럼 추가 (Alembic 마이그레이션)
- API 응답에 `category_name`, `payment_method_name`, `payment_method_id` 포함
- `update_recurring` relationship-expiry 버그 수정 (db.refresh → selectinload 재조회)
- Alembic 다중 헤드 병합 마이그레이션 추가 (household_profile + recurring_payment_method)

### 프론트엔드
- 테이블 레이아웃 제거 → 카드 기반 단일 뷰 (모바일/데스크톱 통일)
- 이모지 + 카테고리명 + 결제수단명 표시
- D-day 표현 ("오늘", "내일", "3일 후", "매월 25일")
- ⋮ 메뉴: 지금 등록(PlusCircle) / 수정 / 삭제
- 삭제: 브라우저 confirm() → 인라인 확인 UI
- 토글: 낙관적 업데이트 (API 실패 시 롤백)
- 지금 등록: Loader2 → Check 인라인 피드백
- 일시정지 항목: 하단 collapsed 섹션
- RecurringModal에 결제수단 드롭다운 추가
- 저장 후 전체 reload 제거 → 로컬 상태 업데이트

### 테스트
- 백엔드: payment_method_id 포함 생성/조회 테스트 추가
- 프론트엔드: 카드 레이아웃, ⋮ 메뉴, 토글 낙관적 업데이트, 롤백, 일시정지 섹션 테스트 추가

## 검증 결과
- 백엔드: 1722 passed (6 pre-existing failures 제외)
- 프론트엔드: 128 test files, 1671 passed (lint warnings only, no errors)
- 빌드: 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)