### PR TITLE
feat: 월간 결산 리포트 자동 생성 시스템

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -54,6 +54,14 @@ SENTRY_WEBHOOK_SECRET=
 # Sentry 에러 알림을 수신할 텔레그램 채팅 ID
 SENTRY_ALERT_CHAT_ID=
 
+# ──────────────── 월간 결산 리포트 ────────────────
+# Supabase pg_cron → webhook 호출 시 HMAC 인증 시크릿
+MONTHLY_REPORT_WEBHOOK_SECRET=your-hmac-secret-here
+# False이면 webhook 수신해도 실행 안 함 (dev 환경 비활성화용)
+MONTHLY_REPORT_AUTO_ENABLED=true
+# Phase 2 최대 처리 가구 수 (LLM 비용 안전장치)
+MONTHLY_REPORT_MAX_PER_RUN=500
+
 # ──────────────── 관리자 설정 ────────────────
 # 피드백 알림 수신할 관리자 텔레그램 채팅 ID (미설정 시 알림 비활성화)
 ADMIN_TELEGRAM_CHAT_ID=

--- a/backend/alembic/versions/0447179ae24d_merge_household_profile_and_recurring_.py
+++ b/backend/alembic/versions/0447179ae24d_merge_household_profile_and_recurring_.py
@@ -1,0 +1,25 @@
+"""merge_household_profile_and_recurring_payment_method
+
+Revision ID: 0447179ae24d
+Revises: 9e4524bd33ae, b2c3d4e5f6a7
+Create Date: 2026-04-26 13:35:06.761028
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "0447179ae24d"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = ("9e4524bd33ae", "b2c3d4e5f6a7")  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/backend/alembic/versions/9267b82bb199_merge_monthly_reports_and_household_.py
+++ b/backend/alembic/versions/9267b82bb199_merge_monthly_reports_and_household_.py
@@ -1,0 +1,25 @@
+"""merge monthly_reports and household_profile heads
+
+Revision ID: 9267b82bb199
+Revises: a0b1c2d3e4f6, b2c3d4e5f6a7
+Create Date: 2026-04-26 08:25:17.433213
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "9267b82bb199"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = ("a0b1c2d3e4f6", "b2c3d4e5f6a7")  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/backend/alembic/versions/9789df318393_merge_all_feature_branch_heads.py
+++ b/backend/alembic/versions/9789df318393_merge_all_feature_branch_heads.py
@@ -1,0 +1,25 @@
+"""merge all feature branch heads
+
+Revision ID: 9789df318393
+Revises: 0447179ae24d, 9267b82bb199, b2c3d4e5f6g7h8
+Create Date: 2026-04-26 16:22:10.693827
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "9789df318393"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = ("0447179ae24d", "9267b82bb199", "b2c3d4e5f6g7h8")  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/backend/alembic/versions/9e4524bd33ae_add_payment_method_to_recurring.py
+++ b/backend/alembic/versions/9e4524bd33ae_add_payment_method_to_recurring.py
@@ -1,0 +1,36 @@
+"""recurring_transactions에 payment_method_id 추가
+
+Revision ID: 9e4524bd33ae
+Revises: z9a0b1c2d3e4
+Create Date: 2026-04-26
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "9e4524bd33ae"  # pragma: allowlist secret
+down_revision = "z9a0b1c2d3e4"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("recurring_transactions") as batch_op:
+        batch_op.add_column(sa.Column("payment_method_id", sa.Integer(), nullable=True))
+        # SQLite는 FK constraint 이름 지원이 제한적이므로 조건부 처리
+        if op.get_bind().dialect.name != "sqlite":
+            batch_op.create_foreign_key(
+                "fk_recurring_payment_method",
+                "payment_methods",
+                ["payment_method_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("recurring_transactions") as batch_op:
+        if op.get_bind().dialect.name != "sqlite":
+            batch_op.drop_constraint("fk_recurring_payment_method", type_="foreignkey")
+        batch_op.drop_column("payment_method_id")

--- a/backend/alembic/versions/a0b1c2d3e4f6_add_monthly_reports.py
+++ b/backend/alembic/versions/a0b1c2d3e4f6_add_monthly_reports.py
@@ -1,0 +1,123 @@
+"""월간 결산 리포트 테이블 추가
+
+가구별 월간 결산 리포트를 저장하는 monthly_reports 테이블을 추가합니다.
+매월 자동 생성되며, 가구당 월 1개의 리포트만 허용됩니다 (unique constraint).
+
+Revision ID: a0b1c2d3e4f6
+Revises: z9a0b1c2d3e4
+Create Date: 2026-04-26
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a0b1c2d3e4f6"  # pragma: allowlist secret
+down_revision: str | None = "z9a0b1c2d3e4"  # pragma: allowlist secret
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "monthly_reports",
+        sa.Column("id", sa.Integer(), nullable=False),
+        # ── 식별 ──
+        sa.Column("household_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "month",
+            sa.String(7),
+            nullable=False,
+            comment="YYYY-MM 형식 (예: 2026-04)",
+        ),
+        # ── 상태 머신 ──
+        sa.Column(
+            "status",
+            sa.String(15),
+            nullable=False,
+            server_default="pending",
+            comment="pending | processing | completed | failed",
+        ),
+        sa.Column(
+            "attempt_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+            comment="LLM 호출 시도 횟수. 0=Phase 1 완료, 1+=Phase 2 시도",
+        ),
+        sa.Column(
+            "last_error",
+            sa.String(2000),
+            nullable=True,
+            comment="마지막 실패 사유 (2000자 truncate)",
+        ),
+        sa.Column(
+            "trigger_source",
+            sa.String(15),
+            nullable=False,
+            server_default="auto",
+            comment="auto | admin | retry",
+        ),
+        # ── 데이터 스냅샷 ──
+        sa.Column(
+            "report_data",
+            sa.JSON(),
+            nullable=False,
+            comment="분석 시점의 입력 스냅샷. 이후 거래 변경과 무관하게 불변.",
+        ),
+        sa.Column(
+            "insights",
+            sa.JSON(),
+            nullable=True,
+            comment="LLM 출력 (StructuredInsightsResponse 구조). completed 시에만 채워짐.",
+        ),
+        sa.Column(
+            "insights_version",
+            sa.Integer(),
+            nullable=False,
+            server_default="1",
+            comment="LLM 출력 스키마 버전. 스키마 변경 시 증가하여 하위 호환 처리 기준으로 사용.",
+        ),
+        # ── 메타 ──
+        sa.Column("llm_tokens_used", sa.Integer(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        # ── 제약조건 ──
+        sa.ForeignKeyConstraint(
+            ["household_id"],
+            ["households.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "household_id",
+            "month",
+            name="uq_monthly_report_household_month",
+        ),
+    )
+    # 월별 + 상태별 조회를 위한 복합 인덱스
+    op.create_index(
+        "ix_monthly_reports_month_status",
+        "monthly_reports",
+        ["month", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_monthly_reports_month_status", table_name="monthly_reports")
+    op.drop_table("monthly_reports")

--- a/backend/alembic/versions/a0b1c2d3e4f6_add_monthly_reports.py
+++ b/backend/alembic/versions/a0b1c2d3e4f6_add_monthly_reports.py
@@ -89,13 +89,13 @@ def upgrade() -> None:
             "created_at",
             sa.DateTime(),
             nullable=False,
-            server_default=sa.text("now()"),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
         ),
         sa.Column(
             "updated_at",
             sa.DateTime(),
             nullable=False,
-            server_default=sa.text("now()"),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
         ),
         # ── 제약조건 ──
         sa.ForeignKeyConstraint(

--- a/backend/alembic/versions/a1b2c3d4e5f6g7_add_category_corrections.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6g7_add_category_corrections.py
@@ -1,0 +1,89 @@
+"""category_corrections 테이블 추가
+
+카테고리 정정 신호 저장 테이블.
+사용자가 거래 카테고리를 수정할 때 자동 기록되며,
+향후 RAG 기반 카테고리 자동 분류 개선에 사용됩니다.
+
+Revision ID: a1b2c3d4e5f6g7
+Revises: b2c3d4e5f6a7
+Create Date: 2026-04-26
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6g7"  # pragma: allowlist secret
+down_revision = "b2c3d4e5f6a7"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "category_corrections",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("household_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("input_text", sa.String(), nullable=False),
+        sa.Column("category_id", sa.Integer(), nullable=True),
+        sa.Column("source", sa.String(), nullable=False, server_default="edit"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["category_id"],
+            ["categories.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["household_id"],
+            ["households.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # 조회 성능을 위한 인덱스: household 스코프 필터링 + 카테고리 집계에 사용
+    op.create_index(
+        op.f("ix_category_corrections_id"),
+        "category_corrections",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_category_corrections_household_id"),
+        "category_corrections",
+        ["household_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_category_corrections_category_id"),
+        "category_corrections",
+        ["category_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_category_corrections_category_id"),
+        table_name="category_corrections",
+    )
+    op.drop_index(
+        op.f("ix_category_corrections_household_id"),
+        table_name="category_corrections",
+    )
+    op.drop_index(
+        op.f("ix_category_corrections_id"),
+        table_name="category_corrections",
+    )
+    op.drop_table("category_corrections")

--- a/backend/alembic/versions/b2c3d4e5f6g7h8_add_embedding_to_category_corrections.py
+++ b/backend/alembic/versions/b2c3d4e5f6g7h8_add_embedding_to_category_corrections.py
@@ -1,0 +1,31 @@
+"""category_corrections에 embedding 컬럼 추가
+
+RAG 기반 카테고리 자동 분류 개선을 위한 임베딩 컬럼.
+Phase 2에서 정정 저장 시 자동으로 채워집니다.
+
+Revision ID: b2c3d4e5f6g7h8
+Revises: a1b2c3d4e5f6g7
+Create Date: 2026-04-26
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b2c3d4e5f6g7h8"  # pragma: allowlist secret
+down_revision = "a1b2c3d4e5f6g7"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # list[float] 임베딩 벡터를 JSON으로 저장 (Phase 2에서 채워짐)
+    op.add_column(
+        "category_corrections",
+        sa.Column("embedding", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("category_corrections", "embedding")

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -4,6 +4,8 @@
 모든 엔드포인트는 ADMIN_USER_ID 사용자만 접근 가능합니다.
 """
 
+from typing import Any
+
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
 from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -89,7 +91,7 @@ async def retry_report(
     background_tasks: BackgroundTasks,
     _admin: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> dict[str, Any]:
     """failed/pending 상태 리포트 LLM 재시도"""
     report = await db.scalar(sa_select(MonthlyReport).where(MonthlyReport.id == report_id))
     if not report:
@@ -111,7 +113,7 @@ async def manual_trigger_reports(
     month: str = Query(..., pattern=r"^\d{4}-\d{2}$"),
     _admin: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> dict[str, Any]:
     """특정 월 결산 리포트 수동 생성 (디버깅/초기 배포용)"""
     queued = await phase1_enqueue_pending(db, month)
     background_tasks.add_task(phase2_process_pending, month)

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -4,12 +4,14 @@
 모든 엔드포인트는 ADMIN_USER_ID 사용자만 접근 가능합니다.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
+from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.dependencies import require_admin
 from app.core.database import get_db
 from app.core.rate_limit import limiter
+from app.models.monthly_report import MonthlyReport
 from app.models.user import User
 from app.schemas.admin import (
     AdminUserDetailResponse,
@@ -18,6 +20,7 @@ from app.schemas.admin import (
     DashboardStatsResponse,
 )
 from app.services import admin_service
+from app.services.report_scheduler import phase1_enqueue_pending, phase2_process_pending
 
 router = APIRouter()
 
@@ -78,3 +81,38 @@ async def update_user(
     # 수정 후 상세 정보 반환
     result = await admin_service.get_user_detail(db, user_id)
     return result
+
+
+@router.post("/reports/{report_id}/retry", status_code=200)
+async def retry_report(
+    report_id: int,
+    background_tasks: BackgroundTasks,
+    _admin: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """failed/pending 상태 리포트 LLM 재시도"""
+    report = await db.scalar(sa_select(MonthlyReport).where(MonthlyReport.id == report_id))
+    if not report:
+        raise HTTPException(status_code=404, detail="리포트를 찾을 수 없습니다")
+    if report.status not in ("failed", "pending"):
+        raise HTTPException(status_code=400, detail=f"재시도 불가 상태: {report.status}")
+
+    report.status = "pending"
+    report.attempt_count = 0
+    await db.commit()
+
+    background_tasks.add_task(phase2_process_pending, report.month)
+    return {"id": report_id, "status": "retrying"}
+
+
+@router.post("/reports/manual-trigger", status_code=200)
+async def manual_trigger_reports(
+    background_tasks: BackgroundTasks,
+    month: str = Query(..., pattern=r"^\d{4}-\d{2}$"),
+    _admin: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """특정 월 결산 리포트 수동 생성 (디버깅/초기 배포용)"""
+    queued = await phase1_enqueue_pending(db, month)
+    background_tasks.add_task(phase2_process_pending, month)
+    return {"queued": queued, "month": month}

--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -16,14 +16,14 @@ from app.schemas.monthly_report import (
     MonthlyReportOrEligibility,
     MonthlyReportResponse,
 )
-from app.services.report_eligibility import check_household_eligibility
+from app.services.report_eligibility import EligibilityResult, check_household_eligibility
 from app.services.report_month_utils import previous_month_kst
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-def _build_eligibility(eligibility) -> MonthlyReportEligibility:
+def _build_eligibility(eligibility: EligibilityResult) -> MonthlyReportEligibility:
     """EligibilityResult → MonthlyReportEligibility 변환 헬퍼"""
     return MonthlyReportEligibility(
         has_profile=eligibility.has_profile,

--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -1,0 +1,110 @@
+"""월간 결산 리포트 사용자 조회 API"""
+
+import logging
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import get_household_member, get_user_active_household_id
+from app.core.auth import get_current_user
+from app.core.database import get_db
+from app.models.monthly_report import MonthlyReport
+from app.models.user import User
+from app.schemas.monthly_report import (
+    MonthlyReportEligibility,
+    MonthlyReportOrEligibility,
+    MonthlyReportResponse,
+)
+from app.services.report_eligibility import check_household_eligibility
+from app.services.report_month_utils import previous_month_kst
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def _build_eligibility(eligibility) -> MonthlyReportEligibility:
+    """EligibilityResult → MonthlyReportEligibility 변환 헬퍼"""
+    return MonthlyReportEligibility(
+        has_profile=eligibility.has_profile,
+        transaction_count=eligibility.transaction_count,
+        transactions_needed=eligibility.transactions_needed,
+        category_count=eligibility.category_count,
+        total_spend=eligibility.total_spend,
+        is_eligible=eligibility.is_eligible,
+        blocker=eligibility.blocker,
+    )
+
+
+@router.get("/monthly", response_model=MonthlyReportOrEligibility)
+async def get_monthly_report(
+    month: str = Query(..., pattern=r"^\d{4}-\d{2}$"),
+    household_id: int | None = Query(None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> object:
+    """특정 월의 결산 리포트 조회
+
+    - 리포트가 존재하면 status/insights 포함 반환
+    - 리포트가 없으면 eligibility(자격 정보) 반환
+    """
+    if household_id is None:
+        household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)
+
+    report = await db.scalar(
+        select(MonthlyReport).where(
+            MonthlyReport.household_id == household_id,
+            MonthlyReport.month == month,
+        )
+    )
+
+    if report:
+        return MonthlyReportOrEligibility(
+            report=MonthlyReportResponse.model_validate(report),
+            eligibility=None,
+        )
+
+    eligibility = await check_household_eligibility(db, household_id, month)
+    return MonthlyReportOrEligibility(
+        report=None,
+        eligibility=_build_eligibility(eligibility),
+    )
+
+
+@router.get("/latest", response_model=MonthlyReportOrEligibility)
+async def get_latest_report(
+    household_id: int | None = Query(None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> object:
+    """직전 마감 월의 결산 리포트 조회 (모아보기 상단 카드용)
+
+    KST 기준 직전 월의 completed 리포트를 반환한다.
+    리포트가 없으면 직전 월 기준 eligibility를 반환한다.
+    """
+    if household_id is None:
+        household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)
+
+    prev_month = previous_month_kst()
+
+    report = await db.scalar(
+        select(MonthlyReport).where(
+            MonthlyReport.household_id == household_id,
+            MonthlyReport.month == prev_month,
+            MonthlyReport.status == "completed",
+        )
+    )
+
+    if report:
+        return MonthlyReportOrEligibility(
+            report=MonthlyReportResponse.model_validate(report),
+            eligibility=None,
+        )
+
+    eligibility = await check_household_eligibility(db, household_id, prev_month)
+    return MonthlyReportOrEligibility(
+        report=None,
+        eligibility=_build_eligibility(eligibility),
+    )

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -119,7 +119,7 @@ async def trigger_monthly_reports(
     request: Request,
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> dict[str, Any]:
     """Supabase pg_cron이 매월 1일 호출하는 월간 결산 리포트 생성 트리거"""
     verify_monthly_report_webhook(request)
 

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -1,6 +1,8 @@
 """외부 서비스 webhook 수신 엔드포인트
 
-현재: Sentry 에러 알림 → 텔레그램 전달
+현재:
+- Sentry 에러 알림 → 텔레그램 전달
+- Supabase pg_cron → 월간 결산 리포트 생성 트리거
 """
 
 import hashlib
@@ -9,9 +11,14 @@ import logging
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, Header, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from app.core.database import get_db
+from app.core.webhook_auth import verify_monthly_report_webhook
+from app.services.report_month_utils import previous_month_kst
+from app.services.report_scheduler import phase1_enqueue_pending, phase2_process_pending
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -105,3 +112,25 @@ async def sentry_webhook(
         logger.exception("Sentry 알림 텔레그램 전송 실패")
 
     return {"ok": True}
+
+
+@router.post("/monthly-reports")
+async def trigger_monthly_reports(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Supabase pg_cron이 매월 1일 호출하는 월간 결산 리포트 생성 트리거"""
+    verify_monthly_report_webhook(request)
+
+    if not settings.MONTHLY_REPORT_AUTO_ENABLED:
+        logger.info("[monthly-reports] 자동 실행 비활성화 (MONTHLY_REPORT_AUTO_ENABLED=false)")
+        return {"skipped": True, "reason": "auto_disabled"}
+
+    target_month = previous_month_kst()
+    queued = await phase1_enqueue_pending(db, target_month)
+
+    background_tasks.add_task(phase2_process_pending, target_month)
+
+    logger.info("[monthly-reports] cron_started month=%s queued=%d", target_month, queued)
+    return {"queued": queued, "month": target_month}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -57,6 +57,11 @@ class Settings(BaseSettings):
     SENTRY_ALERT_CHAT_ID: str = ""  # Sentry 알림 수신할 텔레그램 채팅 ID
     SENTRY_ALERT_BOT_TOKEN: str = ""  # Sentry 알림용 별도 봇 토큰 (미설정 시 TELEGRAM_BOT_TOKEN 사용)
 
+    # 월간 결산 리포트
+    MONTHLY_REPORT_WEBHOOK_SECRET: str = ""  # Supabase pg_cron → webhook HMAC 시크릿
+    MONTHLY_REPORT_AUTO_ENABLED: bool = True  # False이면 webhook 수신해도 실행 안 함 (dev용)
+    MONTHLY_REPORT_MAX_PER_RUN: int = 500  # Phase 2 최대 처리 가구 수 (비용 안전장치)
+
     # 관리자 설정 — 기본값 -1은 "미설정" 의미 (DB에 존재하지 않는 ID)
     # .env에서 실제 사용자 ID를 설정하지 않으면 관리자 기능이 비활성화됨
     ADMIN_USER_ID: int = -1

--- a/backend/app/core/webhook_auth.py
+++ b/backend/app/core/webhook_auth.py
@@ -1,0 +1,28 @@
+"""HMAC-SHA256 기반 웹훅 서명 검증"""
+
+import hashlib
+import hmac
+
+from fastapi import HTTPException, Request
+
+from app.core.config import settings
+
+
+def verify_monthly_report_webhook(request: Request) -> None:
+    """Supabase pg_net이 전송한 HMAC 서명 검증
+
+    Raises:
+        HTTPException: 서명 불일치 시 401
+    """
+    if not settings.MONTHLY_REPORT_WEBHOOK_SECRET:
+        raise HTTPException(status_code=401, detail="Webhook secret not configured")
+
+    received = request.headers.get("x-webhook-signature", "")
+    expected = hmac.new(
+        settings.MONTHLY_REPORT_WEBHOOK_SECRET.encode(),
+        b"monthly-report-trigger",
+        hashlib.sha256,
+    ).hexdigest()
+
+    if not hmac.compare_digest(received, expected):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.api import (
     onboarding,
     payment_methods,
     recurring,
+    reports,
     stocks,
     telegram,
     webhooks,
@@ -289,6 +290,7 @@ app.include_router(payment_methods.router, prefix="/api/payment-methods", tags=[
 app.include_router(admin.router, prefix="/api/admin", tags=["admin"])
 app.include_router(stocks.router, prefix="/api/stocks", tags=["stocks"])
 app.include_router(onboarding.router, prefix="/api/onboarding", tags=["onboarding"])
+app.include_router(reports.router, prefix="/api/reports", tags=["reports"])
 app.include_router(webhooks.router, prefix="/api/webhooks", tags=["webhooks"])
 
 # E2E 테스트 전용 — 라우터는 항상 등록하되, 각 엔드포인트에서 DEBUG 모드를 검사

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from app.models.household_invitation import HouseholdInvitation
 from app.models.household_member import HouseholdMember
 from app.models.household_profile import HouseholdProfile
 from app.models.income import Income
+from app.models.monthly_report import MonthlyReport
 from app.models.payment_method import PaymentMethod
 from app.models.recurring_transaction import RecurringTransaction
 from app.models.stock import Stock
@@ -32,6 +33,7 @@ __all__ = [
     "HouseholdMember",
     "HouseholdProfile",
     "Income",
+    "MonthlyReport",
     "PaymentMethod",
     "RecurringTransaction",
     "Stock",

--- a/backend/app/models/household.py
+++ b/backend/app/models/household.py
@@ -8,11 +8,16 @@ DDD 관점:
 - 도메인 불변식: 가구는 반드시 한 명 이상의 owner를 가져야 합니다.
 """
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import Column, DateTime, Integer, Numeric, String
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, relationship
 from sqlalchemy.sql import func
 
 from app.core.database import Base
+
+if TYPE_CHECKING:
+    from app.models.monthly_report import MonthlyReport
 
 
 class Household(Base):  # type: ignore[misc]
@@ -57,6 +62,11 @@ class Household(Base):  # type: ignore[misc]
         "HouseholdProfile",
         back_populates="household",
         uselist=False,
+        cascade="all, delete-orphan",
+    )
+    # 월간 결산 리포트 — 가구 삭제 시 함께 삭제
+    monthly_reports: Mapped[list["MonthlyReport"]] = relationship(
+        back_populates="household",
         cascade="all, delete-orphan",
     )
 

--- a/backend/app/models/monthly_report.py
+++ b/backend/app/models/monthly_report.py
@@ -1,7 +1,7 @@
 """월간 결산 리포트 엔티티"""
 
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import JSON, ForeignKey, Index, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -60,12 +60,12 @@ class MonthlyReport(Base):  # type: ignore[misc]
     )
 
     # ── 데이터 스냅샷 ──
-    report_data: Mapped[dict] = mapped_column(
+    report_data: Mapped[dict[str, Any]] = mapped_column(
         JSON,
         nullable=False,
         comment="분석 시점의 입력 스냅샷. 이후 거래 변경과 무관하게 불변.",
     )
-    insights: Mapped[dict | None] = mapped_column(
+    insights: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         comment="LLM 출력 (StructuredInsightsResponse 구조). completed 시에만 채워짐.",

--- a/backend/app/models/monthly_report.py
+++ b/backend/app/models/monthly_report.py
@@ -1,0 +1,107 @@
+"""월간 결산 리포트 엔티티"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import JSON, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+if TYPE_CHECKING:
+    from app.models.household import Household
+
+
+class MonthlyReport(Base):  # type: ignore[misc]
+    """가구별 월간 결산 리포트
+
+    매월 1일 03:00 KST에 자동 생성된다.
+    한 가구는 한 달에 하나의 리포트만 가질 수 있다 (unique constraint).
+    """
+
+    __tablename__ = "monthly_reports"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # ── 식별 ──
+    household_id: Mapped[int] = mapped_column(
+        ForeignKey("households.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    month: Mapped[str] = mapped_column(
+        String(7),
+        nullable=False,
+        comment="YYYY-MM 형식 (예: 2026-04)",
+    )
+
+    # ── 상태 머신 ──
+    status: Mapped[str] = mapped_column(
+        String(15),
+        nullable=False,
+        default="pending",
+        comment="pending | processing | completed | failed",
+    )
+    attempt_count: Mapped[int] = mapped_column(
+        default=0,
+        nullable=False,
+        comment="LLM 호출 시도 횟수. 0=Phase 1 완료, 1+=Phase 2 시도",
+    )
+    last_error: Mapped[str | None] = mapped_column(
+        String(2000),
+        nullable=True,
+        comment="마지막 실패 사유 (2000자 truncate)",
+    )
+    trigger_source: Mapped[str] = mapped_column(
+        String(15),
+        nullable=False,
+        default="auto",
+        comment="auto | admin | retry",
+    )
+
+    # ── 데이터 스냅샷 ──
+    report_data: Mapped[dict] = mapped_column(
+        JSON,
+        nullable=False,
+        comment="분석 시점의 입력 스냅샷. 이후 거래 변경과 무관하게 불변.",
+    )
+    insights: Mapped[dict | None] = mapped_column(
+        JSON,
+        nullable=True,
+        comment="LLM 출력 (StructuredInsightsResponse 구조). completed 시에만 채워짐.",
+    )
+    insights_version: Mapped[int] = mapped_column(
+        default=1,
+        nullable=False,
+        comment="LLM 출력 스키마 버전. 스키마 변경 시 증가하여 하위 호환 처리 기준으로 사용.",
+    )
+
+    # ── 메타 ──
+    llm_tokens_used: Mapped[int | None] = mapped_column(nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        default=func.now(),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        default=func.now(),
+        onupdate=func.now(),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    household: Mapped["Household"] = relationship(back_populates="monthly_reports")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "household_id",
+            "month",
+            name="uq_monthly_report_household_month",
+        ),
+        Index("ix_monthly_reports_month_status", "month", "status"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<MonthlyReport(" f"id={self.id}, " f"household_id={self.household_id}, " f"month={self.month}, " f"status={self.status})>"

--- a/backend/app/schemas/monthly_report.py
+++ b/backend/app/schemas/monthly_report.py
@@ -1,0 +1,57 @@
+"""월간 결산 리포트 Pydantic 스키마"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+from app.schemas.insights import StructuredInsightsResponse
+
+
+class MonthlyReportResponse(BaseModel):
+    """사용자 조회 API 응답"""
+
+    id: int
+    month: str
+    status: Literal["pending", "processing", "completed", "failed"]
+    insights: StructuredInsightsResponse | None
+    completed_at: datetime | None
+
+    model_config = {"from_attributes": True}
+
+
+class MonthlyReportListItem(BaseModel):
+    """리스트/카드 그리드용"""
+
+    month: str
+    status: Literal["pending", "processing", "completed", "failed"]
+    headline: str | None  # insights.findings[0].what 미리보기
+    completed_at: datetime | None
+
+    model_config = {"from_attributes": True}
+
+
+class MonthlyReportEligibility(BaseModel):
+    """자격 미달 시 사용자 안내 정보"""
+
+    has_profile: bool
+    transaction_count: int
+    transactions_needed: int
+    category_count: int
+    total_spend: float
+    is_eligible: bool
+    blocker: Literal[
+        "profile_missing",
+        "transactions_short",
+        "categories_short",
+        "spend_short",
+        "first_month",
+        None,
+    ]
+
+
+class MonthlyReportOrEligibility(BaseModel):
+    """리포트 없을 때 자격 정보를 함께 반환"""
+
+    report: MonthlyReportResponse | None
+    eligibility: MonthlyReportEligibility | None

--- a/backend/app/schemas/monthly_report.py
+++ b/backend/app/schemas/monthly_report.py
@@ -40,14 +40,18 @@ class MonthlyReportEligibility(BaseModel):
     category_count: int
     total_spend: float
     is_eligible: bool
-    blocker: Literal[
-        "profile_missing",
-        "transactions_short",
-        "categories_short",
-        "spend_short",
-        "first_month",
-        None,
-    ]
+    blocker: (
+        Literal[
+            "profile_missing",
+            "transactions_short",
+            "categories_short",
+            "spend_short",
+            "first_month",
+        ]
+        | None
+    )
+
+    model_config = {"from_attributes": True}
 
 
 class MonthlyReportOrEligibility(BaseModel):

--- a/backend/app/services/report_data_builder.py
+++ b/backend/app/services/report_data_builder.py
@@ -12,6 +12,7 @@ ComprehensiveInsightsRequest 스키마와 호환되는 dict를 반환한다.
 import logging
 import math
 from datetime import date, datetime, time
+from typing import Any
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -67,7 +68,7 @@ async def _sum_expenses(db: AsyncSession, household_id: int, start: date, end: d
             )
         )
     )
-    return float(result.scalar())
+    return float(result.scalar() or 0)
 
 
 async def _sum_income(db: AsyncSession, household_id: int, start: date, end: date) -> float:
@@ -83,7 +84,7 @@ async def _sum_income(db: AsyncSession, household_id: int, start: date, end: dat
             )
         )
     )
-    return float(result.scalar())
+    return float(result.scalar() or 0)
 
 
 async def _top_expense_categories(
@@ -93,7 +94,7 @@ async def _top_expense_categories(
     end: date,
     expense_total: float,
     limit: int = 5,
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     """카테고리별 지출 집계 TOP N
 
     각 항목: {category_id, name, amount, percentage}
@@ -133,7 +134,7 @@ async def _top_expense_categories(
     return items
 
 
-async def _budget_summary(db: AsyncSession, household_id: int, start: date, end: date) -> dict:
+async def _budget_summary(db: AsyncSession, household_id: int, start: date, end: date) -> dict[str, Any]:
     """활성 예산 대비 실제 지출 요약
 
     반환: {total_budget, total_spent, items: [{category_id, name, budget, spent}]}
@@ -201,7 +202,7 @@ async def _budget_summary(db: AsyncSession, household_id: int, start: date, end:
     }
 
 
-async def _expense_income_trend(db: AsyncSession, household_id: int, current_month: str, months: int = 3) -> list[dict]:
+async def _expense_income_trend(db: AsyncSession, household_id: int, current_month: str, months: int = 3) -> list[dict[str, Any]]:
     """최근 N개월 지출/수입 추이
 
     반환: [{month, expense, income}, ...]  최신 월 포함 N개월 (오름차순)
@@ -241,10 +242,10 @@ async def _savings_total(db: AsyncSession, household_id: int, start: date, end: 
             )
         )
     )
-    return float(result.scalar())
+    return float(result.scalar() or 0)
 
 
-async def _recurring_total(db: AsyncSession, household_id: int, start: date, end: date) -> dict:
+async def _recurring_total(db: AsyncSession, household_id: int, start: date, end: date) -> dict[str, Any]:
     """당월 정기 거래 예정 금액 합계
 
     next_due_date가 해당 월 범위 내에 있는 활성 정기 거래를 집계.
@@ -272,9 +273,9 @@ def _calc_financial_score(
     income_total: float,
     expense_total: float,
     savings_total: float,
-    budget: dict,
-    trend: list[dict],
-) -> dict:
+    budget: dict[str, Any],
+    trend: list[dict[str, Any]],
+) -> dict[str, Any]:
     """재무 건강 점수 계산 (0~100)
 
     4가지 지표:
@@ -337,7 +338,7 @@ def _calc_financial_score(
     }
 
 
-async def build_report_data(db: AsyncSession, household_id: int, month: str) -> dict:
+async def build_report_data(db: AsyncSession, household_id: int, month: str) -> dict[str, Any]:
     """ComprehensiveInsightsRequest 호환 dict 생성
 
     Args:

--- a/backend/app/services/report_data_builder.py
+++ b/backend/app/services/report_data_builder.py
@@ -96,7 +96,7 @@ async def _top_expense_categories(
 ) -> list[dict]:
     """카테고리별 지출 집계 TOP N
 
-    각 항목: {category_id, category_name, amount, ratio}
+    각 항목: {category_id, name, amount, percentage}
     """
     dt_start, dt_end = _date_to_datetime_range(start, end)
     rows = await db.execute(
@@ -121,13 +121,13 @@ async def _top_expense_categories(
     items = []
     for row in rows:
         amount = float(row.total)
-        ratio = round(amount / expense_total * 100, 1) if expense_total > 0 else 0.0
+        percentage = round(amount / expense_total * 100, 1) if expense_total > 0 else 0.0
         items.append(
             {
                 "category_id": row.category_id,
-                "category_name": row.name or "미분류",
+                "name": row.name or "미분류",
                 "amount": amount,
-                "ratio": ratio,
+                "percentage": percentage,
             }
         )
     return items

--- a/backend/app/services/report_data_builder.py
+++ b/backend/app/services/report_data_builder.py
@@ -1,0 +1,390 @@
+"""월간 결산 리포트 데이터 집계 서비스
+
+기존 InsightsPage.tsx가 7~8개 API를 호출해 조립하던 로직을 백엔드로 이관.
+ComprehensiveInsightsRequest 스키마와 호환되는 dict를 반환한다.
+
+주요 설계 결정:
+- Expense.date / Income.date 가 DateTime 타입이므로, date 경계는 datetime으로 변환
+- Category.is_savings 플래그를 기반으로 저축성 지출을 집계
+- RecurringTransaction.next_due_date (Date) 기준으로 당월 예정 금액 집계
+"""
+
+import logging
+import math
+from datetime import date, datetime, time
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import Budget
+from app.models.category import Category
+from app.models.expense import Expense
+from app.models.income import Income
+from app.models.recurring_transaction import RecurringTransaction
+from app.services.report_month_utils import month_boundaries
+
+logger = logging.getLogger(__name__)
+
+# 재무 건강 점수 등급 기준 (overall 0~100 기준)
+_GRADE_THRESHOLDS = [
+    (97, "A+"),
+    (90, "A"),
+    (80, "B+"),
+    (70, "B"),
+    (60, "C+"),
+    (50, "C"),
+    (40, "D"),
+]
+
+
+def _date_to_datetime_range(start: date, end: date) -> tuple[datetime, datetime]:
+    """date 경계를 DateTime 필드 비교용 datetime으로 변환
+
+    Expense.date / Income.date가 DateTime 컬럼이므로
+    date 경계를 midnight datetime으로 변환해야 올바른 범위 필터가 적용된다.
+    """
+    return datetime.combine(start, time.min), datetime.combine(end, time.min)
+
+
+def _previous_month(month: str) -> str:
+    """YYYY-MM → 직전 월 YYYY-MM"""
+    year, mon = map(int, month.split("-"))
+    if mon == 1:
+        return f"{year - 1}-12"
+    return f"{year}-{mon - 1:02d}"
+
+
+async def _sum_expenses(db: AsyncSession, household_id: int, start: date, end: date) -> float:
+    """기간 내 지출 합계 (exclude_from_stats=True 제외)"""
+    dt_start, dt_end = _date_to_datetime_range(start, end)
+    result = await db.execute(
+        select(func.coalesce(func.sum(Expense.amount), 0)).where(
+            and_(
+                Expense.household_id == household_id,
+                Expense.date >= dt_start,
+                Expense.date < dt_end,
+                Expense.exclude_from_stats.is_(False),
+            )
+        )
+    )
+    return float(result.scalar())
+
+
+async def _sum_income(db: AsyncSession, household_id: int, start: date, end: date) -> float:
+    """기간 내 수입 합계 (exclude_from_stats=True 제외)"""
+    dt_start, dt_end = _date_to_datetime_range(start, end)
+    result = await db.execute(
+        select(func.coalesce(func.sum(Income.amount), 0)).where(
+            and_(
+                Income.household_id == household_id,
+                Income.date >= dt_start,
+                Income.date < dt_end,
+                Income.exclude_from_stats.is_(False),
+            )
+        )
+    )
+    return float(result.scalar())
+
+
+async def _top_expense_categories(
+    db: AsyncSession,
+    household_id: int,
+    start: date,
+    end: date,
+    expense_total: float,
+    limit: int = 5,
+) -> list[dict]:
+    """카테고리별 지출 집계 TOP N
+
+    각 항목: {category_id, category_name, amount, ratio}
+    """
+    dt_start, dt_end = _date_to_datetime_range(start, end)
+    rows = await db.execute(
+        select(
+            Expense.category_id,
+            Category.name,
+            func.sum(Expense.amount).label("total"),
+        )
+        .outerjoin(Category, Expense.category_id == Category.id)
+        .where(
+            and_(
+                Expense.household_id == household_id,
+                Expense.date >= dt_start,
+                Expense.date < dt_end,
+                Expense.exclude_from_stats.is_(False),
+            )
+        )
+        .group_by(Expense.category_id, Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .limit(limit)
+    )
+    items = []
+    for row in rows:
+        amount = float(row.total)
+        ratio = round(amount / expense_total * 100, 1) if expense_total > 0 else 0.0
+        items.append(
+            {
+                "category_id": row.category_id,
+                "category_name": row.name or "미분류",
+                "amount": amount,
+                "ratio": ratio,
+            }
+        )
+    return items
+
+
+async def _budget_summary(db: AsyncSession, household_id: int, start: date, end: date) -> dict:
+    """활성 예산 대비 실제 지출 요약
+
+    반환: {total_budget, total_spent, items: [{category_id, name, budget, spent}]}
+    """
+    dt_start, dt_end = _date_to_datetime_range(start, end)
+
+    # 활성 예산: period=monthly이고 해당 월과 겹치는 예산
+    budgets = await db.execute(
+        select(Budget.id, Budget.category_id, Budget.amount, Category.name)
+        .outerjoin(Category, Budget.category_id == Category.id)
+        .where(
+            and_(
+                Budget.household_id == household_id,
+                Budget.period == "monthly",
+                Budget.start_date <= dt_end,
+            )
+        )
+    )
+    budget_rows = budgets.all()
+
+    if not budget_rows:
+        return {"total_budget": 0.0, "total_spent": 0.0, "items": []}
+
+    # 예산별 실제 지출 집계
+    category_ids = [r.category_id for r in budget_rows]
+    spent_rows = await db.execute(
+        select(
+            Expense.category_id,
+            func.sum(Expense.amount).label("spent"),
+        )
+        .where(
+            and_(
+                Expense.household_id == household_id,
+                Expense.date >= dt_start,
+                Expense.date < dt_end,
+                Expense.exclude_from_stats.is_(False),
+                Expense.category_id.in_(category_ids),
+            )
+        )
+        .group_by(Expense.category_id)
+    )
+    spent_map = {r.category_id: float(r.spent) for r in spent_rows}
+
+    items = []
+    total_budget = 0.0
+    total_spent = 0.0
+    for row in budget_rows:
+        budget_amount = float(row.amount)
+        spent_amount = spent_map.get(row.category_id, 0.0)
+        total_budget += budget_amount
+        total_spent += spent_amount
+        items.append(
+            {
+                "category_id": row.category_id,
+                "name": row.name or "미분류",
+                "budget": budget_amount,
+                "spent": spent_amount,
+            }
+        )
+
+    return {
+        "total_budget": total_budget,
+        "total_spent": total_spent,
+        "items": items,
+    }
+
+
+async def _expense_income_trend(db: AsyncSession, household_id: int, current_month: str, months: int = 3) -> list[dict]:
+    """최근 N개월 지출/수입 추이
+
+    반환: [{month, expense, income}, ...]  최신 월 포함 N개월 (오름차순)
+    """
+    # 현재 월 포함 이전 (months-1)개월 수집
+    trend_months: list[str] = []
+    m = current_month
+    for _ in range(months):
+        trend_months.insert(0, m)
+        m = _previous_month(m)
+
+    result = []
+    for month in trend_months:
+        s, e = month_boundaries(month)
+        expense = await _sum_expenses(db, household_id, s, e)
+        income = await _sum_income(db, household_id, s, e)
+        result.append({"month": month, "expense": expense, "income": income})
+    return result
+
+
+async def _savings_total(db: AsyncSession, household_id: int, start: date, end: date) -> float:
+    """저축성 카테고리(is_savings=True) 지출 합계
+
+    Category.is_savings 플래그를 기반으로 집계 — "savings" 타입은 없음.
+    """
+    dt_start, dt_end = _date_to_datetime_range(start, end)
+    result = await db.execute(
+        select(func.coalesce(func.sum(Expense.amount), 0))
+        .join(Category, Expense.category_id == Category.id)
+        .where(
+            and_(
+                Expense.household_id == household_id,
+                Expense.date >= dt_start,
+                Expense.date < dt_end,
+                Expense.exclude_from_stats.is_(False),
+                Category.is_savings.is_(True),
+            )
+        )
+    )
+    return float(result.scalar())
+
+
+async def _recurring_total(db: AsyncSession, household_id: int, start: date, end: date) -> dict:
+    """당월 정기 거래 예정 금액 합계
+
+    next_due_date가 해당 월 범위 내에 있는 활성 정기 거래를 집계.
+    반환: {expense: float, income: float}
+    """
+    rows = await db.execute(
+        select(RecurringTransaction.type, func.sum(RecurringTransaction.amount).label("total"))
+        .where(
+            and_(
+                RecurringTransaction.household_id == household_id,
+                RecurringTransaction.is_active.is_(True),
+                RecurringTransaction.next_due_date >= start,
+                RecurringTransaction.next_due_date < end,
+            )
+        )
+        .group_by(RecurringTransaction.type)
+    )
+    totals = {"expense": 0.0, "income": 0.0}
+    for row in rows:
+        totals[row.type] = float(row.total)
+    return totals
+
+
+def _calc_financial_score(
+    income_total: float,
+    expense_total: float,
+    savings_total: float,
+    budget: dict,
+    trend: list[dict],
+) -> dict:
+    """재무 건강 점수 계산 (0~100)
+
+    4가지 지표:
+    1. 저축률 점수: savings_total / income_total 비율 기반 (0~30점)
+    2. 예산 준수율 점수: spent / budget 비율 기반 (0~30점)
+    3. 지출 안정성 점수: 직전 3개월 변동계수(CV) 기반 (0~20점)
+    4. 흑자율 점수: (income - expense) / income 기반 (0~20점)
+
+    grade: A+ / A / B+ / B / C+ / C / D / F
+    """
+    scores: dict[str, float] = {}
+
+    # 1. 저축률 점수 (0~30) — 저축/수입 비율 20% 이상이면 만점
+    if income_total > 0:
+        savings_ratio = savings_total / income_total
+        scores["savings"] = min(savings_ratio / 0.20, 1.0) * 30
+    else:
+        scores["savings"] = 0.0
+
+    # 2. 예산 준수율 점수 (0~30) — 예산이 없으면 중간 점수 15점
+    total_budget = budget.get("total_budget", 0.0)
+    total_spent = budget.get("total_spent", 0.0)
+    if total_budget > 0:
+        usage_ratio = total_spent / total_budget
+        # 사용률이 80% 이하이면 만점, 100% 초과 시 0점
+        scores["budget"] = max(0.0, min(1.0, (1.0 - usage_ratio) / 0.20)) * 30
+    else:
+        scores["budget"] = 15.0  # 예산 미설정 중간 점수
+
+    # 3. 지출 안정성 점수 (0~20) — 변동계수(CV) 낮을수록 안정적
+    expense_values = [t["expense"] for t in trend if t["expense"] > 0]
+    if len(expense_values) >= 2:
+        mean = sum(expense_values) / len(expense_values)
+        variance = sum((v - mean) ** 2 for v in expense_values) / len(expense_values)
+        cv = math.sqrt(variance) / mean if mean > 0 else 0.0
+        # CV 0.1 이하 만점, 0.5 이상 0점
+        scores["stability"] = max(0.0, min(1.0, 1.0 - (cv - 0.1) / 0.4)) * 20
+    else:
+        scores["stability"] = 10.0  # 데이터 부족 시 중간 점수
+
+    # 4. 흑자율 점수 (0~20) — (수입 - 지출) / 수입 30% 이상이면 만점
+    if income_total > 0:
+        surplus_ratio = (income_total - expense_total) / income_total
+        scores["surplus"] = min(max(surplus_ratio / 0.30, 0.0), 1.0) * 20
+    else:
+        scores["surplus"] = 0.0
+
+    overall = round(sum(scores.values()), 1)
+
+    grade = "F"
+    for threshold, g in _GRADE_THRESHOLDS:
+        if overall >= threshold:
+            grade = g
+            break
+
+    return {
+        "overall": overall,
+        "grade": grade,
+        "details": {k: round(v, 1) for k, v in scores.items()},
+    }
+
+
+async def build_report_data(db: AsyncSession, household_id: int, month: str) -> dict:
+    """ComprehensiveInsightsRequest 호환 dict 생성
+
+    Args:
+        db: AsyncSession
+        household_id: 대상 가구 ID
+        month: YYYY-MM 형식 월 문자열
+
+    Returns:
+        월간 결산 집계 dict — InsightsPage 및 MonthlyReport 스키마와 호환
+    """
+    start, end = month_boundaries(month)
+    prev_month = _previous_month(month)
+    prev_start, prev_end = month_boundaries(prev_month)
+
+    expense_total = await _sum_expenses(db, household_id, start, end)
+    income_total = await _sum_income(db, household_id, start, end)
+    prev_expense = await _sum_expenses(db, household_id, prev_start, prev_end)
+    prev_income = await _sum_income(db, household_id, prev_start, prev_end)
+
+    top_categories = await _top_expense_categories(db, household_id, start, end, expense_total)
+    budget = await _budget_summary(db, household_id, start, end)
+    trend = await _expense_income_trend(db, household_id, month, months=3)
+    savings_total = await _savings_total(db, household_id, start, end)
+    recurring_total = await _recurring_total(db, household_id, start, end)
+
+    # 저축률: (수입 - 지출) / 수입 * 100
+    savings_rate = (income_total - expense_total) / income_total * 100 if income_total > 0 else 0.0
+
+    financial_score = _calc_financial_score(
+        income_total=income_total,
+        expense_total=expense_total,
+        savings_total=savings_total,
+        budget=budget,
+        trend=trend,
+    )
+
+    return {
+        "month": month,
+        "income_total": income_total,
+        "expense_total": expense_total,
+        "top_expense_categories": top_categories,
+        "budget": budget,
+        "savings_rate": round(savings_rate, 2),
+        "trend": trend,
+        "savings_total": savings_total,
+        "recurring_total": recurring_total,
+        "previous_month_expense": prev_expense,
+        "previous_month_income": prev_income,
+        "financial_score": financial_score,
+    }

--- a/backend/app/services/report_eligibility.py
+++ b/backend/app/services/report_eligibility.py
@@ -1,0 +1,181 @@
+"""월간 결산 리포트 자격 검증 서비스
+
+가구가 월간 결산 리포트를 받을 자격이 있는지 판단한다.
+자격 조건은 3가지: 거래 건수, 카테고리 다양성, 총 지출액.
+HouseholdProfile이 없으면 온보딩 미완료로 간주하여 즉시 미달 처리한다.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Literal
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.expense import Expense
+from app.models.household import Household
+from app.models.household_profile import HouseholdProfile
+from app.services.report_month_utils import month_boundaries
+
+logger = logging.getLogger(__name__)
+
+# 자격 임계값 상수
+MIN_TRANSACTIONS = 15
+MIN_CATEGORIES = 3
+MIN_SPEND = 200_000
+
+# HouseholdProfile 미존재 시 반환되는 blocker 값
+_BLOCKER_PROFILE_MISSING = "profile_missing"
+_BLOCKER_TRANSACTIONS_SHORT = "transactions_short"
+_BLOCKER_CATEGORIES_SHORT = "categories_short"
+_BLOCKER_SPEND_SHORT = "spend_short"
+
+BlockerType = Literal[
+    "profile_missing",
+    "transactions_short",
+    "categories_short",
+    "spend_short",
+    None,
+]
+
+
+@dataclass
+class EligibilityResult:
+    """단일 가구의 자격 검증 결과
+
+    Attributes:
+        has_profile: HouseholdProfile 존재 여부
+        transaction_count: 해당 월 통계 포함 지출 건수
+        category_count: 해당 월 고유 카테고리 수
+        total_spend: 해당 월 총 지출액 (원)
+        is_eligible: 모든 조건 통과 여부
+        blocker: 첫 번째 미달 조건 (자격 통과 시 None)
+    """
+
+    has_profile: bool
+    transaction_count: int
+    category_count: int
+    total_spend: float
+    is_eligible: bool
+    blocker: BlockerType
+
+    @property
+    def transactions_needed(self) -> int:
+        """리포트 자격까지 필요한 추가 거래 건수"""
+        return max(0, MIN_TRANSACTIONS - self.transaction_count)
+
+
+def _date_to_datetime(d: date) -> datetime:
+    """date → datetime 변환 (Expense.date가 DateTime 컬럼이므로 필요)"""
+    return datetime(d.year, d.month, d.day)
+
+
+async def find_eligible_households(db: AsyncSession, month: str) -> list[int]:
+    """자격 통과 가구 ID 목록 반환
+
+    HouseholdProfile이 있고, 해당 월의 통계 포함 지출 거래가
+    건수·카테고리·총액 기준을 모두 만족하는 가구를 반환한다.
+
+    Args:
+        db: 비동기 DB 세션
+        month: 대상 월 (YYYY-MM 형식)
+
+    Returns:
+        자격 통과 가구 ID 목록
+    """
+    start, end = month_boundaries(month)
+    start_dt = _date_to_datetime(start)
+    end_dt = _date_to_datetime(end)
+
+    # HouseholdProfile JOIN으로 온보딩 미완료 가구를 한 번에 필터
+    result = await db.execute(
+        select(Household.id)
+        .join(HouseholdProfile, HouseholdProfile.household_id == Household.id)
+        .outerjoin(
+            Expense,
+            and_(
+                Expense.household_id == Household.id,
+                Expense.date >= start_dt,
+                Expense.date < end_dt,
+                Expense.exclude_from_stats == False,  # noqa: E712
+            ),
+        )
+        .group_by(Household.id)
+        .having(
+            func.count(Expense.id) >= MIN_TRANSACTIONS,
+            func.count(func.distinct(Expense.category_id)) >= MIN_CATEGORIES,
+            func.coalesce(func.sum(Expense.amount), 0) >= MIN_SPEND,
+        )
+    )
+    ids = [row[0] for row in result.all()]
+    logger.info("[eligibility] 자격 통과 가구 %d개 (월: %s)", len(ids), month)
+    return ids
+
+
+async def check_household_eligibility(db: AsyncSession, household_id: int, month: str) -> EligibilityResult:
+    """단일 가구의 자격 상세 정보 반환
+
+    API나 스케줄러에서 특정 가구의 자격 여부와 부족한 조건을 확인할 때 사용한다.
+
+    Args:
+        db: 비동기 DB 세션
+        household_id: 검증할 가구 ID
+        month: 대상 월 (YYYY-MM 형식)
+
+    Returns:
+        EligibilityResult (blocker=None이면 자격 통과)
+    """
+    # HouseholdProfile 존재 여부 먼저 확인
+    profile_row = await db.execute(select(HouseholdProfile.id).where(HouseholdProfile.household_id == household_id))
+    has_profile = profile_row.scalar_one_or_none() is not None
+
+    if not has_profile:
+        return EligibilityResult(
+            has_profile=False,
+            transaction_count=0,
+            category_count=0,
+            total_spend=0.0,
+            is_eligible=False,
+            blocker=_BLOCKER_PROFILE_MISSING,
+        )
+
+    # 거래 집계
+    start, end = month_boundaries(month)
+    start_dt = _date_to_datetime(start)
+    end_dt = _date_to_datetime(end)
+
+    row = await db.execute(
+        select(
+            func.count(Expense.id).label("tx_count"),
+            func.count(func.distinct(Expense.category_id)).label("cat_count"),
+            func.coalesce(func.sum(Expense.amount), 0).label("total"),
+        ).where(
+            Expense.household_id == household_id,
+            Expense.date >= start_dt,
+            Expense.date < end_dt,
+            Expense.exclude_from_stats == False,  # noqa: E712
+        )
+    )
+    stats = row.one()
+    tx_count: int = stats.tx_count
+    cat_count: int = stats.cat_count
+    total: float = float(stats.total)
+
+    # 우선순위 순으로 blocker 결정 (거래 건수 → 카테고리 → 총액)
+    blocker: BlockerType = None
+    if tx_count < MIN_TRANSACTIONS:
+        blocker = _BLOCKER_TRANSACTIONS_SHORT
+    elif cat_count < MIN_CATEGORIES:
+        blocker = _BLOCKER_CATEGORIES_SHORT
+    elif total < MIN_SPEND:
+        blocker = _BLOCKER_SPEND_SHORT
+
+    return EligibilityResult(
+        has_profile=True,
+        transaction_count=tx_count,
+        category_count=cat_count,
+        total_spend=total,
+        is_eligible=blocker is None,
+        blocker=blocker,
+    )

--- a/backend/app/services/report_eligibility.py
+++ b/backend/app/services/report_eligibility.py
@@ -25,12 +25,6 @@ MIN_TRANSACTIONS = 15
 MIN_CATEGORIES = 3
 MIN_SPEND = 200_000
 
-# HouseholdProfile 미존재 시 반환되는 blocker 값
-_BLOCKER_PROFILE_MISSING = "profile_missing"
-_BLOCKER_TRANSACTIONS_SHORT = "transactions_short"
-_BLOCKER_CATEGORIES_SHORT = "categories_short"
-_BLOCKER_SPEND_SHORT = "spend_short"
-
 BlockerType = Literal[
     "profile_missing",
     "transactions_short",
@@ -38,6 +32,12 @@ BlockerType = Literal[
     "spend_short",
     None,
 ]
+
+# HouseholdProfile 미존재 시 반환되는 blocker 값 (Literal 타입으로 선언해야 mypy가 허용)
+_BLOCKER_PROFILE_MISSING: Literal["profile_missing"] = "profile_missing"
+_BLOCKER_TRANSACTIONS_SHORT: Literal["transactions_short"] = "transactions_short"
+_BLOCKER_CATEGORIES_SHORT: Literal["categories_short"] = "categories_short"
+_BLOCKER_SPEND_SHORT: Literal["spend_short"] = "spend_short"
 
 
 @dataclass

--- a/backend/app/services/report_generator.py
+++ b/backend/app/services/report_generator.py
@@ -12,6 +12,7 @@ mark_completed / mark_failed는 DB 상태 전이만 담당하며 단독으로도
 import asyncio
 import logging
 from datetime import UTC, datetime
+from typing import Any
 
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,7 +40,7 @@ def _truncate_error(msg: str, max_len: int = MAX_ERROR_LENGTH) -> str:
 async def mark_completed(
     db: AsyncSession,
     report_id: int,
-    insights: dict,
+    insights: dict[str, Any],
 ) -> None:
     """리포트 완료 상태로 전이
 

--- a/backend/app/services/report_generator.py
+++ b/backend/app/services/report_generator.py
@@ -1,0 +1,131 @@
+"""LLM 호출 + MonthlyReport 상태 전이 서비스
+
+흐름:
+  run_llm_for_report(db, report)
+    → format_insights_data_for_llm으로 텍스트 포맷
+    → LLM generate_comprehensive_insights_v2 호출 (30초 타임아웃)
+    → mark_completed (성공) 또는 mark_failed (실패)
+
+mark_completed / mark_failed는 DB 상태 전이만 담당하며 단독으로도 호출 가능합니다.
+"""
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.monthly_report import MonthlyReport
+
+logger = logging.getLogger(__name__)
+
+# LLM 응답 최대 대기 시간 (초)
+LLM_TIMEOUT_SECONDS = 30
+
+# last_error 컬럼 최대 길이 (MonthlyReport.last_error String(2000) 대응)
+MAX_ERROR_LENGTH = 2000
+
+
+def _truncate_error(msg: str, max_len: int = MAX_ERROR_LENGTH) -> str:
+    """에러 메시지를 최대 길이로 자름
+
+    MonthlyReport.last_error 컬럼이 String(2000)으로 선언되어 있어
+    초과 시 DB 저장에 실패하지 않도록 미리 truncate합니다.
+    """
+    return msg[:max_len] if len(msg) > max_len else msg
+
+
+async def mark_completed(
+    db: AsyncSession,
+    report_id: int,
+    insights: dict,
+) -> None:
+    """리포트 완료 상태로 전이
+
+    status=completed, insights 저장, completed_at 기록.
+    """
+    await db.execute(
+        update(MonthlyReport)
+        .where(MonthlyReport.id == report_id)
+        .values(
+            status="completed",
+            insights=insights,
+            completed_at=datetime.now(UTC),
+        )
+    )
+    await db.commit()
+
+
+async def mark_failed(
+    db: AsyncSession,
+    report_id: int,
+    error: str,
+) -> None:
+    """리포트 실패 상태로 전이
+
+    status=failed, last_error 기록 (2000자 truncate).
+    """
+    await db.execute(
+        update(MonthlyReport)
+        .where(MonthlyReport.id == report_id)
+        .values(
+            status="failed",
+            last_error=_truncate_error(error),
+        )
+    )
+    await db.commit()
+
+
+async def run_llm_for_report(
+    db: AsyncSession,
+    report: MonthlyReport,
+) -> None:
+    """LLM 호출 → 완료/실패 상태 저장
+
+    1. format_insights_data_for_llm으로 report_data를 구조화 텍스트로 변환
+    2. LLM generate_comprehensive_insights_v2 호출 (30초 타임아웃)
+    3. 성공 시 mark_completed, 실패 시 mark_failed 후 예외 재발생
+
+    예외 재발생 이유: 호출자(스케줄러/웹훅)가 재시도 여부를 결정해야 하기 때문.
+    """
+    try:
+        from app.services.llm_service import get_llm_provider
+        from app.services.prompts import format_insights_data_for_llm
+
+        # HouseholdProfile이 없으면 None으로 처리 (format 함수가 None을 허용)
+        try:
+            from sqlalchemy import select
+
+            from app.models.household_profile import HouseholdProfile
+
+            profile = await db.scalar(select(HouseholdProfile).where(HouseholdProfile.household_id == report.household_id))
+        except Exception:
+            # HouseholdProfile 모델이 없는 환경(테스트 등)에서는 None 사용
+            profile = None
+
+        formatted_text = format_insights_data_for_llm(report.report_data, profile)
+
+        llm = get_llm_provider("insights")
+        insights_dict = await asyncio.wait_for(
+            llm.generate_comprehensive_insights_v2(formatted_text),
+            timeout=LLM_TIMEOUT_SECONDS,
+        )
+
+        await mark_completed(db, report.id, insights_dict)
+        logger.info(
+            "[monthly-reports] llm_success household_id=%d month=%s",
+            report.household_id,
+            report.month,
+        )
+
+    except Exception as e:
+        error_msg = _truncate_error(str(e))
+        await mark_failed(db, report.id, error_msg)
+        logger.warning(
+            "[monthly-reports] llm_failed household_id=%d month=%s error=%s",
+            report.household_id,
+            report.month,
+            error_msg,
+        )
+        raise

--- a/backend/app/services/report_month_utils.py
+++ b/backend/app/services/report_month_utils.py
@@ -1,0 +1,27 @@
+"""월간 결산 리포트용 날짜/시간대 헬퍼"""
+
+from datetime import date, datetime, timedelta, timezone
+
+# KST = UTC+9
+_KST = timezone(timedelta(hours=9))
+
+
+def previous_month_kst() -> str:
+    """현재 KST 기준 직전 마감 월을 YYYY-MM 형식으로 반환"""
+    now_kst = datetime.now(_KST)
+    if now_kst.month == 1:
+        return f"{now_kst.year - 1}-12"
+    return f"{now_kst.year}-{now_kst.month - 1:02d}"
+
+
+def month_boundaries(month: str) -> tuple[date, date]:
+    """YYYY-MM → (시작일 inclusive, 종료일 exclusive) 반환"""
+    year, mon = map(int, month.split("-"))
+    start = date(year, mon, 1)
+    end = date(year + 1, 1, 1) if mon == 12 else date(year, mon + 1, 1)
+    return start, end
+
+
+def month_str_from_date(d: date) -> str:
+    """date → YYYY-MM 형식"""
+    return f"{d.year}-{d.month:02d}"

--- a/backend/app/services/report_scheduler.py
+++ b/backend/app/services/report_scheduler.py
@@ -1,0 +1,184 @@
+"""월간 결산 리포트 스케줄러 — Phase 1/2 오케스트레이션
+
+Phase 1: 자격 통과 가구의 report_data 집계 + pending row 일괄 생성 (멱등)
+Phase 2: pending row를 꺼내 LLM 호출 + completed/failed 상태 전이 (병렬 처리)
+"""
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import AsyncSessionLocal
+from app.models.monthly_report import MonthlyReport
+from app.services.report_data_builder import build_report_data
+from app.services.report_eligibility import find_eligible_households
+from app.services.report_generator import run_llm_for_report
+
+logger = logging.getLogger(__name__)
+
+# Phase 2 병렬 LLM 호출 최대 동시 수 (DB 커넥션 + LLM rate limit 고려)
+_PHASE2_CONCURRENCY = 5
+
+
+async def phase1_enqueue_pending(db: AsyncSession, month: str) -> int:
+    """자격 통과 가구의 report_data 집계 + pending row 일괄 생성 (멱등)
+
+    이미 MonthlyReport row가 존재하는 가구는 건너뛴다.
+    SQLite 테스트 환경 호환을 위해 SELECT-before-INSERT 패턴을 사용한다.
+
+    Args:
+        db: 비동기 DB 세션
+        month: 대상 월 (YYYY-MM 형식)
+
+    Returns:
+        새로 생성된 row 수
+    """
+    eligible_ids = await find_eligible_households(db, month)
+    logger.info(
+        "[monthly-reports] eligible_households count=%d month=%s",
+        len(eligible_ids),
+        month,
+    )
+
+    created = 0
+    for hid in eligible_ids:
+        # 멱등성 보장: 이미 존재하면 건너뜀
+        existing = await db.scalar(
+            select(MonthlyReport).where(
+                MonthlyReport.household_id == hid,
+                MonthlyReport.month == month,
+            )
+        )
+        if existing:
+            logger.debug(
+                "[monthly-reports] skip existing household_id=%d month=%s",
+                hid,
+                month,
+            )
+            continue
+
+        data = await build_report_data(db, hid, month)
+        report = MonthlyReport(
+            household_id=hid,
+            month=month,
+            status="pending",
+            report_data=data,
+            trigger_source="auto",
+        )
+        db.add(report)
+        created += 1
+
+    await db.commit()
+    logger.info("[monthly-reports] phase1_complete queued=%d month=%s", created, month)
+    return created
+
+
+async def recover_stale_processing(db: AsyncSession, threshold_minutes: int = 15) -> int:
+    """processing 좀비 row를 pending으로 복구
+
+    started_at이 threshold_minutes 이상 경과한 processing row를
+    pending으로 되돌려 재시도 대상에 포함시킨다.
+
+    Args:
+        db: 비동기 DB 세션
+        threshold_minutes: 좀비 판단 기준 시간(분). 기본 15분.
+
+    Returns:
+        복구된 row 수
+    """
+    cutoff = datetime.utcnow() - timedelta(minutes=threshold_minutes)
+
+    result = await db.execute(
+        update(MonthlyReport)
+        .where(
+            MonthlyReport.status == "processing",
+            MonthlyReport.started_at <= cutoff,
+        )
+        .values(status="pending")
+    )
+    recovered = result.rowcount
+    await db.commit()
+
+    if recovered:
+        logger.warning(
+            "[monthly-reports] recovered stale processing rows count=%d threshold_minutes=%d",
+            recovered,
+            threshold_minutes,
+        )
+    return recovered
+
+
+async def phase2_process_pending(month: str) -> int:
+    """pending row를 꺼내 LLM 호출 병렬 처리
+
+    각 report마다 독립된 DB 세션을 생성하여 LLM 호출 후
+    completed 또는 failed 상태로 전이한다.
+
+    Args:
+        month: 대상 월 (YYYY-MM 형식)
+
+    Returns:
+        처리 시도된 row 수 (성공/실패 포함)
+    """
+    async with AsyncSessionLocal() as db:
+        pending_ids: list[int] = list(
+            await db.scalars(
+                select(MonthlyReport.id).where(
+                    MonthlyReport.month == month,
+                    MonthlyReport.status == "pending",
+                )
+            )
+        )
+
+    logger.info(
+        "[monthly-reports] phase2_start pending_count=%d month=%s",
+        len(pending_ids),
+        month,
+    )
+
+    if not pending_ids:
+        return 0
+
+    semaphore = asyncio.Semaphore(_PHASE2_CONCURRENCY)
+
+    async def _process_one(report_id: int) -> None:
+        """단일 report를 독립 세션으로 처리"""
+        async with semaphore, AsyncSessionLocal() as db:
+            report = await db.scalar(select(MonthlyReport).where(MonthlyReport.id == report_id))
+            if not report or report.status != "pending":
+                # 다른 워커가 먼저 처리했거나 상태 변경됨
+                return
+
+            # processing 상태로 전이 (started_at 기록)
+            await db.execute(
+                update(MonthlyReport)
+                .where(MonthlyReport.id == report_id)
+                .values(
+                    status="processing",
+                    started_at=datetime.now(UTC),
+                    attempt_count=MonthlyReport.attempt_count + 1,
+                )
+            )
+            await db.commit()
+            await db.refresh(report)
+
+            try:
+                await run_llm_for_report(db, report)
+            except Exception as exc:
+                logger.warning(
+                    "[monthly-reports] phase2_failed report_id=%d error=%s",
+                    report_id,
+                    str(exc)[:200],
+                )
+
+    await asyncio.gather(*[_process_one(rid) for rid in pending_ids])
+
+    logger.info(
+        "[monthly-reports] phase2_complete processed=%d month=%s",
+        len(pending_ids),
+        month,
+    )
+    return len(pending_ids)

--- a/backend/app/services/report_scheduler.py
+++ b/backend/app/services/report_scheduler.py
@@ -89,7 +89,7 @@ async def recover_stale_processing(db: AsyncSession, threshold_minutes: int = 15
     Returns:
         복구된 row 수
     """
-    cutoff = datetime.utcnow() - timedelta(minutes=threshold_minutes)
+    cutoff = datetime.now(UTC) - timedelta(minutes=threshold_minutes)
 
     result = await db.execute(
         update(MonthlyReport)

--- a/backend/tests/integration/test_api_reports.py
+++ b/backend/tests/integration/test_api_reports.py
@@ -1,0 +1,158 @@
+"""월간 결산 리포트 사용자 조회 API 통합 테스트"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.household import Household
+from app.models.monthly_report import MonthlyReport
+
+
+@pytest.mark.asyncio
+async def test_get_monthly_report_completed(
+    authenticated_client: AsyncClient,
+    db_session: AsyncSession,
+    test_household: Household,
+):
+    """completed 리포트 조회 시 insights 포함 응답"""
+    report = MonthlyReport(
+        household_id=test_household.id,
+        month="2026-03",
+        status="completed",
+        report_data={"expense_total": 100000},
+        insights={
+            "findings": [{"what": "식비가 늘었어요", "so_what": "외식 증가", "now_what": "줄이기"}],
+            "action_items": [{"title": "식비 절감", "description": "외식 줄이기"}],
+            "encouragement": "수고하셨어요",
+        },
+        insights_version=1,
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    resp = await authenticated_client.get(
+        "/api/reports/monthly",
+        params={"month": "2026-03"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report"]["status"] == "completed"
+    assert data["report"]["insights"] is not None
+    assert data["eligibility"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_monthly_report_pending_returns_status(
+    authenticated_client: AsyncClient,
+    db_session: AsyncSession,
+    test_household: Household,
+):
+    """pending 리포트 조회 시 status=pending, insights=None 반환"""
+    report = MonthlyReport(
+        household_id=test_household.id,
+        month="2026-03",
+        status="pending",
+        report_data={},
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    resp = await authenticated_client.get(
+        "/api/reports/monthly",
+        params={"month": "2026-03"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["report"]["status"] == "pending"
+    assert resp.json()["report"]["insights"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_monthly_report_not_found_returns_eligibility(
+    authenticated_client: AsyncClient,
+    db_session: AsyncSession,
+    test_household: Household,
+):
+    """리포트 없으면 eligibility 정보 반환"""
+    resp = await authenticated_client.get(
+        "/api/reports/monthly",
+        params={"month": "2026-03"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report"] is None
+    assert data["eligibility"] is not None
+    assert "blocker" in data["eligibility"]
+
+
+@pytest.mark.asyncio
+async def test_get_monthly_report_invalid_month_format(
+    authenticated_client: AsyncClient,
+    db_session: AsyncSession,
+    test_household: Household,
+):
+    """잘못된 월 형식은 422 반환"""
+    resp = await authenticated_client.get(
+        "/api/reports/monthly",
+        params={"month": "2026-3"},  # YYYY-M (잘못된 형식)
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_latest_report_returns_prev_month_completed(
+    authenticated_client: AsyncClient,
+    db_session: AsyncSession,
+    test_household: Household,
+):
+    """직전 마감 월의 completed 리포트 반환"""
+    from app.services.report_month_utils import previous_month_kst
+
+    prev_month = previous_month_kst()
+    report = MonthlyReport(
+        household_id=test_household.id,
+        month=prev_month,
+        status="completed",
+        report_data={"expense_total": 200000},
+        insights={
+            "findings": [{"what": "절약 잘 했어요", "so_what": "지출 감소", "now_what": "유지하기"}],
+            "action_items": [{"title": "계속 절약", "description": "이 추세 유지"}],
+            "encouragement": "훌륭해요",
+        },
+        insights_version=1,
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/reports/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report"]["status"] == "completed"
+    assert data["report"]["month"] == prev_month
+
+
+@pytest.mark.asyncio
+async def test_get_latest_report_no_report_returns_eligibility(
+    authenticated_client: AsyncClient,
+    db_session: AsyncSession,
+    test_household: Household,
+):
+    """직전 달 리포트 없으면 eligibility 반환"""
+    resp = await authenticated_client.get("/api/reports/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report"] is None
+    assert data["eligibility"] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_monthly_report_unauthenticated(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    test_household: Household,
+):
+    """인증 없으면 401 반환"""
+    resp = await client.get(
+        "/api/reports/monthly",
+        params={"month": "2026-03"},
+    )
+    assert resp.status_code == 401

--- a/backend/tests/integration/test_api_reports_webhook.py
+++ b/backend/tests/integration/test_api_reports_webhook.py
@@ -1,0 +1,67 @@
+"""월간 결산 리포트 cron webhook 엔드포인트 테스트"""
+
+import hashlib
+import hmac
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.core.config import settings
+
+
+def _make_signature(secret: str) -> str:
+    """HMAC-SHA256 서명 생성 (webhook_auth.py와 동일한 방식)"""
+    return hmac.new(secret.encode(), b"monthly-report-trigger", hashlib.sha256).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_webhook_rejects_missing_signature(authenticated_client: AsyncClient):
+    """서명 헤더 없으면 401"""
+    resp = await authenticated_client.post("/api/webhooks/monthly-reports")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_webhook_rejects_invalid_signature(authenticated_client: AsyncClient):
+    """잘못된 서명이면 401"""
+    with patch.object(settings, "MONTHLY_REPORT_WEBHOOK_SECRET", "test-secret"):  # pragma: allowlist secret
+        resp = await authenticated_client.post(
+            "/api/webhooks/monthly-reports",
+            headers={"x-webhook-signature": "invalid"},
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_webhook_accepts_valid_signature(authenticated_client: AsyncClient):
+    """올바른 서명이면 200 + queued 수 반환"""
+    secret = "test-secret"  # pragma: allowlist secret
+    with (
+        patch.object(settings, "MONTHLY_REPORT_WEBHOOK_SECRET", secret),
+        patch.object(settings, "MONTHLY_REPORT_AUTO_ENABLED", True),
+        patch("app.api.webhooks.phase1_enqueue_pending", new=AsyncMock(return_value=3)),
+        patch("app.api.webhooks.phase2_process_pending", new=AsyncMock()),
+    ):
+        resp = await authenticated_client.post(
+            "/api/webhooks/monthly-reports",
+            headers={"x-webhook-signature": _make_signature(secret)},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["queued"] == 3
+
+
+@pytest.mark.asyncio
+async def test_webhook_skips_when_disabled(authenticated_client: AsyncClient):
+    """MONTHLY_REPORT_AUTO_ENABLED=False이면 skipped=True 반환"""
+    secret = "test-secret"  # pragma: allowlist secret
+    with (
+        patch.object(settings, "MONTHLY_REPORT_WEBHOOK_SECRET", secret),
+        patch.object(settings, "MONTHLY_REPORT_AUTO_ENABLED", False),
+    ):
+        resp = await authenticated_client.post(
+            "/api/webhooks/monthly-reports",
+            headers={"x-webhook-signature": _make_signature(secret)},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["skipped"] is True

--- a/backend/tests/integration/test_report_data_builder.py
+++ b/backend/tests/integration/test_report_data_builder.py
@@ -1,0 +1,124 @@
+"""report_data_builder 통합 테스트
+
+TDD 방식 — Red → Green → Refactor 순서로 작성.
+"""
+
+import datetime as dt
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.expense import Expense
+from app.models.income import Income
+from app.services.report_data_builder import build_report_data
+
+
+@pytest.mark.asyncio
+async def test_build_report_data_basic(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """기본 집계 — expense_total, income_total, savings_rate"""
+    # 지출 3건 (카테고리 각 1, 2, 3)
+    for cat_id, amount in [(1, 50000), (2, 30000), (3, 20000)]:
+        db_session.add(
+            Expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=amount,
+                description="지출",
+                date=dt.datetime(2026, 3, 1, 12, 0),
+                category_id=cat_id,
+            )
+        )
+    # 수입 1건
+    db_session.add(
+        Income(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=500000,
+            description="월급",
+            date=dt.datetime(2026, 3, 5, 9, 0),
+            category_id=None,
+        )
+    )
+    await db_session.commit()
+
+    data = await build_report_data(db_session, test_household.id, "2026-03")
+
+    assert data["expense_total"] == 100000.0
+    assert data["income_total"] == 500000.0
+    assert len(data["top_expense_categories"]) == 3
+    # 저축률: (500000 - 100000) / 500000 * 100 = 80.0
+    assert data["savings_rate"] == pytest.approx(80.0, abs=0.1)
+
+
+@pytest.mark.asyncio
+async def test_build_report_data_excludes_stats_excluded(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """exclude_from_stats=True 거래는 합계에서 제외"""
+    db_session.add(
+        Expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=100000,
+            description="일반 지출",
+            date=dt.datetime(2026, 3, 1, 12, 0),
+            category_id=1,
+        )
+    )
+    db_session.add(
+        Expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=1000000,
+            description="통계 제외",
+            date=dt.datetime(2026, 3, 2, 12, 0),
+            category_id=1,
+            exclude_from_stats=True,
+        )
+    )
+    await db_session.commit()
+
+    data = await build_report_data(db_session, test_household.id, "2026-03")
+    assert data["expense_total"] == 100000.0
+
+
+@pytest.mark.asyncio
+async def test_build_report_data_previous_month(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """전월 비교 데이터가 포함된다"""
+    # 2월 지출
+    db_session.add(
+        Expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=80000,
+            description="2월 지출",
+            date=dt.datetime(2026, 2, 10, 12, 0),
+            category_id=1,
+        )
+    )
+    # 3월 지출
+    db_session.add(
+        Expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=100000,
+            description="3월 지출",
+            date=dt.datetime(2026, 3, 10, 12, 0),
+            category_id=1,
+        )
+    )
+    await db_session.commit()
+
+    data = await build_report_data(db_session, test_household.id, "2026-03")
+    assert data["previous_month_expense"] == 80000.0
+    assert data["expense_total"] == 100000.0

--- a/backend/tests/integration/test_report_eligibility.py
+++ b/backend/tests/integration/test_report_eligibility.py
@@ -1,0 +1,356 @@
+"""자격 검증 서비스 통합 테스트"""
+
+import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.expense import Expense
+from app.models.household_profile import HouseholdProfile
+from app.services.report_eligibility import (
+    MIN_CATEGORIES,
+    MIN_TRANSACTIONS,
+    check_household_eligibility,
+    find_eligible_households,
+)
+
+
+def _make_expense(household_id: int, user_id: int, amount: int, day: int, category_id: int) -> Expense:
+    """테스트용 Expense 생성 헬퍼"""
+    return Expense(
+        household_id=household_id,
+        user_id=user_id,
+        amount=amount,
+        description=f"지출 {day}",
+        date=datetime.datetime(2026, 3, day),
+        category_id=category_id,
+    )
+
+
+def _make_profile(household_id: int) -> HouseholdProfile:
+    """테스트용 HouseholdProfile 생성 헬퍼"""
+    return HouseholdProfile(
+        household_id=household_id,
+        household_type="single",
+        housing_type="monthly_rent",
+        income_types=["salary"],
+        age_range="30s",
+    )
+
+
+# ---------------------------------------------------------------------------
+# find_eligible_households 테스트
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eligible_with_sufficient_data(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """프로필 + 거래 15건 + 카테고리 3개 + 지출 20만원 이상이면 자격 통과"""
+    db_session.add(_make_profile(test_household.id))
+
+    for i in range(15):
+        db_session.add(
+            _make_expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                day=i + 1,
+                category_id=(i % 3) + 1,
+            )
+        )
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id in result
+
+
+@pytest.mark.asyncio
+async def test_ineligible_missing_profile(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """HouseholdProfile이 없으면 자격 미달"""
+    for i in range(15):
+        db_session.add(
+            _make_expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                day=i + 1,
+                category_id=(i % 3) + 1,
+            )
+        )
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id not in result
+
+
+@pytest.mark.asyncio
+async def test_ineligible_below_transaction_threshold(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """프로필 있어도 거래 14건이면 미달 (임계값 15건)"""
+    db_session.add(_make_profile(test_household.id))
+
+    for i in range(14):
+        db_session.add(
+            _make_expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                day=i + 1,
+                category_id=(i % 4) + 1,
+            )
+        )
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id not in result
+
+
+@pytest.mark.asyncio
+async def test_ineligible_below_category_threshold(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """거래 15건이지만 카테고리 2개뿐이면 미달 (임계값 3개)"""
+    db_session.add(_make_profile(test_household.id))
+
+    for i in range(15):
+        db_session.add(
+            _make_expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                day=i + 1,
+                category_id=(i % 2) + 1,  # 카테고리 2개만
+            )
+        )
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id not in result
+
+
+@pytest.mark.asyncio
+async def test_ineligible_below_spend_threshold(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """거래 15건, 카테고리 3개지만 총액 미달이면 자격 실패"""
+    db_session.add(_make_profile(test_household.id))
+
+    # 15건 × 1,000원 = 15,000원 (200,000원 미만)
+    for i in range(15):
+        db_session.add(
+            _make_expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=1000,
+                day=i + 1,
+                category_id=(i % 3) + 1,
+            )
+        )
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id not in result
+
+
+@pytest.mark.asyncio
+async def test_exclude_from_stats_ignored(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """exclude_from_stats=True 거래는 집계에서 제외된다"""
+    db_session.add(_make_profile(test_household.id))
+
+    # 10건 정상 + 5건 exclude → 정상 거래만 10건, 임계값 15건 미달
+    for i in range(10):
+        db_session.add(
+            _make_expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                day=i + 1,
+                category_id=(i % 3) + 1,
+            )
+        )
+    for i in range(5):
+        expense = _make_expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=20000,
+            day=15 + i,
+            category_id=(i % 3) + 1,
+        )
+        expense.exclude_from_stats = True
+        db_session.add(expense)
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id not in result
+
+
+@pytest.mark.asyncio
+async def test_different_month_not_counted(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """다른 달 거래는 해당 월 집계에 포함되지 않는다"""
+    db_session.add(_make_profile(test_household.id))
+
+    # 2월 거래 15건 — 3월 집계에 포함되면 안 됨
+    for i in range(15):
+        db_session.add(
+            Expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                description=f"2월 지출 {i}",
+                date=datetime.datetime(2026, 2, i + 1),
+                category_id=(i % 3) + 1,
+            )
+        )
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id not in result
+
+
+# ---------------------------------------------------------------------------
+# check_household_eligibility 테스트
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_household_eligibility_eligible(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """자격 통과 시 is_eligible=True, blocker=None"""
+    db_session.add(_make_profile(test_household.id))
+
+    for i in range(15):
+        db_session.add(
+            _make_expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                day=i + 1,
+                category_id=(i % 3) + 1,
+            )
+        )
+    await db_session.commit()
+
+    result = await check_household_eligibility(db_session, test_household.id, "2026-03")
+    assert result.is_eligible is True
+    assert result.blocker is None
+    assert result.transaction_count == 15
+    assert result.category_count == MIN_CATEGORIES
+    assert result.total_spend == 300_000.0
+
+
+@pytest.mark.asyncio
+async def test_check_household_eligibility_no_profile(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """프로필 없으면 blocker='profile_missing'"""
+    result = await check_household_eligibility(db_session, test_household.id, "2026-03")
+    assert result.is_eligible is False
+    assert result.blocker == "profile_missing"
+    assert result.has_profile is False
+
+
+@pytest.mark.asyncio
+async def test_check_household_eligibility_transactions_short(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """거래 부족 시 blocker='transactions_short'"""
+    db_session.add(_make_profile(test_household.id))
+
+    for i in range(10):
+        db_session.add(
+            _make_expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                day=i + 1,
+                category_id=(i % 3) + 1,
+            )
+        )
+    await db_session.commit()
+
+    result = await check_household_eligibility(db_session, test_household.id, "2026-03")
+    assert result.is_eligible is False
+    assert result.blocker == "transactions_short"
+    assert result.transactions_needed == MIN_TRANSACTIONS - 10
+
+
+@pytest.mark.asyncio
+async def test_check_household_eligibility_categories_short(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """거래 충분하지만 카테고리 부족 시 blocker='categories_short'"""
+    db_session.add(_make_profile(test_household.id))
+
+    for i in range(15):
+        db_session.add(
+            _make_expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                day=i + 1,
+                category_id=(i % 2) + 1,  # 카테고리 2개
+            )
+        )
+    await db_session.commit()
+
+    result = await check_household_eligibility(db_session, test_household.id, "2026-03")
+    assert result.is_eligible is False
+    assert result.blocker == "categories_short"
+
+
+@pytest.mark.asyncio
+async def test_check_household_eligibility_spend_short(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """거래/카테고리 충분하지만 총액 미달 시 blocker='spend_short'"""
+    db_session.add(_make_profile(test_household.id))
+
+    for i in range(15):
+        db_session.add(
+            _make_expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=1000,  # 총액 = 15,000원
+                day=i + 1,
+                category_id=(i % 3) + 1,
+            )
+        )
+    await db_session.commit()
+
+    result = await check_household_eligibility(db_session, test_household.id, "2026-03")
+    assert result.is_eligible is False
+    assert result.blocker == "spend_short"

--- a/backend/tests/integration/test_report_scheduler.py
+++ b/backend/tests/integration/test_report_scheduler.py
@@ -1,0 +1,107 @@
+"""report_scheduler 통합 테스트 (mock LLM)"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from app.models.expense import Expense
+from app.models.household_profile import HouseholdProfile
+from app.models.monthly_report import MonthlyReport
+from app.services.report_scheduler import phase1_enqueue_pending, recover_stale_processing
+
+
+@pytest.mark.asyncio
+async def test_phase1_creates_pending_rows(db_session, test_household, test_user):
+    """자격 통과 가구에 pending row가 생성된다"""
+    profile = HouseholdProfile(
+        household_id=test_household.id,
+        household_type="single",
+        housing_type="monthly_rent",
+        income_types=["salary"],
+        age_range="30s",
+    )
+    db_session.add(profile)
+    for i in range(15):
+        db_session.add(
+            Expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                description=f"지출 {i}",
+                date=datetime(2026, 3, i + 1),
+                category_id=(i % 3) + 1,
+            )
+        )
+    await db_session.commit()
+
+    count = await phase1_enqueue_pending(db_session, "2026-03")
+    assert count >= 1
+
+    report = await db_session.scalar(
+        select(MonthlyReport).where(
+            MonthlyReport.household_id == test_household.id,
+            MonthlyReport.month == "2026-03",
+        )
+    )
+    assert report is not None
+    assert report.status == "pending"
+    assert report.report_data != {}
+
+
+@pytest.mark.asyncio
+async def test_phase1_idempotent(db_session, test_household, test_user):
+    """두 번 호출해도 row는 하나만 생성된다"""
+    profile = HouseholdProfile(
+        household_id=test_household.id,
+        household_type="single",
+        housing_type="monthly_rent",
+        income_types=["salary"],
+        age_range="30s",
+    )
+    db_session.add(profile)
+    for i in range(15):
+        db_session.add(
+            Expense(
+                household_id=test_household.id,
+                user_id=test_user.id,
+                amount=20000,
+                description=f"지출 {i}",
+                date=datetime(2026, 3, i + 1),
+                category_id=(i % 3) + 1,
+            )
+        )
+    await db_session.commit()
+
+    await phase1_enqueue_pending(db_session, "2026-03")
+    await phase1_enqueue_pending(db_session, "2026-03")
+
+    rows = (
+        await db_session.scalars(
+            select(MonthlyReport).where(
+                MonthlyReport.household_id == test_household.id,
+                MonthlyReport.month == "2026-03",
+            )
+        )
+    ).all()
+    assert len(list(rows)) == 1
+
+
+@pytest.mark.asyncio
+async def test_recover_stale_processing(db_session, test_household):
+    """processing 좀비 row가 pending으로 복구된다"""
+    stale = MonthlyReport(
+        household_id=test_household.id,
+        month="2026-03",
+        status="processing",
+        report_data={},
+        attempt_count=1,
+        started_at=datetime.utcnow() - timedelta(minutes=30),
+    )
+    db_session.add(stale)
+    await db_session.commit()
+
+    await recover_stale_processing(db_session, threshold_minutes=15)
+    await db_session.refresh(stale)
+
+    assert stale.status == "pending"

--- a/backend/tests/integration/test_report_scheduler.py
+++ b/backend/tests/integration/test_report_scheduler.py
@@ -1,6 +1,6 @@
 """report_scheduler 통합 테스트 (mock LLM)"""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import select
@@ -96,7 +96,7 @@ async def test_recover_stale_processing(db_session, test_household):
         status="processing",
         report_data={},
         attempt_count=1,
-        started_at=datetime.utcnow() - timedelta(minutes=30),
+        started_at=datetime.now(UTC) - timedelta(minutes=30),
     )
     db_session.add(stale)
     await db_session.commit()

--- a/backend/tests/unit/test_report_generator.py
+++ b/backend/tests/unit/test_report_generator.py
@@ -1,0 +1,99 @@
+"""report_generator 단위 테스트
+
+LLM 호출과 DB 상태 전이를 담당하는 서비스의 핵심 로직을 검증합니다.
+run_llm_for_report는 LLM 의존성이 있어 단위 테스트 대상에서 제외합니다.
+"""
+
+import pytest
+
+from app.services.report_generator import _truncate_error, mark_completed, mark_failed
+
+
+def test_truncate_error_long_message():
+    """2000자 초과 에러 메시지는 잘린다"""
+    long_msg = "x" * 3000
+    result = _truncate_error(long_msg)
+    assert len(result) <= 2000
+
+
+def test_truncate_error_short_message():
+    """2000자 이하 메시지는 그대로 반환한다"""
+    msg = "short error"
+    assert _truncate_error(msg) == msg
+
+
+def test_truncate_error_exactly_max():
+    """정확히 2000자는 잘리지 않는다"""
+    msg = "x" * 2000
+    result = _truncate_error(msg)
+    assert result == msg
+    assert len(result) == 2000
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_updates_status(db_session, test_household, test_user):
+    """mark_failed 호출 시 status=failed, last_error 갱신된다"""
+    from app.models.monthly_report import MonthlyReport
+
+    report = MonthlyReport(
+        household_id=test_household.id,
+        month="2026-03",
+        status="processing",
+        report_data={},
+        attempt_count=1,
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    await mark_failed(db_session, report.id, "LLM timeout")
+    await db_session.refresh(report)
+
+    assert report.status == "failed"
+    assert "LLM timeout" in report.last_error
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_truncates_long_error(db_session, test_household, test_user):
+    """mark_failed는 긴 에러 메시지를 2000자로 잘라 저장한다"""
+    from app.models.monthly_report import MonthlyReport
+
+    report = MonthlyReport(
+        household_id=test_household.id,
+        month="2026-04",
+        status="processing",
+        report_data={},
+        attempt_count=1,
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    long_error = "e" * 3000
+    await mark_failed(db_session, report.id, long_error)
+    await db_session.refresh(report)
+
+    assert report.status == "failed"
+    assert len(report.last_error) <= 2000
+
+
+@pytest.mark.asyncio
+async def test_mark_completed_updates_status(db_session, test_household, test_user):
+    """mark_completed 호출 시 status=completed, insights 저장, completed_at 설정된다"""
+    from app.models.monthly_report import MonthlyReport
+
+    report = MonthlyReport(
+        household_id=test_household.id,
+        month="2026-05",
+        status="processing",
+        report_data={},
+        attempt_count=1,
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    insights = {"summary": "테스트 인사이트", "health_score": 80}
+    await mark_completed(db_session, report.id, insights)
+    await db_session.refresh(report)
+
+    assert report.status == "completed"
+    assert report.insights == insights
+    assert report.completed_at is not None

--- a/backend/tests/unit/test_report_month_utils.py
+++ b/backend/tests/unit/test_report_month_utils.py
@@ -1,0 +1,30 @@
+from datetime import date
+
+from app.services.report_month_utils import (
+    month_boundaries,
+    month_str_from_date,
+    previous_month_kst,
+)
+
+
+def test_previous_month_kst_returns_yyyy_mm():
+    result = previous_month_kst()
+    assert len(result) == 7
+    assert result[4] == "-"
+
+
+def test_month_boundaries_april():
+    start, end = month_boundaries("2026-04")
+    assert start == date(2026, 4, 1)
+    assert end == date(2026, 5, 1)
+
+
+def test_month_boundaries_december():
+    start, end = month_boundaries("2026-12")
+    assert start == date(2026, 12, 1)
+    assert end == date(2027, 1, 1)
+
+
+def test_month_str_from_date():
+    assert month_str_from_date(date(2026, 4, 15)) == "2026-04"
+    assert month_str_from_date(date(2026, 1, 1)) == "2026-01"

--- a/docs/plans/2026-04-26-monthly-report-design.md
+++ b/docs/plans/2026-04-26-monthly-report-design.md
@@ -1,0 +1,718 @@
+# 월간 결산 리포트 설계 문서
+
+작성일: 2026-04-26
+상태: 설계 확정
+
+---
+
+## 배경 및 목표
+
+### 문제
+
+기존 AI 분석은 사용자가 "분석하기" 버튼을 누를 때만 실행되고, 결과가 로컬 state에만 저장되어 페이지 이탈 시 사라진다. 이는 두 가지 문제를 만든다:
+
+1. **재분석 피로**: 같은 달 데이터를 볼 때마다 몇 초를 기다려야 함
+2. **일회성 소비**: 리포트가 쌓이지 않아 시계열 비교가 불가능함
+
+### 가계부 도메인 통찰
+
+가계부는 **월말 마감 사이클**로 움직인다. 월급, 카드값, 공과금이 모두 월 단위이므로 월 중간 분석은 미완성 데이터다. 진짜 의미 있는 분석은 마감 후, 즉 **다음 달 초**다.
+
+이 도메인 특성을 살리면 수동 트리거가 불필요해진다. 마감된 달의 데이터는 고정되므로 **매월 1일 자동 생성**이 정확하고 자연스럽다.
+
+### 단계별 로드맵
+
+```
+단계 1 (현재): 월간 결산 리포트 자동 생성 + 앱 내 표시
+  → 사용자가 아무것도 안 해도 매달 리포트가 쌓임
+
+단계 2 (다음): 이전 리포트 컨텍스트 활용 + 리포트 컬렉션 뷰
+  → "지난달에 식비 줄이자 했는데 이번달도 또 늘었네요" 연속성
+  → 잡지 컬렉션처럼 시간순 카드 그리드
+
+단계 3 (이후): 이메일 뉴스레터 자동 발송
+  → 매월 1일 새벽 생성된 리포트를 오전에 이메일로 발송
+  → 이미 자동 생성 인프라가 있으므로 발송 채널만 추가
+  → 유료 플랜 진입점
+```
+
+단계 3을 전제로 설계한다. 특히 리포트 상세 화면의 딥링크(`/insights/reports/:month`)는 단계 3 이메일의 "앱에서 보기" 목적지가 된다.
+
+---
+
+## 아키텍처 개요
+
+```
+[Supabase pg_cron] (매월 1일 03:00 KST = 전날 18:00 UTC)
+        │ HTTP POST + HMAC 서명
+        ▼
+[POST /api/internal/reports/generate-monthly]
+        │
+        ├─ HMAC 검증
+        ├─ 자격 통과 가구 조회 (단일 SQL)
+        ├─ pending row 일괄 INSERT (ON CONFLICT DO NOTHING)
+        ├─ 즉시 응답 (200 OK) ← webhook 타임아웃 방지
+        │
+        └─ BackgroundTasks: process_pending_reports(month)
+                │
+                ├─ recover_stale_processing()  ← 좀비 row 복구
+                ├─ Semaphore(5) 동시 LLM 호출 제한
+                │
+                ├─ pick_next_pending() [SKIP LOCKED] → status='processing'
+                ├─ build_report_data() ← 백엔드 직접 집계
+                ├─ format_insights_data_for_llm()
+                ├─ llm.generate_comprehensive_insights_v2()  30초 timeout
+                └─ mark_completed() or mark_failed()
+
+[사용자 조회]
+GET /api/reports/monthly?month=YYYY-MM
+GET /api/reports/latest
+        │
+        └─ status별 분기 응답 (pending / completed / failed / 404)
+```
+
+---
+
+## 데이터 모델
+
+### `MonthlyReport` 테이블
+
+```python
+class MonthlyReport(Base):
+    __tablename__ = "monthly_reports"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # ── 식별 ──
+    household_id: Mapped[int] = mapped_column(
+        ForeignKey("households.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    month: Mapped[str] = mapped_column(
+        String(7), nullable=False,
+        comment="YYYY-MM 형식 (예: 2026-04)",
+    )
+
+    # ── 상태 머신 ──
+    status: Mapped[str] = mapped_column(
+        String(15), nullable=False, default="pending",
+        comment="pending | processing | completed | failed",
+    )
+    attempt_count: Mapped[int] = mapped_column(
+        default=0, nullable=False,
+        comment="LLM 호출 시도 횟수. 0=Phase 1 완료, 1+=Phase 2 시도",
+    )
+    last_error: Mapped[str | None] = mapped_column(
+        String(2000), nullable=True,
+        comment="마지막 실패 사유 (2000자 truncate)",
+    )
+    trigger_source: Mapped[str] = mapped_column(
+        String(15), nullable=False, default="auto",
+        comment="auto | admin | retry",
+    )
+
+    # ── 데이터 스냅샷 ──
+    report_data: Mapped[dict] = mapped_column(
+        JSON, nullable=False,
+        comment="분석 시점의 입력 스냅샷 (ComprehensiveInsightsRequest 구조). "
+                "이후 거래 추가/수정과 무관하게 리포트는 이 시점 데이터 기준.",
+    )
+    insights: Mapped[dict | None] = mapped_column(
+        JSON, nullable=True,
+        comment="LLM 출력 (StructuredInsightsResponse 구조). completed 시에만 채워짐.",
+    )
+    insights_version: Mapped[int] = mapped_column(
+        default=1, nullable=False,
+        comment="LLM 출력 스키마 버전. 스키마 변경 시 증가. 하위 호환 처리 기준.",
+    )
+
+    # ── 메타 ──
+    llm_tokens_used: Mapped[int | None] = mapped_column(nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        default=func.now(), server_default=func.now(), nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        default=func.now(), onupdate=func.now(),
+        server_default=func.now(), nullable=False,
+    )
+
+    household: Mapped["Household"] = relationship(back_populates="monthly_reports")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "household_id", "month",
+            name="uq_monthly_report_household_month",
+        ),
+        Index("ix_monthly_reports_month_status", "month", "status"),
+        # cron 처리 시 (month, status) 조합 쿼리 최적화
+    )
+```
+
+**설계 결정 근거**:
+- `JSON` (not `JSONB`): 테스트 환경이 SQLite in-memory라 cross-dialect 호환 필요
+- `report_data` 스냅샷: 리포트 생성 후 거래가 추가/수정돼도 리포트 내용 불변
+- `insights_version`: LLM 출력 구조가 진화할 때 (단계 2 action_items 구조화 등) 하위 호환 처리 기준
+- unique constraint가 인덱스 역할도 하므로 `(household_id, month)` 별도 인덱스 불필요
+
+### Household 변경
+
+```python
+# models/household.py에 추가
+monthly_reports: Mapped[list["MonthlyReport"]] = relationship(
+    back_populates="household",
+    cascade="all, delete-orphan",
+)
+```
+
+---
+
+## 자격 검증
+
+### 임계값
+
+리포트가 의미 있으려면 충분한 데이터와 개인화 컨텍스트가 필요하다.
+
+| 조건 | 값 | 이유 |
+|------|-----|------|
+| HouseholdProfile Step 1 완료 | 필수 (INNER JOIN) | 개인화 없으면 일반론만 나옴 |
+| 해당 월 거래 수 | ≥ 15건 | 미만이면 카테고리 패턴 분석 불가 |
+| 해당 월 카테고리 수 | ≥ 3개 | 단일 카테고리는 비교 불가 |
+| 해당 월 총 지출 | ≥ 200,000원 | 테스트 거래만 있는 경우 필터링 |
+
+`exclude_from_stats=true` 거래는 집계에서 제외.
+
+### 자격 검증 SQL
+
+```python
+async def find_eligible_households(
+    db: AsyncSession, month: str
+) -> list[int]:
+    start, end = month_boundaries(month)  # (date(2026, 3, 1), date(2026, 4, 1))
+
+    result = await db.execute(
+        select(Household.id)
+        .join(HouseholdProfile, HouseholdProfile.household_id == Household.id)
+        # INNER JOIN: 프로필 없는 가구 자동 제외
+        .outerjoin(
+            Expense,
+            and_(
+                Expense.household_id == Household.id,
+                Expense.date >= start,
+                Expense.date < end,
+                Expense.exclude_from_stats == False,  # noqa: E712
+            ),
+        )
+        .group_by(Household.id)
+        .having(
+            func.count(Expense.id) >= 15,
+            func.count(func.distinct(Expense.category_id)) >= 3,
+            func.coalesce(func.sum(Expense.amount), 0) >= 200000,
+        )
+    )
+    return [row[0] for row in result.all()]
+```
+
+---
+
+## 백엔드 구현
+
+### 디렉토리 구조
+
+```
+backend/app/
+├── api/
+│   ├── reports.py                 # 사용자 조회 (GET /reports/monthly, /reports/latest)
+│   ├── admin/reports.py           # 관리자 (retry, manual-trigger)
+│   └── internal/reports_webhook.py  # pg_cron webhook 수신
+├── models/
+│   └── monthly_report.py          # MonthlyReport 모델
+├── schemas/
+│   └── monthly_report.py          # 응답 스키마 + EligibilityResponse
+├── services/
+│   ├── report_eligibility.py      # 자격 검증 SQL
+│   ├── report_data_builder.py     # 집계 로직 (핵심 신규 서비스)
+│   ├── report_generator.py        # LLM 호출 + 상태 전이
+│   └── report_scheduler.py        # Phase 1/2 오케스트레이션
+└── core/
+    └── webhook_auth.py            # HMAC 검증
+```
+
+### `report_data_builder.py` — 가장 큰 신규 작업
+
+기존에 프론트엔드(`InsightsPage.tsx`)가 7~8개 API를 호출해 조립하던 데이터를 **백엔드에서 직접 집계**한다. 이것이 단계 1의 가장 큰 작업량이다.
+
+집계해야 하는 필드 목록 (`ComprehensiveInsightsRequest` 기준):
+
+```
+income_total               # Income 테이블 합계
+expense_total              # Expense 테이블 합계 (exclude_from_stats 제외)
+top_expense_categories     # 카테고리별 합계 상위 5개 + 비율
+budget                     # Budget 테이블 (설정된 경우)
+savings_rate               # (income - expense) / income × 100
+financial_score            # 4지표 계산 (savings_rate, budget_adherence, fixed_expense_ratio, spending_stability)
+trend                      # 직전 3개월 income/expense 트렌드
+savings_total              # Income 중 type='savings' 합계
+recurring_total            # RecurringTransaction execute 금액 합계
+previous_month_expense     # 전월 expense_total
+previous_month_income      # 전월 income_total
+```
+
+> **이관 전략**: 기존 `generate-comprehensive` 엔드포인트가 받던 프론트 입력과 동일한 구조를 `report_data_builder.py`가 생성한다. 이 서비스를 기존 엔드포인트도 내부적으로 사용하도록 리팩토링하면 로직 중복이 제거된다. 단, 단계 1에서는 기존 엔드포인트 동작을 보존하면서 신규 서비스를 추가하는 방식으로 진행한다 (점진적 이관).
+
+### Phase 1 — webhook 수신
+
+```python
+@router.post("/generate-monthly")
+async def trigger_monthly_reports(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    verify_webhook_signature(request)  # HMAC 검증
+
+    target_month = previous_month_kst()  # 직전 마감 월 (KST 기준)
+
+    eligible_ids = await find_eligible_households(db, target_month)
+
+    # 각 가구별 report_data 집계 + pending row 생성
+    for household_id in eligible_ids:
+        report_data = await build_report_data(db, household_id, target_month)
+        await db.execute(
+            insert(MonthlyReport)
+            .values(
+                household_id=household_id,
+                month=target_month,
+                status="pending",
+                report_data=report_data,
+                trigger_source="auto",
+            )
+            .on_conflict_do_nothing()
+        )
+    await db.commit()
+
+    background_tasks.add_task(process_pending_reports, target_month)
+
+    return {"queued": len(eligible_ids), "month": target_month}
+```
+
+### Phase 2 — 백그라운드 워커
+
+```python
+async def process_pending_reports(month: str) -> None:
+    async with AsyncSessionLocal() as db:
+        await recover_stale_processing(db, threshold_minutes=15)
+        await db.commit()
+
+    sem = asyncio.Semaphore(5)
+
+    async def _process_one() -> None:
+        async with sem:
+            async with AsyncSessionLocal() as db:
+                report = await pick_next_pending(db, month)
+                if not report:
+                    return
+            await _run_llm(report)
+
+    # 최대 처리 수 제한 (비용 안전장치)
+    tasks = [asyncio.create_task(_process_one()) for _ in range(MAX_REPORTS_PER_RUN)]
+    await asyncio.gather(*tasks)
+
+
+async def pick_next_pending(db: AsyncSession, month: str) -> MonthlyReport | None:
+    """SELECT FOR UPDATE SKIP LOCKED로 원자적 픽업"""
+    report = await db.scalar(
+        select(MonthlyReport)
+        .where(
+            MonthlyReport.month == month,
+            MonthlyReport.status == "pending",
+            MonthlyReport.attempt_count < 3,
+        )
+        .order_by(MonthlyReport.id)
+        .limit(1)
+        .with_for_update(skip_locked=True)
+    )
+    if report:
+        report.status = "processing"
+        report.started_at = datetime.utcnow()
+        report.attempt_count += 1
+        await db.commit()
+    return report
+```
+
+**참고**: `SELECT FOR UPDATE SKIP LOCKED`는 PostgreSQL 전용이므로 이 함수는 단위 테스트 대신 통합 테스트(PostgreSQL)로만 검증한다.
+
+### 좀비 row 복구
+
+```python
+async def recover_stale_processing(
+    db: AsyncSession, threshold_minutes: int = 15
+) -> None:
+    """processing 상태로 N분 이상 된 row를 pending으로 복구"""
+    cutoff = datetime.utcnow() - timedelta(minutes=threshold_minutes)
+    await db.execute(
+        update(MonthlyReport)
+        .where(
+            MonthlyReport.status == "processing",
+            MonthlyReport.started_at < cutoff,
+        )
+        .values(status="pending")
+    )
+```
+
+Phase 2 시작 시 항상 먼저 호출한다.
+
+### 상태 전이 요약
+
+```
+pending  ──pick_next_pending()──▶  processing  ──성공──▶  completed
+                                       │
+                                    실패/timeout
+                                       │
+                                       ▼
+                                     failed
+                                       │
+                               attempt_count < 3
+                                       │
+                              다음 cron에서 재시도
+```
+
+### 사용자 조회 API
+
+```python
+# GET /api/reports/monthly?month=YYYY-MM
+# GET /api/reports/latest
+
+# 응답 스키마
+class MonthlyReportResponse(BaseModel):
+    id: int
+    month: str
+    status: Literal["pending", "processing", "completed", "failed"]
+    insights: StructuredInsightsResponse | None  # completed 시에만
+    completed_at: datetime | None
+
+class MonthlyReportEligibility(BaseModel):
+    has_profile: bool
+    transaction_count: int
+    transactions_needed: int   # 15 - transaction_count (음수면 0)
+    category_count: int
+    total_spend: float
+    is_eligible: bool
+    blocker: Literal[
+        "profile_missing",
+        "transactions_short",
+        "categories_short",
+        "spend_short",
+        "first_month",
+    ] | None
+
+# 리포트 없을 때 자격 정보 함께 반환
+class MonthlyReportOrEligibility(BaseModel):
+    report: MonthlyReportResponse | None
+    eligibility: MonthlyReportEligibility | None  # report=None일 때만 채워짐
+```
+
+### 환경 변수 추가
+
+```
+WEBHOOK_SECRET            # HMAC 서명 검증 (Supabase Vault에도 동일 값 저장)
+MONTHLY_REPORT_AUTO_ENABLED  # true(prod) | false(dev). dev 환경에서 자동 실행 방지
+MAX_REPORTS_PER_RUN       # Phase 2 최대 처리 수 (기본 500, 비용 안전장치)
+```
+
+---
+
+## Supabase pg_cron 설정
+
+### 설치 (Supabase SQL Editor)
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- pg_net의 HTTP 요청은 Supabase 공개 IP에서 나가므로
+-- Fly.io allowlist에 추가 필요 없음 (public endpoint)
+```
+
+### Supabase Vault에 시크릿 저장
+
+```sql
+SELECT vault.create_secret(
+  'WEBHOOK_SECRET_VALUE_HERE',
+  'monthly_report_webhook_secret'
+);
+```
+
+### cron job 등록
+
+```sql
+-- 매월 1일 18:00 UTC = KST 다음날 03:00
+-- 실패 복구를 위해 18:30, 21:00에도 추가 실행 (백엔드 멱등이므로 안전)
+SELECT cron.schedule(
+  'monthly-reports-primary',
+  '0 18 1 * *',
+  $$ SELECT net.http_post(
+       url := 'https://podo-budget-backend.fly.dev/api/internal/reports/generate-monthly',
+       headers := jsonb_build_object(
+         'Content-Type', 'application/json',
+         'X-Webhook-Signature', (SELECT decrypted_secret FROM vault.decrypted_secrets
+                                  WHERE name = 'monthly_report_webhook_secret')
+       ),
+       body := '{}'::jsonb
+     ); $$
+);
+
+SELECT cron.schedule('monthly-reports-retry-1', '30 18 1 * *', $$ ... $$);
+SELECT cron.schedule('monthly-reports-retry-2', '0 21 1 * *', $$ ... $$);
+```
+
+> **개발 환경**: dev Supabase에는 cron job 등록하지 않는다. `MONTHLY_REPORT_AUTO_ENABLED=false`. 수동 테스트는 admin API로만.
+
+---
+
+## 프론트엔드 구현
+
+### 파일 구조
+
+```
+frontend/src/
+├── api/reports.ts                  # 리포트 API 클라이언트
+├── pages/ReportDetailPage.tsx      # 결산 리포트 상세 (/insights/reports/:month)
+└── components/reports/
+    ├── MonthlyReportCard.tsx       # 모아보기 상단 표지 카드
+    ├── ReportContent.tsx           # 리포트 본문 (상세 페이지용)
+    ├── ReportEmptyState.tsx        # 자격 미충족 안내
+    └── ReportPendingState.tsx      # pending/processing 중 안내
+```
+
+### 라우팅 추가
+
+```tsx
+// App.tsx
+<Route path="/insights/reports/:month" element={<ReportDetailPage />} />
+```
+
+`:month`는 `YYYY-MM` 형식. 단계 3 이메일 딥링크의 목적지.
+
+### InsightsPage 변경 요약
+
+**제거**:
+- `structuredInsights` useState + `aiLoading` 상태
+- "분석하기" 버튼 + `generateInsights` 함수
+- AI 섹션 내 `StructuredInsightsView` 직접 렌더링
+
+**추가**:
+- Hero 직후 `<MonthlyReportCard />` (useQuery로 latest 리포트 자동 fetch)
+
+### 결산 카드 위치 — Hero 직후
+
+```
+┌─────────────────────────────────────┐
+│  Hero — 5월 (이번 달, 진행 중)      │
+│  ₩2,500,000 / 예산 ₩3,000,000      │
+└─────────────────────────────────────┘
+
+┌─ 4월호 결산 리포트 ─────────────────┐  ← MonthlyReportCard
+│  📬 4월 결산 리포트가 도착했어요    │
+│  "식비가 23% 늘었어요"              │
+│  보러 가기 →                         │
+└─────────────────────────────────────┘
+
+┌─ 카테고리 TOP / 예산 / 자산변동 등 ─┐
+```
+
+**배치 근거**: 현재(Hero) → 지난 달 회고(결산 카드) → 현재 상세(데이터 섹션)의 자연스러운 시간 흐름.
+
+### 상세 페이지 레이아웃 — 잡지형 가독성
+
+```
+┌──────────────────────────────────┐
+│ ← 모아보기로                      │
+├──────────────────────────────────┤
+│        2026년 4월호               │  메타 (14px, muted)
+│   식비가 늘었지만 저축률은        │  표지 헤드라인 (36px, bold)
+│   유지했어요                      │
+│   📬 4월 1일 도착 · 가구명       │  부제 (14px)
+│   ───────────────────────────    │  구분선
+├──────────────────────────────────┤
+│   "이번 달도 수고하셨어요."       │  인용구 (18px, 좌측 grape 바)
+├──────────────────────────────────┤
+│   💡 핵심 발견                    │
+│                                   │
+│   ① 식비가 23% 늘었어요          │  What (22px, bold)
+│   외식 비중이 높았고 주말에…      │  So What (16px, line-h 1.7)
+│   ┌────────────────────────────┐ │
+│   │ → 다음 달엔 외식을 주 2회로 │ │  Now What (강조 박스, leaf-50)
+│   └────────────────────────────┘ │
+│                                   │
+│   ② ... (구분선 후 반복)          │
+├──────────────────────────────────┤
+│   🎯 이번 달 액션                 │
+│   ⭕ 식비 50만원 이내 유지       │
+│   ⭕ 정기구독 점검               │
+│   ⭕ 비상금 충전                 │
+├──────────────────────────────────┤
+│   ⓘ 일반적인 재무 정보...        │  disclaimer (12px)
+└──────────────────────────────────┘
+```
+
+**타이포그래피**: 좌우 마진 16px, max-width 640px (콘텐츠 기사 표준), section gap 64px+
+
+### 상태별 UI 분기
+
+| 응답 | 컴포넌트 | 핵심 메시지 |
+|------|----------|------------|
+| 404 + `profile_missing` | ReportEmptyState | "가구 프로필을 완성하면 결산 리포트를 받아볼 수 있어요" |
+| 404 + `transactions_short` | ReportEmptyState | "이번 달 15건 이상 거래하면 다음 달 1일 결산 리포트가 도착해요 (현재 N건)" |
+| 404 + `first_month` | ReportEmptyState | "다음 달 1일에 첫 결산 리포트가 도착해요" |
+| `pending` / `processing` | ReportPendingState | "리포트를 준비하고 있어요" (30초 폴링) |
+| `completed` | MonthlyReportCard | 표지 카드 |
+| `failed` | ReportEmptyState | 사용자에게 실패 노출 안 함 (부드러운 안내) |
+
+### React Query 캐시
+
+```typescript
+// staleTime 5분 — 리포트는 자주 바뀌지 않음
+const { data: report } = useQuery({
+  queryKey: ['report-latest', activeHouseholdId],
+  queryFn: () => reportsApi.getLatest(activeHouseholdId),
+  staleTime: 5 * 60 * 1000,
+  // pending/processing 상태일 때만 폴링
+  refetchInterval: (data) =>
+    data?.status === 'pending' || data?.status === 'processing'
+      ? 30_000
+      : false,
+})
+```
+
+---
+
+## 에러 처리
+
+| 케이스 | 처리 |
+|--------|------|
+| HMAC 검증 실패 | 401 응답 + 에러 로그 |
+| pg_cron 발사 실패 (Fly.io 다운) | 18:30, 21:00 재시도 cron이 복구 |
+| LLM 타임아웃 (30초) | `failed` + last_error, 다른 가구 무관 |
+| LLM rate limit (429) | `failed`, 다음 cron 재시도 |
+| LLM 파싱 실패 | `failed` + raw response 로깅 |
+| processing 좀비 | 다음 cron의 `recover_stale_processing`이 복구 |
+| `failed` 상태 (사용자 조회 시) | `ReportEmptyState` 표시 (실패 노출 X) |
+
+---
+
+## 테스트 전략
+
+### 백엔드
+
+```
+tests/
+├── unit/
+│   ├── test_report_eligibility.py    # 경계값 (14건/15건, 카테고리 2/3개 등)
+│   ├── test_report_data_builder.py   # 집계 정확성 (각 필드별)
+│   ├── test_webhook_auth.py          # HMAC 검증 성공/실패
+│   └── test_kst_month_helpers.py     # 월 경계/시간대 변환
+└── integration/
+    ├── test_api_reports.py           # 4가지 status별 응답
+    ├── test_api_reports_eligibility.py  # blocker별 eligibility 응답
+    └── test_reports_scheduler.py     # Phase 1/2 통합 (mock LLM)
+    # NOTE: pick_next_pending (SKIP LOCKED)은 PostgreSQL 전용
+    #       SQLite 테스트 환경에서는 락 없이 동작하는 별도 경로로 테스트
+```
+
+**핵심 테스트 케이스**:
+
+```python
+# 멱등성
+- webhook 두 번 호출 → pending row 1개만 생성
+
+# 경계값
+- 거래 14건 → 미달 / 15건 → 통과
+- exclude_from_stats=true 거래는 카운트 제외
+
+# 실패 격리
+- 100가구 중 5개 LLM 실패 → 95개 completed, 5개 failed
+
+# 좀비 복구
+- started_at 30분 전 + processing → recover 후 pending 전환
+
+# attempt_count 상한
+- attempt_count=3 → pick_next_pending에서 제외 (재시도 안 함)
+```
+
+### 프론트엔드
+
+```
+components/reports/__tests__/
+├── MonthlyReportCard.test.tsx       # 4 status × 3 eligibility blocker
+├── ReportContent.test.tsx           # 핵심 발견/액션 렌더링
+├── ReportEmptyState.test.tsx        # blocker별 카피
+└── ReportPendingState.test.tsx      # 폴링 동작 (vi.useFakeTimers)
+```
+
+MSW 핸들러: `GET /api/reports/monthly`, `GET /api/reports/latest` 추가.
+
+---
+
+## 모니터링
+
+### 구조화 로그
+
+```python
+logger.info("[monthly-reports] cron_started month=%s", month)
+logger.info("[monthly-reports] eligible_households count=%d month=%s", n, month)
+logger.info("[monthly-reports] phase1_complete queued=%d", n)
+logger.info("[monthly-reports] phase2_complete completed=%d failed=%d duration_s=%d", c, f, d)
+logger.warning("[monthly-reports] llm_failed household_id=%d error=%s", h, e)
+```
+
+`grep '[monthly-reports]'`로 한 달 처리 흐름 한 눈에 확인.
+
+### Sentry
+
+- LLM 호출 실패 자동 캡처 (기존 DSN 사용)
+- 실패 시 `household_id`, `month`, `attempt_count` 태그 포함
+
+### 매월 1일 운영 체크 (단계 1 초반)
+
+1. 로그에서 `cron_started`가 KST 03:00경 찍혔는지 확인
+2. `phase2_complete`의 `failed` 수치 확인
+3. Sentry 알림 여부 확인
+4. 실패 가구는 admin retry API로 재시도
+
+---
+
+## 보안
+
+- **Webhook secret**: Supabase Vault 저장. `.env`에 동일 값. 절대 git 커밋 금지.
+- **Admin 엔드포인트**: 기존 `require_admin` 의존성 재사용
+- **사용자 조회 rate limit**: `@limiter.limit("60/minute")`
+- **LLM 비용 폭주 방지**: `MAX_REPORTS_PER_RUN` 환경변수로 상한 제어
+
+---
+
+## 단계 1 범위 (미포함)
+
+다음은 단계 2/3에서 구현한다:
+
+- 이전 리포트 컨텍스트를 LLM 프롬프트에 포함 (단계 2)
+- "지난 리포트" 시간순 카드 그리드 (`/insights/reports`) (단계 2)
+- 홈 페이지에 "새 리포트 도착" 알림 카드 + 읽음 상태 (단계 3)
+- 이메일 뉴스레터 발송 (단계 3, Resend)
+- 리포트 수신 설정 (단계 3)
+- 유료 플랜 게이팅 (단계 4)
+
+---
+
+## 출시 전 체크리스트
+
+- [ ] Alembic 마이그레이션 작성 및 dev 환경 검증
+- [ ] Supabase pg_cron + pg_net 설치 확인
+- [ ] Vault에 webhook secret 저장
+- [ ] Fly.io `WEBHOOK_SECRET`, `MONTHLY_REPORT_AUTO_ENABLED=true` 환경변수 설정
+- [ ] dev 환경 `MONTHLY_REPORT_AUTO_ENABLED=false` 확인
+- [ ] admin manual-trigger로 첫 배포 후 직전 달(4월) 리포트 일괄 생성
+- [ ] 생성된 리포트 샘플 품질 검토
+- [ ] 자격 미달 가구 eligibility 응답 프론트 표시 확인
+- [ ] pending → polled → completed 시나리오 E2E 확인

--- a/docs/plans/2026-04-26-monthly-report-plan.md
+++ b/docs/plans/2026-04-26-monthly-report-plan.md
@@ -1,0 +1,2968 @@
+# 월간 결산 리포트 구현 계획
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 매월 1일 자동으로 전월 결산 리포트를 생성하고 앱 내에서 콘텐츠 객체로 제공한다.
+
+**Architecture:** Supabase pg_cron이 매월 1일 03:00 KST에 webhook을 호출하면, Phase 1에서 자격 통과 가구의 pending row를 생성하고 FastAPI BackgroundTasks로 Phase 2를 실행한다. Phase 2는 `SELECT FOR UPDATE SKIP LOCKED`로 원자적으로 픽업한 뒤 Semaphore(5)로 병렬 LLM 호출을 관리한다. 결과는 `MonthlyReport` 테이블에 영구 저장된다.
+
+**Tech Stack:** FastAPI BackgroundTasks, SQLAlchemy 2.0 async, Supabase pg_cron + pg_net, HMAC-SHA256, Anthropic LLM, React Query polling, Vitest + MSW
+
+**설계 문서:** `docs/plans/2026-04-26-monthly-report-design.md`
+
+---
+
+## Task 1: MonthlyReport 모델 + Alembic 마이그레이션
+
+**Files:**
+- Create: `backend/app/models/monthly_report.py`
+- Modify: `backend/app/models/__init__.py`
+- Modify: `backend/app/models/household.py`
+- Create: `backend/alembic/versions/<hash>_add_monthly_reports.py`
+
+### Step 1: MonthlyReport 모델 작성
+
+```python
+# backend/app/models/monthly_report.py
+"""월간 결산 리포트 엔티티"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Index, JSON, String, Text, UniqueConstraint, func
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+if TYPE_CHECKING:
+    from app.models.household import Household
+
+
+class MonthlyReport(Base):  # type: ignore[misc]
+    """가구별 월간 결산 리포트
+
+    매월 1일 03:00 KST에 자동 생성된다.
+    한 가구는 한 달에 하나의 리포트만 가질 수 있다 (unique constraint).
+    """
+
+    __tablename__ = "monthly_reports"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # ── 식별 ──
+    household_id: Mapped[int] = mapped_column(
+        ForeignKey("households.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    month: Mapped[str] = mapped_column(
+        String(7), nullable=False,
+        comment="YYYY-MM 형식 (예: 2026-04)",
+    )
+
+    # ── 상태 머신 ──
+    status: Mapped[str] = mapped_column(
+        String(15), nullable=False, default="pending",
+        comment="pending | processing | completed | failed",
+    )
+    attempt_count: Mapped[int] = mapped_column(
+        default=0, nullable=False,
+        comment="LLM 호출 시도 횟수. 0=Phase 1 완료, 1+=Phase 2 시도",
+    )
+    last_error: Mapped[str | None] = mapped_column(
+        String(2000), nullable=True,
+        comment="마지막 실패 사유 (2000자 truncate)",
+    )
+    trigger_source: Mapped[str] = mapped_column(
+        String(15), nullable=False, default="auto",
+        comment="auto | admin | retry",
+    )
+
+    # ── 데이터 스냅샷 ──
+    report_data: Mapped[dict] = mapped_column(
+        JSON, nullable=False,
+        comment="분석 시점의 입력 스냅샷. 이후 거래 변경과 무관하게 불변.",
+    )
+    insights: Mapped[dict | None] = mapped_column(
+        JSON, nullable=True,
+        comment="LLM 출력 (StructuredInsightsResponse 구조). completed 시에만 채워짐.",
+    )
+    insights_version: Mapped[int] = mapped_column(
+        default=1, nullable=False,
+        comment="LLM 출력 스키마 버전. 스키마 변경 시 증가하여 하위 호환 처리 기준으로 사용.",
+    )
+
+    # ── 메타 ──
+    llm_tokens_used: Mapped[int | None] = mapped_column(nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        default=func.now(), server_default=func.now(), nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        default=func.now(), onupdate=func.now(),
+        server_default=func.now(), nullable=False,
+    )
+
+    household: Mapped["Household"] = relationship(back_populates="monthly_reports")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "household_id", "month",
+            name="uq_monthly_report_household_month",
+        ),
+        Index("ix_monthly_reports_month_status", "month", "status"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<MonthlyReport(id={self.id}, household_id={self.household_id}, month={self.month}, status={self.status})>"
+```
+
+### Step 2: `__init__.py`에 MonthlyReport 추가
+
+`backend/app/models/__init__.py`에서 다른 모델들이 import되는 패턴을 따라 추가:
+```python
+from app.models.monthly_report import MonthlyReport  # noqa: F401
+```
+
+### Step 3: Household 모델에 relationship 추가
+
+`backend/app/models/household.py`에서 기존 relationships 블록 끝에 추가:
+```python
+# 파일 상단 TYPE_CHECKING 블록에 추가
+if TYPE_CHECKING:
+    from app.models.monthly_report import MonthlyReport
+
+# relationships 블록에 추가
+monthly_reports: Mapped[list["MonthlyReport"]] = relationship(
+    back_populates="household",
+    cascade="all, delete-orphan",
+)
+```
+
+### Step 4: Alembic 마이그레이션 생성
+
+```bash
+cd backend
+alembic revision --autogenerate -m "add_monthly_reports"
+```
+
+생성된 파일에서 `upgrade()`/`downgrade()` 검토 — 테이블 생성, unique constraint, index가 포함됐는지 확인.
+
+### Step 5: 마이그레이션 적용 확인
+
+```bash
+cd backend
+alembic upgrade head
+```
+
+Expected: `Running upgrade ... -> <hash>, add_monthly_reports`
+
+### Step 6: 커밋
+
+```bash
+git add backend/app/models/monthly_report.py \
+        backend/app/models/__init__.py \
+        backend/app/models/household.py \
+        backend/alembic/versions/*add_monthly_reports.py
+git commit -m "feat: MonthlyReport 모델 + Alembic 마이그레이션 추가"
+```
+
+---
+
+## Task 2: 환경변수 + 설정 추가
+
+**Files:**
+- Modify: `backend/app/core/config.py`
+- Modify: `backend/.env.example`
+
+### Step 1: config.py에 신규 설정 추가
+
+`backend/app/core/config.py`의 `Settings` 클래스에서 기존 `SENTRY_WEBHOOK_SECRET` 근처에 추가:
+
+```python
+# 월간 결산 리포트
+MONTHLY_REPORT_WEBHOOK_SECRET: str = ""   # Supabase pg_cron → webhook HMAC 시크릿
+MONTHLY_REPORT_AUTO_ENABLED: bool = True  # False이면 webhook 수신해도 실행 안 함 (dev용)
+MONTHLY_REPORT_MAX_PER_RUN: int = 500     # Phase 2 최대 처리 가구 수 (비용 안전장치)
+```
+
+### Step 2: `.env.example`에 추가
+
+```bash
+# 월간 결산 리포트
+MONTHLY_REPORT_WEBHOOK_SECRET=your-hmac-secret-here
+MONTHLY_REPORT_AUTO_ENABLED=true
+MONTHLY_REPORT_MAX_PER_RUN=500
+```
+
+로컬 `backend/.env`에도 동일하게 추가 (MONTHLY_REPORT_AUTO_ENABLED=false로 설정).
+
+### Step 3: 커밋
+
+```bash
+git add backend/app/core/config.py backend/.env.example
+git commit -m "feat: 월간 결산 리포트 환경변수 설정 추가"
+```
+
+---
+
+## Task 3: 웹훅 인증 + 월/시간대 헬퍼
+
+**Files:**
+- Create: `backend/app/core/webhook_auth.py`
+- Create: `backend/app/services/report_month_utils.py`
+- Create: `backend/tests/unit/test_report_month_utils.py`
+
+### Step 1: 웹훅 인증 모듈 작성
+
+```python
+# backend/app/core/webhook_auth.py
+"""HMAC-SHA256 기반 웹훅 서명 검증"""
+
+import hashlib
+import hmac
+
+from fastapi import HTTPException, Request
+
+from app.core.config import settings
+
+
+def verify_monthly_report_webhook(request: Request) -> None:
+    """Supabase pg_net이 전송한 HMAC 서명 검증
+
+    Raises:
+        HTTPException: 서명 불일치 시 401
+    """
+    if not settings.MONTHLY_REPORT_WEBHOOK_SECRET:
+        raise HTTPException(status_code=401, detail="Webhook secret not configured")
+
+    received = request.headers.get("x-webhook-signature", "")
+    expected = hmac.new(
+        settings.MONTHLY_REPORT_WEBHOOK_SECRET.encode(),
+        b"monthly-report-trigger",
+        hashlib.sha256,
+    ).hexdigest()
+
+    if not hmac.compare_digest(received, expected):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+```
+
+### Step 2: 월/시간대 헬퍼 작성 (실패 테스트 먼저)
+
+```python
+# backend/tests/unit/test_report_month_utils.py
+from datetime import date
+import pytest
+from app.services.report_month_utils import (
+    previous_month_kst,
+    month_boundaries,
+    month_str_from_date,
+)
+
+
+def test_previous_month_kst_returns_yyyy_mm():
+    result = previous_month_kst()
+    assert len(result) == 7
+    assert result[4] == "-"
+
+
+def test_month_boundaries_april():
+    start, end = month_boundaries("2026-04")
+    assert start == date(2026, 4, 1)
+    assert end == date(2026, 5, 1)
+
+
+def test_month_boundaries_december():
+    start, end = month_boundaries("2026-12")
+    assert start == date(2026, 12, 1)
+    assert end == date(2027, 1, 1)
+
+
+def test_month_str_from_date():
+    assert month_str_from_date(date(2026, 4, 15)) == "2026-04"
+    assert month_str_from_date(date(2026, 1, 1)) == "2026-01"
+```
+
+### Step 3: 테스트 실패 확인
+
+```bash
+cd backend && pytest tests/unit/test_report_month_utils.py -v
+```
+Expected: FAIL (ImportError)
+
+### Step 4: 헬퍼 구현
+
+```python
+# backend/app/services/report_month_utils.py
+"""월간 결산 리포트용 날짜/시간대 헬퍼"""
+
+from datetime import date, datetime, timezone, timedelta
+
+
+_KST = timezone(timedelta(hours=9))
+
+
+def previous_month_kst() -> str:
+    """현재 KST 기준 직전 마감 월을 YYYY-MM 형식으로 반환"""
+    now_kst = datetime.now(_KST)
+    if now_kst.month == 1:
+        return f"{now_kst.year - 1}-12"
+    return f"{now_kst.year}-{now_kst.month - 1:02d}"
+
+
+def month_boundaries(month: str) -> tuple[date, date]:
+    """YYYY-MM → (시작일 inclusive, 종료일 exclusive) 반환"""
+    year, mon = map(int, month.split("-"))
+    start = date(year, mon, 1)
+    if mon == 12:
+        end = date(year + 1, 1, 1)
+    else:
+        end = date(year, mon + 1, 1)
+    return start, end
+
+
+def month_str_from_date(d: date) -> str:
+    """date → YYYY-MM 형식"""
+    return f"{d.year}-{d.month:02d}"
+```
+
+### Step 5: 테스트 통과 확인
+
+```bash
+cd backend && pytest tests/unit/test_report_month_utils.py -v
+```
+Expected: 4 passed
+
+### Step 6: 커밋
+
+```bash
+git add backend/app/core/webhook_auth.py \
+        backend/app/services/report_month_utils.py \
+        backend/tests/unit/test_report_month_utils.py
+git commit -m "feat: 월간 결산 웹훅 인증 + 날짜 헬퍼 추가"
+```
+
+---
+
+## Task 4: 자격 검증 서비스
+
+**Files:**
+- Create: `backend/app/services/report_eligibility.py`
+- Create: `backend/tests/integration/test_report_eligibility.py`
+
+### Step 1: 실패 테스트 작성
+
+```python
+# backend/tests/integration/test_report_eligibility.py
+"""자격 검증 서비스 통합 테스트"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.expense import Expense
+from app.models.household_profile import HouseholdProfile
+from app.services.report_eligibility import find_eligible_households, check_household_eligibility
+
+
+@pytest.mark.asyncio
+async def test_eligible_with_sufficient_data(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    # HouseholdProfile 생성
+    profile = HouseholdProfile(
+        household_id=test_household.id,
+        household_type="single",
+        housing_type="monthly_rent",
+        income_types=["salary"],
+        age_range="30s",
+    )
+    db_session.add(profile)
+
+    # 거래 15건, 카테고리 3개, 지출 20만원 이상
+    for i in range(15):
+        db_session.add(Expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=20000,
+            description=f"지출 {i}",
+            date=__import__('datetime').date(2026, 3, i + 1),
+            category_id=(i % 3) + 1,  # 3개 카테고리 순환
+        ))
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id in result
+
+
+@pytest.mark.asyncio
+async def test_ineligible_no_profile(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """프로필 없는 가구는 자격 미달"""
+    for i in range(20):
+        db_session.add(Expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=20000,
+            description=f"지출 {i}",
+            date=__import__('datetime').date(2026, 3, i + 1),
+            category_id=(i % 4) + 1,
+        ))
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id not in result
+
+
+@pytest.mark.asyncio
+async def test_ineligible_below_transaction_threshold(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """거래 14건이면 미달 (임계값 15건)"""
+    profile = HouseholdProfile(
+        household_id=test_household.id,
+        household_type="single",
+        housing_type="monthly_rent",
+        income_types=["salary"],
+        age_range="30s",
+    )
+    db_session.add(profile)
+    for i in range(14):
+        db_session.add(Expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=20000,
+            description=f"지출 {i}",
+            date=__import__('datetime').date(2026, 3, i + 1),
+            category_id=(i % 4) + 1,
+        ))
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id not in result
+
+
+@pytest.mark.asyncio
+async def test_exclude_from_stats_not_counted(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """exclude_from_stats=True 거래는 임계값 카운트에서 제외"""
+    profile = HouseholdProfile(
+        household_id=test_household.id,
+        household_type="single",
+        housing_type="monthly_rent",
+        income_types=["salary"],
+        age_range="30s",
+    )
+    db_session.add(profile)
+    # 실제 거래 10건 + exclude 거래 5건 = 합계 15건이지만 자격은 미달이어야 함
+    for i in range(10):
+        db_session.add(Expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=20000,
+            description=f"지출 {i}",
+            date=__import__('datetime').date(2026, 3, i + 1),
+            category_id=(i % 4) + 1,
+        ))
+    for i in range(5):
+        db_session.add(Expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=100000,
+            description=f"제외 지출 {i}",
+            date=__import__('datetime').date(2026, 3, i + 1),
+            category_id=1,
+            exclude_from_stats=True,
+        ))
+    await db_session.commit()
+
+    result = await find_eligible_households(db_session, "2026-03")
+    assert test_household.id not in result
+
+
+@pytest.mark.asyncio
+async def test_check_household_eligibility_returns_detail(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """check_household_eligibility는 상세 blocker 정보를 반환한다"""
+    # 프로필 없음
+    result = await check_household_eligibility(db_session, test_household.id, "2026-03")
+    assert result.is_eligible is False
+    assert result.blocker == "profile_missing"
+```
+
+### Step 2: 테스트 실패 확인
+
+```bash
+cd backend && pytest tests/integration/test_report_eligibility.py -v
+```
+Expected: FAIL (ImportError)
+
+### Step 3: 서비스 구현
+
+```python
+# backend/app/services/report_eligibility.py
+"""월간 결산 리포트 자격 검증 서비스"""
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+from typing import Literal
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.expense import Expense
+from app.models.household import Household
+from app.models.household_profile import HouseholdProfile
+from app.services.report_month_utils import month_boundaries
+
+logger = logging.getLogger(__name__)
+
+# 자격 임계값 상수
+MIN_TRANSACTIONS = 15
+MIN_CATEGORIES = 3
+MIN_SPEND = 200_000
+
+
+@dataclass
+class EligibilityResult:
+    has_profile: bool
+    transaction_count: int
+    category_count: int
+    total_spend: float
+    is_eligible: bool
+    blocker: Literal[
+        "profile_missing",
+        "transactions_short",
+        "categories_short",
+        "spend_short",
+        None,
+    ]
+
+    @property
+    def transactions_needed(self) -> int:
+        return max(0, MIN_TRANSACTIONS - self.transaction_count)
+
+
+async def find_eligible_households(
+    db: AsyncSession, month: str
+) -> list[int]:
+    """자격 통과 가구 ID 목록 반환 (단일 SQL)"""
+    start, end = month_boundaries(month)
+
+    result = await db.execute(
+        select(Household.id)
+        .join(HouseholdProfile, HouseholdProfile.household_id == Household.id)
+        .outerjoin(
+            Expense,
+            and_(
+                Expense.household_id == Household.id,
+                Expense.date >= start,
+                Expense.date < end,
+                Expense.exclude_from_stats == False,  # noqa: E712
+            ),
+        )
+        .group_by(Household.id)
+        .having(
+            func.count(Expense.id) >= MIN_TRANSACTIONS,
+            func.count(func.distinct(Expense.category_id)) >= MIN_CATEGORIES,
+            func.coalesce(func.sum(Expense.amount), 0) >= MIN_SPEND,
+        )
+    )
+    ids = [row[0] for row in result.all()]
+    logger.info("[eligibility] 자격 통과 가구 %d개 (월: %s)", len(ids), month)
+    return ids
+
+
+async def check_household_eligibility(
+    db: AsyncSession, household_id: int, month: str
+) -> EligibilityResult:
+    """단일 가구의 자격 상세 정보 반환 (사용자 안내용)"""
+    start, end = month_boundaries(month)
+
+    # 프로필 확인
+    profile = await db.scalar(
+        select(HouseholdProfile).where(
+            HouseholdProfile.household_id == household_id
+        )
+    )
+    if not profile:
+        return EligibilityResult(
+            has_profile=False,
+            transaction_count=0,
+            category_count=0,
+            total_spend=0.0,
+            is_eligible=False,
+            blocker="profile_missing",
+        )
+
+    # 거래 집계
+    row = await db.execute(
+        select(
+            func.count(Expense.id).label("tx_count"),
+            func.count(func.distinct(Expense.category_id)).label("cat_count"),
+            func.coalesce(func.sum(Expense.amount), 0).label("total"),
+        ).where(
+            Expense.household_id == household_id,
+            Expense.date >= start,
+            Expense.date < end,
+            Expense.exclude_from_stats == False,  # noqa: E712
+        )
+    )
+    stats = row.one()
+    tx_count = stats.tx_count
+    cat_count = stats.cat_count
+    total = float(stats.total)
+
+    blocker = None
+    if tx_count < MIN_TRANSACTIONS:
+        blocker = "transactions_short"
+    elif cat_count < MIN_CATEGORIES:
+        blocker = "categories_short"
+    elif total < MIN_SPEND:
+        blocker = "spend_short"
+
+    return EligibilityResult(
+        has_profile=True,
+        transaction_count=tx_count,
+        category_count=cat_count,
+        total_spend=total,
+        is_eligible=blocker is None,
+        blocker=blocker,
+    )
+```
+
+### Step 4: 테스트 통과 확인
+
+```bash
+cd backend && pytest tests/integration/test_report_eligibility.py -v
+```
+Expected: 5 passed
+
+### Step 5: 커밋
+
+```bash
+git add backend/app/services/report_eligibility.py \
+        backend/tests/integration/test_report_eligibility.py
+git commit -m "feat: 결산 리포트 자격 검증 서비스 추가"
+```
+
+---
+
+## Task 5: report_data_builder 서비스
+
+**Files:**
+- Create: `backend/app/services/report_data_builder.py`
+- Create: `backend/tests/integration/test_report_data_builder.py`
+
+이 서비스는 기존에 프론트엔드(`InsightsPage.tsx`)가 7~8개 API를 호출해 조립하던 데이터를 백엔드에서 직접 집계한다. **단계 1의 가장 큰 작업량이다.**
+
+`financial_score` 계산 로직은 `frontend/src/utils/financialScore.ts`를 참고하여 Python으로 포팅한다.
+
+### Step 1: 실패 테스트 작성
+
+```python
+# backend/tests/integration/test_report_data_builder.py
+"""report_data_builder 통합 테스트"""
+
+import pytest
+from datetime import date
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.expense import Expense
+from app.models.income import Income
+from app.services.report_data_builder import build_report_data
+
+
+@pytest.mark.asyncio
+async def test_build_report_data_basic(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """기본 집계 — expense_total, income_total, top_expense_categories"""
+    # 지출 3건 (카테고리 각 1, 2, 3)
+    for cat_id, amount in [(1, 50000), (2, 30000), (3, 20000)]:
+        db_session.add(Expense(
+            household_id=test_household.id,
+            user_id=test_user.id,
+            amount=amount,
+            description="지출",
+            date=date(2026, 3, 1),
+            category_id=cat_id,
+        ))
+    # 수입 1건
+    db_session.add(Income(
+        household_id=test_household.id,
+        user_id=test_user.id,
+        amount=500000,
+        description="월급",
+        date=date(2026, 3, 5),
+        category_id=None,
+    ))
+    await db_session.commit()
+
+    data = await build_report_data(db_session, test_household.id, "2026-03")
+
+    assert data["expense_total"] == 100000.0
+    assert data["income_total"] == 500000.0
+    assert len(data["top_expense_categories"]) == 3
+    assert data["savings_rate"] == pytest.approx(80.0, abs=0.1)
+
+
+@pytest.mark.asyncio
+async def test_build_report_data_excludes_stats_excluded(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """exclude_from_stats=True 거래는 합계에서 제외"""
+    db_session.add(Expense(
+        household_id=test_household.id,
+        user_id=test_user.id,
+        amount=100000,
+        description="일반 지출",
+        date=date(2026, 3, 1),
+        category_id=1,
+    ))
+    db_session.add(Expense(
+        household_id=test_household.id,
+        user_id=test_user.id,
+        amount=1000000,
+        description="통계 제외",
+        date=date(2026, 3, 2),
+        category_id=1,
+        exclude_from_stats=True,
+    ))
+    await db_session.commit()
+
+    data = await build_report_data(db_session, test_household.id, "2026-03")
+    assert data["expense_total"] == 100000.0
+
+
+@pytest.mark.asyncio
+async def test_build_report_data_previous_month(
+    db_session: AsyncSession,
+    test_household,
+    test_user,
+):
+    """전월 비교 데이터가 포함된다"""
+    # 2월 지출
+    db_session.add(Expense(
+        household_id=test_household.id,
+        user_id=test_user.id,
+        amount=80000,
+        description="2월 지출",
+        date=date(2026, 2, 10),
+        category_id=1,
+    ))
+    # 3월 지출
+    db_session.add(Expense(
+        household_id=test_household.id,
+        user_id=test_user.id,
+        amount=100000,
+        description="3월 지출",
+        date=date(2026, 3, 10),
+        category_id=1,
+    ))
+    await db_session.commit()
+
+    data = await build_report_data(db_session, test_household.id, "2026-03")
+    assert data["previous_month_expense"] == 80000.0
+```
+
+### Step 2: 테스트 실패 확인
+
+```bash
+cd backend && pytest tests/integration/test_report_data_builder.py -v
+```
+Expected: FAIL (ImportError)
+
+### Step 3: 서비스 구현
+
+```python
+# backend/app/services/report_data_builder.py
+"""월간 결산 리포트 데이터 집계 서비스
+
+기존 InsightsPage.tsx가 7~8개 API를 호출해 조립하던 로직을 백엔드로 이관.
+ComprehensiveInsightsRequest 스키마와 호환되는 dict를 반환한다.
+"""
+
+import logging
+from datetime import date
+
+from sqlalchemy import and_, case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.budget import Budget
+from app.models.category import Category
+from app.models.expense import Expense
+from app.models.income import Income
+from app.models.recurring_transaction import RecurringTransaction
+from app.services.report_month_utils import month_boundaries, month_str_from_date
+
+logger = logging.getLogger(__name__)
+
+
+async def build_report_data(
+    db: AsyncSession, household_id: int, month: str
+) -> dict:
+    """ComprehensiveInsightsRequest 호환 dict 생성"""
+    start, end = month_boundaries(month)
+    prev_month = _previous_month(month)
+    prev_start, prev_end = month_boundaries(prev_month)
+
+    expense_total = await _sum_expenses(db, household_id, start, end)
+    income_total = await _sum_income(db, household_id, start, end)
+    prev_expense = await _sum_expenses(db, household_id, prev_start, prev_end)
+    prev_income = await _sum_income(db, household_id, prev_start, prev_end)
+
+    top_categories = await _top_expense_categories(db, household_id, start, end, expense_total)
+    budget = await _budget_summary(db, household_id, start, end)
+    trend = await _expense_income_trend(db, household_id, month, months=3)
+    savings_total = await _savings_total(db, household_id, start, end)
+    recurring_total = await _recurring_total(db, household_id, start, end)
+
+    savings_rate = (
+        (income_total - expense_total) / income_total * 100
+        if income_total > 0
+        else 0.0
+    )
+
+    return {
+        "month": month,
+        "income_total": income_total,
+        "expense_total": expense_total,
+        "top_expense_categories": top_categories,
+        "budget": budget,
+        "savings_rate": round(savings_rate, 2),
+        "trend": trend,
+        "savings_total": savings_total,
+        "recurring_total": recurring_total,
+        "previous_month_expense": prev_expense,
+        "previous_month_income": prev_income,
+        # financial_score는 복잡한 계산이므로 별도 함수로 분리
+        "financial_score": _calc_financial_score(
+            income_total=income_total,
+            expense_total=expense_total,
+            savings_total=savings_total,
+            budget=budget,
+            trend=trend,
+        ),
+    }
+
+
+async def _sum_expenses(
+    db: AsyncSession, household_id: int, start: date, end: date
+) -> float:
+    result = await db.scalar(
+        select(func.coalesce(func.sum(Expense.amount), 0)).where(
+            Expense.household_id == household_id,
+            Expense.date >= start,
+            Expense.date < end,
+            Expense.exclude_from_stats == False,  # noqa: E712
+        )
+    )
+    return float(result)  # type: ignore[arg-type]
+
+
+async def _sum_income(
+    db: AsyncSession, household_id: int, start: date, end: date
+) -> float:
+    result = await db.scalar(
+        select(func.coalesce(func.sum(Income.amount), 0)).where(
+            Income.household_id == household_id,
+            Income.date >= start,
+            Income.date < end,
+            Income.exclude_from_stats == False,  # noqa: E712
+        )
+    )
+    return float(result)  # type: ignore[arg-type]
+
+
+async def _top_expense_categories(
+    db: AsyncSession,
+    household_id: int,
+    start: date,
+    end: date,
+    expense_total: float,
+    limit: int = 5,
+) -> list[dict]:
+    rows = await db.execute(
+        select(
+            Category.name,
+            func.sum(Expense.amount).label("amount"),
+        )
+        .join(Category, Expense.category_id == Category.id, isouter=True)
+        .where(
+            Expense.household_id == household_id,
+            Expense.date >= start,
+            Expense.date < end,
+            Expense.exclude_from_stats == False,  # noqa: E712
+        )
+        .group_by(Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .limit(limit)
+    )
+    total = expense_total or 1.0
+    return [
+        {
+            "name": row.name or "미분류",
+            "amount": float(row.amount),
+            "percentage": round(float(row.amount) / total * 100, 1),
+        }
+        for row in rows.all()
+    ]
+
+
+async def _budget_summary(
+    db: AsyncSession, household_id: int, start: date, end: date
+) -> dict | None:
+    budgets = await db.scalars(
+        select(Budget).where(Budget.household_id == household_id)
+    )
+    budget_list = list(budgets)
+    if not budget_list:
+        return None
+
+    total_budget = sum(float(b.amount) for b in budget_list)
+
+    # 예산 초과 카테고리 이름 조회
+    over_result = await db.execute(
+        select(Category.name)
+        .join(Budget, Budget.category_id == Category.id)
+        .join(
+            select(
+                Expense.category_id,
+                func.sum(Expense.amount).label("spent"),
+            )
+            .where(
+                Expense.household_id == household_id,
+                Expense.date >= start,
+                Expense.date < end,
+                Expense.exclude_from_stats == False,  # noqa: E712
+            )
+            .group_by(Expense.category_id)
+            .subquery(),
+            Budget.category_id == func.column("category_id"),
+            isouter=True,
+        )
+        .where(
+            Budget.household_id == household_id,
+            func.column("spent") > Budget.amount,
+        )
+    )
+    over_categories = [row[0] for row in over_result.all()]
+
+    # 총 지출 (예산 관련 카테고리)
+    spent_result = await db.scalar(
+        select(func.coalesce(func.sum(Expense.amount), 0)).where(
+            Expense.household_id == household_id,
+            Expense.date >= start,
+            Expense.date < end,
+            Expense.exclude_from_stats == False,  # noqa: E712
+        )
+    )
+
+    return {
+        "total_budget": total_budget,
+        "total_spent": float(spent_result),  # type: ignore[arg-type]
+        "over_categories": over_categories,
+    }
+
+
+async def _expense_income_trend(
+    db: AsyncSession, household_id: int, current_month: str, months: int = 3
+) -> list[dict]:
+    """직전 N개월 income/expense 트렌드"""
+    result = []
+    year, mon = map(int, current_month.split("-"))
+    for i in range(months, 0, -1):
+        m = mon - i
+        y = year
+        while m <= 0:
+            m += 12
+            y -= 1
+        m_str = f"{y}-{m:02d}"
+        s, e = month_boundaries(m_str)
+        exp = await _sum_expenses(db, household_id, s, e)
+        inc = await _sum_income(db, household_id, s, e)
+        result.append({"month": m_str, "income": inc, "expense": exp})
+    return result
+
+
+async def _savings_total(
+    db: AsyncSession, household_id: int, start: date, end: date
+) -> float | None:
+    """is_savings=True인 수입 카테고리 합계 (저축 카테고리 없으면 None)"""
+    result = await db.scalar(
+        select(func.coalesce(func.sum(Income.amount), 0))
+        .join(Category, Income.category_id == Category.id, isouter=True)
+        .where(
+            Income.household_id == household_id,
+            Income.date >= start,
+            Income.date < end,
+            Category.type == "savings",
+        )
+    )
+    if result == 0:
+        # 저축 카테고리가 아예 없을 수도 있음 — None 반환
+        has_savings_cat = await db.scalar(
+            select(func.count(Category.id)).where(
+                Category.household_id == household_id,
+                Category.type == "savings",
+            )
+        )
+        if not has_savings_cat:
+            return None
+    return float(result)  # type: ignore[arg-type]
+
+
+async def _recurring_total(
+    db: AsyncSession, household_id: int, start: date, end: date
+) -> float | None:
+    result = await db.scalar(
+        select(func.coalesce(func.sum(RecurringTransaction.amount), 0)).where(
+            RecurringTransaction.household_id == household_id,
+            RecurringTransaction.next_date >= start,
+            RecurringTransaction.next_date < end,
+        )
+    )
+    return float(result) if result else None  # type: ignore[arg-type]
+
+
+def _previous_month(month: str) -> str:
+    year, mon = map(int, month.split("-"))
+    if mon == 1:
+        return f"{year - 1}-12"
+    return f"{year}-{mon - 1:02d}"
+
+
+def _calc_financial_score(
+    income_total: float,
+    expense_total: float,
+    savings_total: float | None,
+    budget: dict | None,
+    trend: list[dict],
+) -> dict:
+    """재무 점수 계산 (frontend/src/utils/financialScore.ts 포팅)
+
+    4가지 지표: savings_rate, budget_adherence, fixed_expense_ratio, spending_stability
+    """
+    scores: list[int] = []
+
+    # 1. 저축률 점수
+    savings_score: int | None = None
+    if income_total > 0 and savings_total is not None:
+        ratio = savings_total / income_total * 100
+        if ratio >= 30:
+            savings_score = 100
+        elif ratio >= 20:
+            savings_score = int(80 + (ratio - 20) / 10 * 20)
+        elif ratio >= 10:
+            savings_score = int(50 + (ratio - 10) / 10 * 30)
+        else:
+            savings_score = int(ratio / 10 * 50)
+        scores.append(savings_score)
+
+    # 2. 예산 준수율 점수
+    budget_score: int | None = None
+    if budget and budget["total_budget"] > 0:
+        adherence = 1 - (budget["total_spent"] / budget["total_budget"])
+        budget_score = max(0, min(100, int(adherence * 100 + 50)))
+        scores.append(budget_score)
+
+    # 3. 지출 안정성 점수 (직전 3개월 변동계수)
+    stability_score: int | None = None
+    expenses = [t["expense"] for t in trend if t["expense"] > 0]
+    if len(expenses) >= 2:
+        mean = sum(expenses) / len(expenses)
+        if mean > 0:
+            variance = sum((x - mean) ** 2 for x in expenses) / len(expenses)
+            cv = (variance ** 0.5) / mean  # 변동계수
+            if cv <= 0.1:
+                stability_score = 100
+            elif cv <= 0.3:
+                stability_score = int(100 - (cv - 0.1) / 0.2 * 40)
+            else:
+                stability_score = max(0, int(60 - (cv - 0.3) / 0.7 * 60))
+            scores.append(stability_score)
+
+    overall = int(sum(scores) / len(scores)) if scores else 0
+
+    def grade(s: int) -> str:
+        if s >= 90: return "A+"
+        if s >= 80: return "A"
+        if s >= 70: return "B+"
+        if s >= 60: return "B"
+        if s >= 50: return "C+"
+        if s >= 40: return "C"
+        if s >= 30: return "D"
+        return "F"
+
+    return {
+        "savings_rate": savings_score,
+        "budget_adherence": budget_score,
+        "fixed_expense_ratio": None,  # 정기거래 비율 — 단계 2에서 보강
+        "spending_stability": stability_score,
+        "overall": overall,
+        "grade": grade(overall),
+    }
+```
+
+### Step 4: 테스트 통과 확인
+
+```bash
+cd backend && pytest tests/integration/test_report_data_builder.py -v
+```
+Expected: 3 passed
+
+### Step 5: 커밋
+
+```bash
+git add backend/app/services/report_data_builder.py \
+        backend/tests/integration/test_report_data_builder.py
+git commit -m "feat: 결산 리포트 데이터 집계 서비스 추가"
+```
+
+---
+
+## Task 6: Pydantic 스키마
+
+**Files:**
+- Create: `backend/app/schemas/monthly_report.py`
+
+### Step 1: 스키마 작성
+
+```python
+# backend/app/schemas/monthly_report.py
+"""월간 결산 리포트 Pydantic 스키마"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel
+
+from app.schemas.insights import StructuredInsightsResponse
+
+
+class MonthlyReportResponse(BaseModel):
+    """사용자 조회 API 응답"""
+    id: int
+    month: str
+    status: Literal["pending", "processing", "completed", "failed"]
+    insights: StructuredInsightsResponse | None
+    completed_at: datetime | None
+
+    model_config = {"from_attributes": True}
+
+
+class MonthlyReportListItem(BaseModel):
+    """리스트/카드 그리드용 (단계 2 대비)"""
+    month: str
+    status: Literal["pending", "processing", "completed", "failed"]
+    headline: str | None  # insights.findings[0].what 미리보기
+    completed_at: datetime | None
+
+    model_config = {"from_attributes": True}
+
+
+class MonthlyReportEligibility(BaseModel):
+    """자격 미달 시 사용자 안내 정보"""
+    has_profile: bool
+    transaction_count: int
+    transactions_needed: int
+    category_count: int
+    total_spend: float
+    is_eligible: bool
+    blocker: Literal[
+        "profile_missing",
+        "transactions_short",
+        "categories_short",
+        "spend_short",
+        "first_month",
+        None,
+    ]
+
+
+class MonthlyReportOrEligibility(BaseModel):
+    """리포트 없을 때 자격 정보를 함께 반환"""
+    report: MonthlyReportResponse | None
+    eligibility: MonthlyReportEligibility | None
+```
+
+### Step 2: 커밋
+
+```bash
+git add backend/app/schemas/monthly_report.py
+git commit -m "feat: 월간 결산 리포트 Pydantic 스키마 추가"
+```
+
+---
+
+## Task 7: report_generator 서비스
+
+**Files:**
+- Create: `backend/app/services/report_generator.py`
+- Create: `backend/tests/unit/test_report_generator.py`
+
+### Step 1: 실패 테스트 작성
+
+```python
+# backend/tests/unit/test_report_generator.py
+"""report_generator 단위 테스트"""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, patch
+import pytest
+
+from app.services.report_generator import mark_completed, mark_failed, _truncate_error
+
+
+def test_truncate_error_long_message():
+    long_msg = "x" * 3000
+    result = _truncate_error(long_msg)
+    assert len(result) <= 2000
+
+
+def test_truncate_error_short_message():
+    msg = "short error"
+    assert _truncate_error(msg) == msg
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_updates_status(db_session, test_household, test_user):
+    from app.models.monthly_report import MonthlyReport
+    report = MonthlyReport(
+        household_id=test_household.id,
+        month="2026-03",
+        status="processing",
+        report_data={},
+        attempt_count=1,
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    await mark_failed(db_session, report.id, "LLM timeout")
+    await db_session.refresh(report)
+
+    assert report.status == "failed"
+    assert "LLM timeout" in report.last_error
+```
+
+### Step 2: 테스트 실패 확인
+
+```bash
+cd backend && pytest tests/unit/test_report_generator.py -v
+```
+Expected: FAIL
+
+### Step 3: 구현
+
+```python
+# backend/app/services/report_generator.py
+"""LLM 호출 + MonthlyReport 상태 전이 서비스"""
+
+import asyncio
+import logging
+from datetime import datetime
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.household_profile import HouseholdProfile
+from app.models.monthly_report import MonthlyReport
+from app.services.llm_service import get_llm_provider
+from app.services.prompts import format_insights_data_for_llm
+
+logger = logging.getLogger(__name__)
+
+LLM_TIMEOUT_SECONDS = 30
+
+
+def _truncate_error(msg: str, max_len: int = 2000) -> str:
+    return msg[:max_len] if len(msg) > max_len else msg
+
+
+async def run_llm_for_report(
+    db: AsyncSession, report: MonthlyReport
+) -> None:
+    """LLM 호출 → 완료/실패 상태 저장"""
+    profile = await db.scalar(
+        __import__('sqlalchemy', fromlist=['select']).select(HouseholdProfile).where(
+            HouseholdProfile.household_id == report.household_id
+        )
+    )
+    formatted = format_insights_data_for_llm(report.report_data, profile)
+    llm = get_llm_provider("insights")
+
+    try:
+        structured = await asyncio.wait_for(
+            llm.generate_comprehensive_insights_v2(formatted),
+            timeout=LLM_TIMEOUT_SECONDS,
+        )
+        await mark_completed(db, report.id, structured.model_dump())
+        logger.info(
+            "[monthly-reports] llm_success household_id=%d month=%s",
+            report.household_id, report.month,
+        )
+    except Exception as e:
+        error_msg = _truncate_error(str(e))
+        await mark_failed(db, report.id, error_msg)
+        logger.warning(
+            "[monthly-reports] llm_failed household_id=%d month=%s error=%s",
+            report.household_id, report.month, error_msg,
+        )
+        raise
+
+
+async def mark_completed(
+    db: AsyncSession, report_id: int, insights: dict
+) -> None:
+    await db.execute(
+        update(MonthlyReport)
+        .where(MonthlyReport.id == report_id)
+        .values(
+            status="completed",
+            insights=insights,
+            completed_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+
+
+async def mark_failed(
+    db: AsyncSession, report_id: int, error: str
+) -> None:
+    await db.execute(
+        update(MonthlyReport)
+        .where(MonthlyReport.id == report_id)
+        .values(
+            status="failed",
+            last_error=error,
+        )
+    )
+    await db.commit()
+```
+
+**참고**: `select` import를 직접 쓰는 대신 `from sqlalchemy import select` 형태로 수정해야 함 (위 코드는 동작하지만 가독성이 나쁨). 구현 시 수정.
+
+### Step 4: 테스트 통과 확인
+
+```bash
+cd backend && pytest tests/unit/test_report_generator.py -v
+```
+Expected: 3 passed
+
+### Step 5: 커밋
+
+```bash
+git add backend/app/services/report_generator.py \
+        backend/tests/unit/test_report_generator.py
+git commit -m "feat: 결산 리포트 LLM 생성 + 상태 전이 서비스 추가"
+```
+
+---
+
+## Task 8: report_scheduler 서비스
+
+**Files:**
+- Create: `backend/app/services/report_scheduler.py`
+- Create: `backend/tests/integration/test_report_scheduler.py`
+
+### Step 1: 실패 테스트 작성
+
+```python
+# backend/tests/integration/test_report_scheduler.py
+"""report_scheduler 통합 테스트 (mock LLM)"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.models.expense import Expense
+from app.models.household_profile import HouseholdProfile
+from app.models.monthly_report import MonthlyReport
+from app.services.report_scheduler import phase1_enqueue_pending, recover_stale_processing
+from datetime import datetime, timedelta
+
+
+@pytest.mark.asyncio
+async def test_phase1_creates_pending_rows(
+    db_session, test_household, test_user
+):
+    """자격 통과 가구에 pending row가 생성된다"""
+    profile = HouseholdProfile(
+        household_id=test_household.id,
+        household_type="single", housing_type="monthly_rent",
+        income_types=["salary"], age_range="30s",
+    )
+    db_session.add(profile)
+    for i in range(15):
+        db_session.add(Expense(
+            household_id=test_household.id, user_id=test_user.id,
+            amount=20000, description=f"지출 {i}",
+            date=__import__('datetime').date(2026, 3, i + 1),
+            category_id=(i % 3) + 1,
+        ))
+    await db_session.commit()
+
+    count = await phase1_enqueue_pending(db_session, "2026-03")
+    assert count >= 1
+
+    report = await db_session.scalar(
+        select(MonthlyReport).where(
+            MonthlyReport.household_id == test_household.id,
+            MonthlyReport.month == "2026-03",
+        )
+    )
+    assert report is not None
+    assert report.status == "pending"
+    assert report.report_data != {}
+
+
+@pytest.mark.asyncio
+async def test_phase1_idempotent(db_session, test_household, test_user):
+    """두 번 호출해도 row는 하나만 생성된다"""
+    profile = HouseholdProfile(
+        household_id=test_household.id,
+        household_type="single", housing_type="monthly_rent",
+        income_types=["salary"], age_range="30s",
+    )
+    db_session.add(profile)
+    for i in range(15):
+        db_session.add(Expense(
+            household_id=test_household.id, user_id=test_user.id,
+            amount=20000, description=f"지출 {i}",
+            date=__import__('datetime').date(2026, 3, i + 1),
+            category_id=(i % 3) + 1,
+        ))
+    await db_session.commit()
+
+    await phase1_enqueue_pending(db_session, "2026-03")
+    await phase1_enqueue_pending(db_session, "2026-03")
+
+    rows = await db_session.scalars(
+        select(MonthlyReport).where(
+            MonthlyReport.household_id == test_household.id,
+            MonthlyReport.month == "2026-03",
+        )
+    )
+    assert len(list(rows)) == 1
+
+
+@pytest.mark.asyncio
+async def test_recover_stale_processing(db_session, test_household):
+    """processing 좀비 row가 pending으로 복구된다"""
+    stale = MonthlyReport(
+        household_id=test_household.id,
+        month="2026-03",
+        status="processing",
+        report_data={},
+        attempt_count=1,
+        started_at=datetime.utcnow() - timedelta(minutes=30),
+    )
+    db_session.add(stale)
+    await db_session.commit()
+
+    await recover_stale_processing(db_session, threshold_minutes=15)
+    await db_session.refresh(stale)
+
+    assert stale.status == "pending"
+```
+
+### Step 2: 테스트 실패 확인
+
+```bash
+cd backend && pytest tests/integration/test_report_scheduler.py -v
+```
+Expected: FAIL
+
+### Step 3: 구현
+
+```python
+# backend/app/services/report_scheduler.py
+"""월간 결산 리포트 스케줄러 — Phase 1/2 오케스트레이션"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+from sqlalchemy import insert, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.database import AsyncSessionLocal
+from app.models.monthly_report import MonthlyReport
+from app.services.report_data_builder import build_report_data
+from app.services.report_eligibility import find_eligible_households
+from app.services.report_generator import run_llm_for_report
+
+logger = logging.getLogger(__name__)
+
+
+async def phase1_enqueue_pending(
+    db: AsyncSession, month: str
+) -> int:
+    """자격 통과 가구의 report_data 집계 + pending row 일괄 생성
+
+    Returns:
+        생성된(또는 이미 존재하는) row 수
+    """
+    eligible_ids = await find_eligible_households(db, month)
+    logger.info(
+        "[monthly-reports] eligible_households count=%d month=%s",
+        len(eligible_ids), month,
+    )
+
+    created = 0
+    for hid in eligible_ids:
+        data = await build_report_data(db, hid, month)
+        # ON CONFLICT DO NOTHING — 멱등성 보장
+        result = await db.execute(
+            pg_insert(MonthlyReport)
+            .values(
+                household_id=hid,
+                month=month,
+                status="pending",
+                report_data=data,
+                trigger_source="auto",
+            )
+            .on_conflict_do_nothing(
+                index_elements=["household_id", "month"]
+            )
+        )
+        if result.rowcount:
+            created += 1
+
+    await db.commit()
+    logger.info("[monthly-reports] phase1_complete queued=%d month=%s", created, month)
+    return created
+
+
+async def recover_stale_processing(
+    db: AsyncSession, threshold_minutes: int = 15
+) -> None:
+    """processing 상태로 N분 이상 된 row를 pending으로 복구"""
+    cutoff = datetime.utcnow() - timedelta(minutes=threshold_minutes)
+    result = await db.execute(
+        update(MonthlyReport)
+        .where(
+            MonthlyReport.status == "processing",
+            MonthlyReport.started_at < cutoff,
+        )
+        .values(status="pending")
+    )
+    if result.rowcount:
+        logger.warning(
+            "[monthly-reports] recovered_stale count=%d", result.rowcount
+        )
+    await db.commit()
+
+
+async def _pick_next_pending(
+    db: AsyncSession, month: str
+) -> MonthlyReport | None:
+    """SELECT FOR UPDATE SKIP LOCKED로 원자적 픽업
+
+    NOTE: PostgreSQL 전용. SQLite 테스트 환경에서는 락 없이 동작.
+    """
+    report = await db.scalar(
+        select(MonthlyReport)
+        .where(
+            MonthlyReport.month == month,
+            MonthlyReport.status == "pending",
+            MonthlyReport.attempt_count < 3,
+        )
+        .order_by(MonthlyReport.id)
+        .limit(1)
+        .with_for_update(skip_locked=True)
+    )
+    if report:
+        report.status = "processing"
+        report.started_at = datetime.utcnow()
+        report.attempt_count += 1
+        await db.commit()
+    return report
+
+
+async def _process_one(month: str, sem: asyncio.Semaphore) -> None:
+    async with sem:
+        async with AsyncSessionLocal() as db:
+            report = await _pick_next_pending(db, month)
+            if not report:
+                return
+            try:
+                await run_llm_for_report(db, report)
+            except Exception:
+                pass  # mark_failed는 run_llm_for_report 내부에서 처리
+
+
+async def phase2_process_pending(month: str) -> None:
+    """pending row를 Semaphore(5)로 병렬 LLM 호출"""
+    # 먼저 좀비 복구
+    async with AsyncSessionLocal() as db:
+        await recover_stale_processing(db)
+
+    sem = asyncio.Semaphore(5)
+    max_tasks = settings.MONTHLY_REPORT_MAX_PER_RUN
+
+    tasks = [asyncio.create_task(_process_one(month, sem)) for _ in range(max_tasks)]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    completed = sum(1 for r in results if r is None)
+    failed = sum(1 for r in results if isinstance(r, Exception))
+    logger.info(
+        "[monthly-reports] phase2_complete completed=%d failed=%d month=%s",
+        completed, failed, month,
+    )
+```
+
+**참고**: SQLite 테스트 환경에서 `with_for_update(skip_locked=True)`는 지원되지 않는다. 통합 테스트에서 phase2는 `mock LLM`으로만 검증하고 실제 SKIP LOCKED 동작은 PostgreSQL에서만 확인한다.
+
+### Step 4: 테스트 통과 확인
+
+```bash
+cd backend && pytest tests/integration/test_report_scheduler.py -v
+```
+Expected: 3 passed
+
+### Step 5: 커밋
+
+```bash
+git add backend/app/services/report_scheduler.py \
+        backend/tests/integration/test_report_scheduler.py
+git commit -m "feat: 결산 리포트 Phase 1/2 스케줄러 서비스 추가"
+```
+
+---
+
+## Task 9: 내부 웹훅 API
+
+**Files:**
+- Modify: `backend/app/api/webhooks.py`
+- Create: `backend/tests/integration/test_api_reports_webhook.py`
+
+### Step 1: 실패 테스트 작성
+
+```python
+# backend/tests/integration/test_api_reports_webhook.py
+import hashlib
+import hmac
+import pytest
+from httpx import AsyncClient
+from unittest.mock import AsyncMock, patch
+
+from app.core.config import settings
+
+
+def _make_signature(secret: str) -> str:
+    return hmac.new(
+        secret.encode(), b"monthly-report-trigger", hashlib.sha256
+    ).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_webhook_rejects_missing_signature(authenticated_client: AsyncClient):
+    resp = await authenticated_client.post("/api/webhooks/monthly-reports")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_webhook_rejects_invalid_signature(authenticated_client: AsyncClient):
+    resp = await authenticated_client.post(
+        "/api/webhooks/monthly-reports",
+        headers={"x-webhook-signature": "invalid"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_webhook_accepts_valid_signature(authenticated_client: AsyncClient):
+    secret = "test-secret"  # pragma: allowlist secret
+    with (
+        patch.object(settings, "MONTHLY_REPORT_WEBHOOK_SECRET", secret),
+        patch.object(settings, "MONTHLY_REPORT_AUTO_ENABLED", True),
+        patch("app.api.webhooks.phase1_enqueue_pending", new=AsyncMock(return_value=3)),
+        patch("app.api.webhooks.phase2_process_pending"),
+    ):
+        resp = await authenticated_client.post(
+            "/api/webhooks/monthly-reports",
+            headers={"x-webhook-signature": _make_signature(secret)},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["queued"] == 3
+
+
+@pytest.mark.asyncio
+async def test_webhook_skips_when_disabled(authenticated_client: AsyncClient):
+    secret = "test-secret"  # pragma: allowlist secret
+    with (
+        patch.object(settings, "MONTHLY_REPORT_WEBHOOK_SECRET", secret),
+        patch.object(settings, "MONTHLY_REPORT_AUTO_ENABLED", False),
+    ):
+        resp = await authenticated_client.post(
+            "/api/webhooks/monthly-reports",
+            headers={"x-webhook-signature": _make_signature(secret)},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["skipped"] is True
+```
+
+### Step 2: 테스트 실패 확인
+
+```bash
+cd backend && pytest tests/integration/test_api_reports_webhook.py -v
+```
+Expected: FAIL
+
+### Step 3: `webhooks.py`에 엔드포인트 추가
+
+기존 `router` 아래에 추가:
+
+```python
+# backend/app/api/webhooks.py 하단에 추가
+from fastapi import BackgroundTasks
+from app.core.config import settings
+from app.core.webhook_auth import verify_monthly_report_webhook
+from app.core.database import get_db
+from app.services.report_month_utils import previous_month_kst
+from app.services.report_scheduler import phase1_enqueue_pending, phase2_process_pending
+
+
+@router.post("/monthly-reports")
+async def trigger_monthly_reports(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Supabase pg_cron이 매월 1일 호출하는 월간 결산 리포트 생성 트리거"""
+    verify_monthly_report_webhook(request)
+
+    if not settings.MONTHLY_REPORT_AUTO_ENABLED:
+        logger.info("[monthly-reports] 자동 실행 비활성화 (MONTHLY_REPORT_AUTO_ENABLED=false)")
+        return {"skipped": True, "reason": "auto_disabled"}
+
+    target_month = previous_month_kst()
+    queued = await phase1_enqueue_pending(db, target_month)
+
+    background_tasks.add_task(phase2_process_pending, target_month)
+
+    logger.info("[monthly-reports] cron_started month=%s queued=%d", target_month, queued)
+    return {"queued": queued, "month": target_month}
+```
+
+### Step 4: 테스트 통과 확인
+
+```bash
+cd backend && pytest tests/integration/test_api_reports_webhook.py -v
+```
+Expected: 4 passed
+
+### Step 5: 커밋
+
+```bash
+git add backend/app/api/webhooks.py \
+        backend/tests/integration/test_api_reports_webhook.py
+git commit -m "feat: 월간 결산 리포트 cron webhook 엔드포인트 추가"
+```
+
+---
+
+## Task 10: 사용자 조회 API
+
+**Files:**
+- Create: `backend/app/api/reports.py`
+- Create: `backend/tests/integration/test_api_reports.py`
+
+### Step 1: 실패 테스트 작성
+
+```python
+# backend/tests/integration/test_api_reports.py
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.monthly_report import MonthlyReport
+from app.schemas.insights import StructuredInsightsResponse
+
+
+@pytest.mark.asyncio
+async def test_get_monthly_report_completed(
+    authenticated_client: AsyncClient,
+    db_session: AsyncSession,
+    test_household,
+):
+    report = MonthlyReport(
+        household_id=test_household.id,
+        month="2026-03",
+        status="completed",
+        report_data={"expense_total": 100000},
+        insights={
+            "findings": [{"what": "식비가 늘었어요", "so_what": "외식 증가", "now_what": "줄이기"}],
+            "action_items": [{"title": "식비 절감", "description": "외식 줄이기"}],
+            "encouragement": "수고하셨어요",
+        },
+        insights_version=1,
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    resp = await authenticated_client.get(
+        "/api/reports/monthly",
+        params={"month": "2026-03"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report"]["status"] == "completed"
+    assert data["report"]["insights"] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_monthly_report_pending_returns_status(
+    authenticated_client: AsyncClient,
+    db_session: AsyncSession,
+    test_household,
+):
+    report = MonthlyReport(
+        household_id=test_household.id,
+        month="2026-03",
+        status="pending",
+        report_data={},
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    resp = await authenticated_client.get(
+        "/api/reports/monthly",
+        params={"month": "2026-03"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["report"]["status"] == "pending"
+    assert resp.json()["report"]["insights"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_monthly_report_not_found_returns_eligibility(
+    authenticated_client: AsyncClient,
+    db_session: AsyncSession,
+    test_household,
+):
+    """리포트 없으면 eligibility 정보 반환"""
+    resp = await authenticated_client.get(
+        "/api/reports/monthly",
+        params={"month": "2026-03"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report"] is None
+    assert data["eligibility"] is not None
+    assert "blocker" in data["eligibility"]
+```
+
+### Step 2: 테스트 실패 확인
+
+```bash
+cd backend && pytest tests/integration/test_api_reports.py -v
+```
+Expected: FAIL
+
+### Step 3: API 구현
+
+```python
+# backend/app/api/reports.py
+"""월간 결산 리포트 사용자 조회 API"""
+
+import logging
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import get_household_member, get_user_active_household_id
+from app.core.auth import get_current_user
+from app.core.database import get_db
+from app.models.monthly_report import MonthlyReport
+from app.models.user import User
+from app.schemas.monthly_report import (
+    MonthlyReportEligibility,
+    MonthlyReportOrEligibility,
+    MonthlyReportResponse,
+)
+from app.services.report_eligibility import check_household_eligibility
+from app.services.report_month_utils import previous_month_kst
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@router.get("/monthly", response_model=MonthlyReportOrEligibility)
+async def get_monthly_report(
+    month: str = Query(..., pattern=r"^\d{4}-\d{2}$"),
+    household_id: int | None = Query(None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> object:
+    """특정 월의 결산 리포트 조회
+
+    리포트가 없으면 자격 정보(eligibility)를 함께 반환한다.
+    """
+    if household_id is None:
+        household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)
+
+    report = await db.scalar(
+        select(MonthlyReport).where(
+            MonthlyReport.household_id == household_id,
+            MonthlyReport.month == month,
+        )
+    )
+
+    if report:
+        return MonthlyReportOrEligibility(
+            report=MonthlyReportResponse.model_validate(report),
+            eligibility=None,
+        )
+
+    # 리포트 없음 → 자격 정보 반환
+    eligibility = await check_household_eligibility(db, household_id, month)
+    return MonthlyReportOrEligibility(
+        report=None,
+        eligibility=MonthlyReportEligibility(
+            has_profile=eligibility.has_profile,
+            transaction_count=eligibility.transaction_count,
+            transactions_needed=eligibility.transactions_needed,
+            category_count=eligibility.category_count,
+            total_spend=eligibility.total_spend,
+            is_eligible=eligibility.is_eligible,
+            blocker=eligibility.blocker,
+        ),
+    )
+
+
+@router.get("/latest", response_model=MonthlyReportOrEligibility)
+async def get_latest_report(
+    household_id: int | None = Query(None),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> object:
+    """직전 마감 월의 결산 리포트 조회 (모아보기 상단 카드용)"""
+    if household_id is None:
+        household_id = await get_user_active_household_id(current_user, db)
+    await get_household_member(household_id, current_user, db)
+
+    prev_month = previous_month_kst()
+
+    report = await db.scalar(
+        select(MonthlyReport).where(
+            MonthlyReport.household_id == household_id,
+            MonthlyReport.month == prev_month,
+            MonthlyReport.status == "completed",
+        )
+    )
+
+    if report:
+        return MonthlyReportOrEligibility(
+            report=MonthlyReportResponse.model_validate(report),
+            eligibility=None,
+        )
+
+    eligibility = await check_household_eligibility(db, household_id, prev_month)
+    return MonthlyReportOrEligibility(
+        report=None,
+        eligibility=MonthlyReportEligibility(
+            has_profile=eligibility.has_profile,
+            transaction_count=eligibility.transaction_count,
+            transactions_needed=eligibility.transactions_needed,
+            category_count=eligibility.category_count,
+            total_spend=eligibility.total_spend,
+            is_eligible=eligibility.is_eligible,
+            blocker=eligibility.blocker,
+        ),
+    )
+```
+
+### Step 4: 테스트 통과 확인
+
+```bash
+cd backend && pytest tests/integration/test_api_reports.py -v
+```
+Expected: 3 passed
+
+### Step 5: 커밋
+
+```bash
+git add backend/app/api/reports.py \
+        backend/tests/integration/test_api_reports.py
+git commit -m "feat: 월간 결산 리포트 사용자 조회 API 추가"
+```
+
+---
+
+## Task 11: Admin API + main.py 라우터 등록
+
+**Files:**
+- Modify: `backend/app/api/admin.py`
+- Modify: `backend/app/main.py`
+
+### Step 1: admin.py에 retry/manual-trigger 추가
+
+기존 `admin.py` 하단에 추가:
+
+```python
+# backend/app/api/admin.py 하단에 추가
+
+from app.models.monthly_report import MonthlyReport
+from app.services.report_scheduler import phase1_enqueue_pending, phase2_process_pending
+
+
+@router.post("/reports/{report_id}/retry", status_code=200)
+async def retry_report(
+    report_id: int,
+    background_tasks: BackgroundTasks,
+    _admin: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """failed/pending 상태 리포트 LLM 재시도"""
+    from sqlalchemy import select
+    report = await db.scalar(
+        select(MonthlyReport).where(MonthlyReport.id == report_id)
+    )
+    if not report:
+        raise HTTPException(status_code=404, detail="리포트를 찾을 수 없습니다")
+    if report.status not in ("failed", "pending"):
+        raise HTTPException(status_code=400, detail=f"재시도 불가 상태: {report.status}")
+
+    report.status = "pending"
+    report.attempt_count = 0
+    await db.commit()
+
+    background_tasks.add_task(phase2_process_pending, report.month)
+    return {"id": report_id, "status": "retrying"}
+
+
+@router.post("/reports/manual-trigger", status_code=200)
+async def manual_trigger_reports(
+    month: str = Query(..., pattern=r"^\d{4}-\d{2}$"),
+    background_tasks: BackgroundTasks,
+    _admin: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """특정 월 결산 리포트 수동 생성 (디버깅/초기 배포용)"""
+    queued = await phase1_enqueue_pending(db, month)
+    background_tasks.add_task(phase2_process_pending, month)
+    return {"queued": queued, "month": month}
+```
+
+### Step 2: main.py에 reports 라우터 등록
+
+`backend/app/main.py`에서 기존 `app.include_router(insights.router, ...)` 아래에 추가:
+
+```python
+from app.api import reports  # 상단 import 블록에 추가
+
+# include_router 블록에 추가
+app.include_router(reports.router, prefix="/api/reports", tags=["reports"])
+```
+
+### Step 3: 전체 테스트 통과 확인
+
+```bash
+cd backend && pytest -x -q
+```
+Expected: 모든 기존 테스트 포함 통과
+
+### Step 4: 커밋
+
+```bash
+git add backend/app/api/admin.py backend/app/main.py
+git commit -m "feat: 결산 리포트 Admin API + 라우터 등록"
+```
+
+---
+
+## Task 12: 프론트엔드 타입 + API 클라이언트 + MSW 핸들러
+
+**Files:**
+- Create: `frontend/src/types/report.ts`
+- Create: `frontend/src/api/reports.ts`
+- Modify: `frontend/src/mocks/handlers.ts`
+
+### Step 1: 타입 정의
+
+```typescript
+// frontend/src/types/report.ts
+import type { StructuredInsights } from './index'
+
+export type ReportStatus = 'pending' | 'processing' | 'completed' | 'failed'
+
+export type ReportBlocker =
+  | 'profile_missing'
+  | 'transactions_short'
+  | 'categories_short'
+  | 'spend_short'
+  | 'first_month'
+  | null
+
+export interface MonthlyReport {
+  id: number
+  month: string
+  status: ReportStatus
+  insights: StructuredInsights | null
+  completed_at: string | null
+}
+
+export interface ReportEligibility {
+  has_profile: boolean
+  transaction_count: number
+  transactions_needed: number
+  category_count: number
+  total_spend: number
+  is_eligible: boolean
+  blocker: ReportBlocker
+}
+
+export interface MonthlyReportOrEligibility {
+  report: MonthlyReport | null
+  eligibility: ReportEligibility | null
+}
+```
+
+### Step 2: API 클라이언트
+
+```typescript
+// frontend/src/api/reports.ts
+import type { MonthlyReportOrEligibility } from '../types/report'
+import api from './client'  // 기존 axios 인스턴스
+
+export const reportsApi = {
+  async getMonthly(
+    month: string,
+    householdId?: number
+  ): Promise<MonthlyReportOrEligibility> {
+    const params: Record<string, unknown> = { month }
+    if (householdId) params.household_id = householdId
+    const res = await api.get('/reports/monthly', { params })
+    return res.data
+  },
+
+  async getLatest(
+    householdId?: number
+  ): Promise<MonthlyReportOrEligibility> {
+    const params: Record<string, unknown> = {}
+    if (householdId) params.household_id = householdId
+    const res = await api.get('/reports/latest', { params })
+    return res.data
+  },
+}
+```
+
+**참고**: 기존 API 클라이언트 인스턴스 파일 경로(`api/client.ts` 또는 `api/index.ts`)를 확인 후 import 경로 수정.
+
+### Step 3: MSW 핸들러 추가
+
+`frontend/src/mocks/handlers.ts`에서 기존 핸들러 배열에 추가:
+
+```typescript
+import { http, HttpResponse } from 'msw'
+
+// handlers 배열에 추가
+http.get('/api/reports/monthly', () => {
+  return HttpResponse.json({
+    report: {
+      id: 1,
+      month: '2026-03',
+      status: 'completed',
+      insights: {
+        findings: [
+          { what: '식비가 23% 늘었어요', so_what: '외식이 증가했어요', now_what: '주 2회로 줄여보세요' }
+        ],
+        action_items: [
+          { title: '식비 절감', description: '외식 주 2회 제한' }
+        ],
+        encouragement: '이번 달도 수고하셨어요',
+      },
+      completed_at: '2026-04-01T03:30:00Z',
+    },
+    eligibility: null,
+  })
+}),
+
+http.get('/api/reports/latest', () => {
+  return HttpResponse.json({
+    report: {
+      id: 1,
+      month: '2026-03',
+      status: 'completed',
+      insights: {
+        findings: [
+          { what: '식비가 23% 늘었어요', so_what: '외식이 증가했어요', now_what: '주 2회로 줄여보세요' }
+        ],
+        action_items: [
+          { title: '식비 절감', description: '외식 주 2회 제한' }
+        ],
+        encouragement: '이번 달도 수고하셨어요',
+      },
+      completed_at: '2026-04-01T03:30:00Z',
+    },
+    eligibility: null,
+  })
+}),
+```
+
+### Step 4: 빌드 확인
+
+```bash
+cd frontend && npm run build
+```
+Expected: 빌드 오류 없음
+
+### Step 5: 커밋
+
+```bash
+git add frontend/src/types/report.ts \
+        frontend/src/api/reports.ts \
+        frontend/src/mocks/handlers.ts
+git commit -m "feat: 결산 리포트 프론트엔드 타입 + API 클라이언트 + MSW 핸들러 추가"
+```
+
+---
+
+## Task 13: ReportEmptyState 컴포넌트
+
+**Files:**
+- Create: `frontend/src/components/reports/ReportEmptyState.tsx`
+- Create: `frontend/src/components/reports/__tests__/ReportEmptyState.test.tsx`
+
+### Step 1: 실패 테스트 작성
+
+```typescript
+// frontend/src/components/reports/__tests__/ReportEmptyState.test.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import ReportEmptyState from '../ReportEmptyState'
+import type { ReportEligibility } from '../../../types/report'
+
+const baseEligibility: ReportEligibility = {
+  has_profile: true,
+  transaction_count: 8,
+  transactions_needed: 7,
+  category_count: 2,
+  total_spend: 80000,
+  is_eligible: false,
+  blocker: 'transactions_short',
+}
+
+describe('ReportEmptyState', () => {
+  it('거래 부족 시 이번 달 N건 이상 안내가 표시된다', () => {
+    render(<ReportEmptyState eligibility={baseEligibility} />)
+    expect(screen.getByText(/15건 이상/)).toBeInTheDocument()
+  })
+
+  it('프로필 미완성 시 프로필 완성 안내가 표시된다', () => {
+    render(
+      <ReportEmptyState
+        eligibility={{ ...baseEligibility, has_profile: false, blocker: 'profile_missing' }}
+      />
+    )
+    expect(screen.getByText(/프로필/)).toBeInTheDocument()
+  })
+
+  it('첫 달 가입 시 다음달 안내가 표시된다', () => {
+    render(
+      <ReportEmptyState
+        eligibility={{ ...baseEligibility, blocker: 'first_month' }}
+      />
+    )
+    expect(screen.getByText(/다음 달/)).toBeInTheDocument()
+  })
+
+  it('eligibility null이면 기본 안내 표시', () => {
+    render(<ReportEmptyState eligibility={null} />)
+    expect(screen.getByText(/결산 리포트/)).toBeInTheDocument()
+  })
+})
+```
+
+### Step 2: 테스트 실패 확인
+
+```bash
+cd frontend && npm test -- ReportEmptyState --run
+```
+Expected: FAIL
+
+### Step 3: 컴포넌트 구현
+
+```tsx
+// frontend/src/components/reports/ReportEmptyState.tsx
+import type { ReportEligibility } from '../../types/report'
+import { useNavigate } from 'react-router-dom'
+
+interface Props {
+  eligibility: ReportEligibility | null
+}
+
+export default function ReportEmptyState({ eligibility }: Props) {
+  const navigate = useNavigate()
+
+  const { title, description, ctaLabel, ctaPath } = resolveContent(eligibility)
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-8 px-4 text-center">
+      <span className="text-4xl">📬</span>
+      <div className="space-y-1.5">
+        <p className="font-semibold text-[var(--text-primary)]">{title}</p>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed">{description}</p>
+      </div>
+      {ctaLabel && (
+        <button
+          onClick={() => navigate(ctaPath!)}
+          className="mt-2 text-sm text-grape-600 font-medium underline underline-offset-2"
+        >
+          {ctaLabel} →
+        </button>
+      )}
+    </div>
+  )
+}
+
+function resolveContent(eligibility: ReportEligibility | null) {
+  if (!eligibility) {
+    return {
+      title: '결산 리포트를 준비 중이에요',
+      description: '매달 1일에 지난 달 결산 리포트가 자동으로 도착해요.',
+      ctaLabel: null,
+      ctaPath: null,
+    }
+  }
+
+  switch (eligibility.blocker) {
+    case 'profile_missing':
+      return {
+        title: '가구 프로필을 완성해주세요',
+        description: '프로필을 완성하면 개인화된 결산 리포트를 다음 달 1일에 받아보실 수 있어요.',
+        ctaLabel: '프로필 완성하기',
+        ctaPath: '/settings',
+      }
+    case 'transactions_short':
+      return {
+        title: '다음 달부터 결산 리포트를 받아보세요',
+        description: `이번 달 거래를 15건 이상 입력하시면 다음 달 1일에 결산 리포트가 도착해요. (현재 ${eligibility.transaction_count}건)`,
+        ctaLabel: '거래 입력하기',
+        ctaPath: '/home',
+      }
+    case 'first_month':
+      return {
+        title: '첫 결산 리포트가 준비 중이에요',
+        description: '다음 달 1일에 첫 결산 리포트가 도착해요. 그동안 거래를 입력해주세요.',
+        ctaLabel: '거래 입력하기',
+        ctaPath: '/home',
+      }
+    default:
+      return {
+        title: '이번 달은 결산 리포트가 없어요',
+        description: '거래를 꾸준히 입력하시면 다음 달부터 결산 리포트를 받아보실 수 있어요.',
+        ctaLabel: null,
+        ctaPath: null,
+      }
+  }
+}
+```
+
+### Step 4: 테스트 통과 확인
+
+```bash
+cd frontend && npm test -- ReportEmptyState --run
+```
+Expected: 4 passed
+
+### Step 5: 커밋
+
+```bash
+git add frontend/src/components/reports/ReportEmptyState.tsx \
+        frontend/src/components/reports/__tests__/ReportEmptyState.test.tsx
+git commit -m "feat: ReportEmptyState 컴포넌트 추가"
+```
+
+---
+
+## Task 14: ReportPendingState + MonthlyReportCard
+
+**Files:**
+- Create: `frontend/src/components/reports/ReportPendingState.tsx`
+- Create: `frontend/src/components/reports/MonthlyReportCard.tsx`
+- Create: 각 `__tests__/*.test.tsx`
+
+### Step 1: ReportPendingState 구현
+
+```tsx
+// frontend/src/components/reports/ReportPendingState.tsx
+export default function ReportPendingState() {
+  return (
+    <div className="flex flex-col items-center gap-3 py-8 px-4 text-center">
+      <span className="text-4xl animate-bounce">📬</span>
+      <p className="font-semibold text-[var(--text-primary)]">결산 리포트를 준비하고 있어요</p>
+      <p className="text-sm text-[var(--text-secondary)]">잠시 후 자동으로 업데이트돼요</p>
+    </div>
+  )
+}
+```
+
+### Step 2: ReportPendingState 테스트
+
+```typescript
+// frontend/src/components/reports/__tests__/ReportPendingState.test.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import ReportPendingState from '../ReportPendingState'
+
+describe('ReportPendingState', () => {
+  it('준비 중 메시지가 표시된다', () => {
+    render(<ReportPendingState />)
+    expect(screen.getByText(/준비하고 있어요/)).toBeInTheDocument()
+  })
+})
+```
+
+### Step 3: MonthlyReportCard 테스트 작성
+
+```typescript
+// frontend/src/components/reports/__tests__/MonthlyReportCard.test.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import MonthlyReportCard from '../MonthlyReportCard'
+
+// MSW 서버 설정 (server는 setup.ts에서 전역 설정됨)
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </QueryClientProvider>
+)
+
+vi.mock('../../../stores/useHouseholdStore', () => ({
+  useHouseholdStore: (selector?: Function) => {
+    const state = { activeHouseholdId: 1 }
+    return selector ? selector(state) : state
+  },
+}))
+
+describe('MonthlyReportCard', () => {
+  it('completed 리포트가 있으면 카드 헤드라인이 표시된다', async () => {
+    render(<MonthlyReportCard />, { wrapper })
+    expect(await screen.findByText(/식비가 23% 늘었어요/)).toBeInTheDocument()
+  })
+})
+```
+
+### Step 4: MonthlyReportCard 구현
+
+```tsx
+// frontend/src/components/reports/MonthlyReportCard.tsx
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { ChevronRight } from 'lucide-react'
+import { reportsApi } from '../../api/reports'
+import { useHouseholdStore } from '../../stores/useHouseholdStore'
+import ReportEmptyState from './ReportEmptyState'
+import ReportPendingState from './ReportPendingState'
+
+export default function MonthlyReportCard() {
+  const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['report-latest', activeHouseholdId],
+    queryFn: () => reportsApi.getLatest(activeHouseholdId ?? undefined),
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: (query) => {
+      const status = query.state.data?.report?.status
+      return status === 'pending' || status === 'processing' ? 30_000 : false
+    },
+  })
+
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl bg-[var(--surface-elevated)] p-4 animate-pulse h-24" />
+    )
+  }
+
+  if (!data?.report) {
+    return <ReportEmptyState eligibility={data?.eligibility ?? null} />
+  }
+
+  const { report } = data
+
+  if (report.status !== 'completed') {
+    return <ReportPendingState />
+  }
+
+  const headline = report.insights?.findings?.[0]?.what ?? ''
+  const monthLabel = formatMonthLabel(report.month)
+
+  return (
+    <Link
+      to={`/insights/reports/${report.month}`}
+      className="block rounded-2xl bg-gradient-to-br from-grape-50 to-grape-100 border border-grape-200 p-4 space-y-2 hover:opacity-90 transition-opacity"
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-grape-500">📬 {monthLabel} 결산 리포트</span>
+        <ChevronRight className="w-4 h-4 text-grape-400" />
+      </div>
+      <p className="text-sm font-semibold text-[var(--text-primary)] line-clamp-2">{headline}</p>
+      <p className="text-xs text-[var(--text-tertiary)]">
+        {report.completed_at ? formatRelative(report.completed_at) + '에 도착' : ''}
+      </p>
+    </Link>
+  )
+}
+
+function formatMonthLabel(month: string): string {
+  const [year, m] = month.split('-')
+  return `${year}년 ${parseInt(m)}월호`
+}
+
+function formatRelative(dateStr: string): string {
+  const d = new Date(dateStr)
+  const now = new Date()
+  const diffDays = Math.floor((now.getTime() - d.getTime()) / (1000 * 60 * 60 * 24))
+  if (diffDays === 0) return '오늘'
+  if (diffDays === 1) return '어제'
+  return `${diffDays}일 전`
+}
+```
+
+### Step 5: 테스트 통과 확인
+
+```bash
+cd frontend && npm test -- ReportPendingState ReportEmptyState MonthlyReportCard --run
+```
+Expected: 전체 통과
+
+### Step 6: 커밋
+
+```bash
+git add frontend/src/components/reports/
+git commit -m "feat: ReportPendingState + MonthlyReportCard 컴포넌트 추가"
+```
+
+---
+
+## Task 15: ReportContent + ReportDetailPage
+
+**Files:**
+- Create: `frontend/src/components/reports/ReportContent.tsx`
+- Create: `frontend/src/pages/ReportDetailPage.tsx`
+- Create: `frontend/src/pages/__tests__/ReportDetailPage.test.tsx`
+
+### Step 1: ReportContent 구현
+
+기존 `StructuredInsightsView`를 잡지형 레이아웃으로 재구성. 상세 페이지 전용이므로 타이포그래피를 키운다.
+
+```tsx
+// frontend/src/components/reports/ReportContent.tsx
+import { Lightbulb, Target } from 'lucide-react'
+import type { StructuredInsights } from '../../types'
+
+interface Props {
+  insights: StructuredInsights
+  month: string
+  completedAt: string | null
+}
+
+export default function ReportContent({ insights, month, completedAt }: Props) {
+  const [year, m] = month.split('-')
+  const monthLabel = `${year}년 ${parseInt(m)}월호`
+  const dateLabel = completedAt
+    ? new Date(completedAt).toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })
+    : ''
+
+  return (
+    <article className="max-w-[640px] mx-auto px-4 pb-16 space-y-12">
+      {/* 표지 헤더 */}
+      <header className="pt-6 space-y-3">
+        <p className="text-xs text-[var(--text-muted)] font-medium tracking-wider uppercase">
+          {monthLabel}
+        </p>
+        {insights.findings[0] && (
+          <h1 className="text-3xl font-bold text-[var(--text-primary)] leading-snug">
+            {insights.findings[0].what}
+          </h1>
+        )}
+        {dateLabel && (
+          <p className="text-sm text-[var(--text-tertiary)]">📬 {dateLabel}에 도착</p>
+        )}
+        <div className="h-px bg-gradient-to-r from-grape-300 to-transparent" />
+      </header>
+
+      {/* 격려 메시지 */}
+      {insights.encouragement && (
+        <blockquote className="border-l-4 border-grape-400 pl-4">
+          <p className="text-lg text-[var(--text-secondary)] leading-relaxed italic">
+            {insights.encouragement}
+          </p>
+        </blockquote>
+      )}
+
+      {/* 핵심 발견 */}
+      <section className="space-y-8">
+        <h2 className="flex items-center gap-2 text-sm font-bold text-[var(--text-tertiary)] uppercase tracking-wider">
+          <Lightbulb className="w-4 h-4 text-grape-500" />
+          핵심 발견
+        </h2>
+        {insights.findings.map((f, i) => (
+          <div key={i} className="space-y-3">
+            <h3 className="text-xl font-semibold text-[var(--text-primary)] leading-snug">
+              {i + 1}. {f.what}
+            </h3>
+            <p className="text-base text-[var(--text-secondary)] leading-relaxed">
+              {f.so_what}
+            </p>
+            <div className="bg-leaf-50 rounded-xl p-4">
+              <p className="text-sm text-leaf-700 font-medium">
+                → {f.now_what}
+              </p>
+            </div>
+            {i < insights.findings.length - 1 && (
+              <div className="h-px bg-[var(--border-subtle)] mt-4" />
+            )}
+          </div>
+        ))}
+      </section>
+
+      {/* 이번 달 액션 */}
+      <section className="space-y-4">
+        <h2 className="flex items-center gap-2 text-sm font-bold text-[var(--text-tertiary)] uppercase tracking-wider">
+          <Target className="w-4 h-4 text-grape-500" />
+          이번 달 액션
+        </h2>
+        <div className="space-y-3">
+          {insights.action_items.map((item, i) => (
+            <div key={i} className="flex gap-3 items-start">
+              <span className="shrink-0 w-6 h-6 rounded-full bg-grape-100 text-grape-600 text-sm font-bold flex items-center justify-center mt-0.5">
+                {i + 1}
+              </span>
+              <div>
+                <p className="text-base font-semibold text-[var(--text-primary)]">{item.title}</p>
+                <p className="text-sm text-[var(--text-secondary)] leading-relaxed mt-0.5">
+                  {item.description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* 참고 사항 */}
+      <p className="text-xs text-[var(--text-muted)] leading-relaxed border-t border-[var(--border-subtle)] pt-4">
+        ⓘ 이 정보는 일반적인 재무 정보이며, 개인 맞춤 투자 자문이 아닙니다. 투자 결정은 전문가와 상담하세요.
+      </p>
+    </article>
+  )
+}
+```
+
+### Step 2: ReportDetailPage 구현
+
+```tsx
+// frontend/src/pages/ReportDetailPage.tsx
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { ChevronLeft } from 'lucide-react'
+import { reportsApi } from '../api/reports'
+import { useHouseholdStore } from '../stores/useHouseholdStore'
+import ReportContent from '../components/reports/ReportContent'
+import ReportEmptyState from '../components/reports/ReportEmptyState'
+import ReportPendingState from '../components/reports/ReportPendingState'
+
+export default function ReportDetailPage() {
+  const { month } = useParams<{ month: string }>()
+  const navigate = useNavigate()
+  const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['report', activeHouseholdId, month],
+    queryFn: () => reportsApi.getMonthly(month!, activeHouseholdId ?? undefined),
+    enabled: !!month,
+    staleTime: 5 * 60 * 1000,
+    refetchInterval: (query) => {
+      const status = query.state.data?.report?.status
+      return status === 'pending' || status === 'processing' ? 30_000 : false
+    },
+  })
+
+  return (
+    <div className="min-h-screen bg-[var(--bg-primary)]">
+      {/* 네비게이션 헤더 */}
+      <div className="sticky top-0 z-10 bg-[var(--bg-primary)] border-b border-[var(--border-subtle)] px-4 py-3 flex items-center gap-2">
+        <button
+          onClick={() => navigate('/insights')}
+          className="flex items-center gap-1 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+        >
+          <ChevronLeft className="w-4 h-4" />
+          모아보기로
+        </button>
+      </div>
+
+      {/* 콘텐츠 */}
+      {isLoading ? (
+        <div className="max-w-[640px] mx-auto px-4 pt-8 space-y-4 animate-pulse">
+          <div className="h-6 bg-[var(--surface-elevated)] rounded w-24" />
+          <div className="h-10 bg-[var(--surface-elevated)] rounded w-3/4" />
+          <div className="h-4 bg-[var(--surface-elevated)] rounded w-1/3" />
+        </div>
+      ) : !data?.report ? (
+        <div className="max-w-[640px] mx-auto">
+          <ReportEmptyState eligibility={data?.eligibility ?? null} />
+        </div>
+      ) : data.report.status !== 'completed' ? (
+        <div className="max-w-[640px] mx-auto">
+          <ReportPendingState />
+        </div>
+      ) : (
+        <ReportContent
+          insights={data.report.insights!}
+          month={data.report.month}
+          completedAt={data.report.completed_at}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+### Step 3: ReportDetailPage 테스트
+
+```typescript
+// frontend/src/pages/__tests__/ReportDetailPage.test.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import ReportDetailPage from '../ReportDetailPage'
+
+vi.mock('../../stores/useHouseholdStore', () => ({
+  useHouseholdStore: (selector?: Function) => {
+    const state = { activeHouseholdId: 1 }
+    return selector ? selector(state) : state
+  },
+}))
+
+const wrapper = ({ month }: { month: string }) => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    <MemoryRouter initialEntries={[`/insights/reports/${month}`]}>
+      <Routes>
+        <Route path="/insights/reports/:month" element={<ReportDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+describe('ReportDetailPage', () => {
+  it('completed 리포트의 핵심 발견이 표시된다', async () => {
+    const { container } = render(wrapper({ month: '2026-03' }) as any)
+    // MSW 핸들러가 completed 리포트 반환
+    expect(await screen.findByText(/식비가 23% 늘었어요/)).toBeInTheDocument()
+  })
+
+  it('뒤로가기 버튼이 있다', async () => {
+    render(wrapper({ month: '2026-03' }) as any)
+    expect(await screen.findByText(/모아보기로/)).toBeInTheDocument()
+  })
+})
+```
+
+### Step 4: 테스트 통과 확인
+
+```bash
+cd frontend && npm test -- ReportDetailPage --run
+```
+Expected: 2 passed
+
+### Step 5: 커밋
+
+```bash
+git add frontend/src/components/reports/ReportContent.tsx \
+        frontend/src/pages/ReportDetailPage.tsx \
+        frontend/src/pages/__tests__/ReportDetailPage.test.tsx
+git commit -m "feat: ReportContent + ReportDetailPage 추가"
+```
+
+---
+
+## Task 16: InsightsPage 수정 + App.tsx 라우트
+
+**Files:**
+- Modify: `frontend/src/pages/InsightsPage.tsx`
+- Modify: `frontend/src/App.tsx`
+
+### Step 1: InsightsPage에서 AI 섹션 교체
+
+**제거할 코드** (정확한 라인 확인 후):
+- Line 156: `const [structuredInsights, setStructuredInsights] = useState<StructuredInsights | null>(null)`
+- Line 157: `const [aiLoading, setAiLoading] = useState(false)`
+- `generateInsights` 함수 전체
+- `insightsApi` import (다른 곳에서 쓰이면 유지)
+- Lines 744~780: AI 분석 섹션 전체 (분석하기 버튼, 스피너, StructuredInsightsView)
+
+**추가할 코드**:
+
+```tsx
+// InsightsPage.tsx 상단 import에 추가
+import MonthlyReportCard from '../components/reports/MonthlyReportCard'
+
+// AI 섹션 자리 (sectionVisibility.ai 블록) 대신:
+{sectionVisibility.ai && (
+  <section>
+    <SectionHeader title="결산 리포트" />
+    <MonthlyReportCard />
+  </section>
+)}
+```
+
+**Hero 직후**에 MonthlyReportCard 배치:
+```tsx
+// HeroSummary 컴포넌트 바로 다음에 추가
+<MonthlyReportCard />
+```
+
+정확한 삽입 위치는 InsightsPage.tsx를 읽고 HeroSummary 렌더링 이후 지점을 확인.
+
+### Step 2: App.tsx 라우트 추가
+
+```tsx
+// frontend/src/App.tsx
+// 기존 import 블록에 추가
+import ReportDetailPage from './pages/ReportDetailPage'
+
+// '/insights' 라우트 아래에 추가 (같은 레이아웃 안에서)
+<Route path="/insights/reports/:month" element={<ReportDetailPage />} />
+```
+
+기존 `<Route path="/insights" element={<InsightsPage />} />`는 유지.
+
+### Step 3: 전체 프론트엔드 테스트 + 빌드
+
+```bash
+cd frontend && npm run lint && npm run test:run && npm run build
+```
+Expected: 모두 통과
+
+### Step 4: 커밋
+
+```bash
+git add frontend/src/pages/InsightsPage.tsx \
+        frontend/src/App.tsx
+git commit -m "feat: InsightsPage AI 분석 → MonthlyReportCard 교체 + 라우트 추가"
+```
+
+---
+
+## Task 17: Supabase pg_cron 설정 (수동 작업)
+
+이 태스크는 코드가 아닌 Supabase 대시보드에서 수행한다.
+
+### Step 1: Supabase SQL Editor에서 익스텐션 활성화
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+```
+
+### Step 2: Vault에 시크릿 저장
+
+```sql
+SELECT vault.create_secret(
+  'your-actual-webhook-secret-here',
+  'monthly_report_webhook_secret'
+);
+```
+
+Fly.io 환경변수 `MONTHLY_REPORT_WEBHOOK_SECRET`에 동일 값 설정.
+
+### Step 3: cron job 등록 (운영 환경용)
+
+```sql
+-- Primary: 매월 1일 18:00 UTC (= KST 03:00)
+SELECT cron.schedule(
+  'monthly-reports-primary',
+  '0 18 1 * *',
+  $$
+  SELECT net.http_post(
+    url := 'https://podo-budget-backend.fly.dev/api/webhooks/monthly-reports',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-webhook-signature',
+      (SELECT decrypted_secret FROM vault.decrypted_secrets
+       WHERE name = 'monthly_report_webhook_secret')
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);
+
+-- Retry 1: 18:30 UTC
+SELECT cron.schedule(
+  'monthly-reports-retry-1',
+  '30 18 1 * *',
+  $$ ... (동일 내용) $$
+);
+
+-- Retry 2: 21:00 UTC
+SELECT cron.schedule(
+  'monthly-reports-retry-2',
+  '0 21 1 * *',
+  $$ ... (동일 내용) $$
+);
+```
+
+### Step 4: 첫 배포 후 이전 달 리포트 수동 생성
+
+```bash
+# 운영 환경에서 직전 달(예: 2026-03) 일괄 생성
+curl -X POST "https://podo-budget-backend.fly.dev/api/admin/reports/manual-trigger?month=2026-03" \
+  -H "Authorization: Bearer <admin-token>"
+```
+
+---
+
+## 전체 테스트 체크리스트
+
+```bash
+# 백엔드 전체
+cd backend && pytest -v
+
+# 프론트엔드 전체
+cd frontend && npm run lint && npm run test:run && npm run build
+```
+
+모든 기존 테스트가 깨지지 않아야 한다.
+
+---
+
+## PR 체크리스트
+
+- [ ] `MONTHLY_REPORT_AUTO_ENABLED=false` (dev), `true` (prod) 확인
+- [ ] `MONTHLY_REPORT_WEBHOOK_SECRET` Fly.io 환경변수 설정 완료
+- [ ] Supabase Vault 시크릿 저장 완료
+- [ ] pg_cron job 3개 등록 완료 (primary + retry 2)
+- [ ] admin manual-trigger로 직전 달 리포트 배치 생성 완료
+- [ ] `InsightsPage.tsx`에서 AI 분석 섹션 잔여 코드 없음 확인
+- [ ] `StructuredInsightsView`가 여전히 import되어 있는지 확인 (미사용이면 제거)
+- [ ] PR body에 `close #이슈번호` 포함

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ const LandingPage = lazy(() => import('./pages/LandingPage'))
 const FeedbackPage = lazy(() => import('./pages/FeedbackPage'))
 const AdminPage = lazy(() => import('./pages/AdminPage'))
 const OnboardingPage = lazy(() => import('./pages/OnboardingPage'))
+const ReportDetailPage = lazy(() => import('./pages/ReportDetailPage'))
 
 /* /transactions → /home 쿼리 보존 리다이렉트 */
 function TransactionsRedirect() {
@@ -105,6 +106,7 @@ function App() {
             <Route path="/budgets" element={<BudgetManager />} />
             <Route path="/recurring" element={<RecurringList />} />
             <Route path="/insights" element={<InsightsPage />} />
+            <Route path="/insights/reports/:month" element={<ReportDetailPage />} />
             <Route path="/households" element={<HouseholdListPage />} />
             <Route path="/households/:id" element={<HouseholdDetailPage />} />
             <Route path="/invitations" element={<InvitationListPage />} />

--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -1,0 +1,27 @@
+/* 결산 리포트 API 클라이언트 */
+
+import apiClient from './client'
+import type { MonthlyReportOrEligibility } from '../types/report'
+
+export const reportsApi = {
+  /**
+   * 특정 월의 결산 리포트 조회
+   * 리포트가 없으면 eligibility 포함한 응답 반환
+   * @param month YYYY-MM 형식
+   */
+  getMonthly: (month: string, householdId?: number) => {
+    const params: Record<string, unknown> = { month }
+    if (householdId) params.household_id = householdId
+    return apiClient.get<MonthlyReportOrEligibility>('/reports/monthly', { params })
+  },
+
+  /**
+   * 가장 최근 완성된 결산 리포트 조회
+   * 없으면 eligibility 포함한 응답 반환
+   */
+  getLatest: (householdId?: number) => {
+    const params: Record<string, unknown> = {}
+    if (householdId) params.household_id = householdId
+    return apiClient.get<MonthlyReportOrEligibility>('/reports/latest', { params })
+  },
+}

--- a/frontend/src/components/reports/MonthlyReportCard.tsx
+++ b/frontend/src/components/reports/MonthlyReportCard.tsx
@@ -1,0 +1,89 @@
+/**
+ * @file MonthlyReportCard.tsx
+ * @description 홈 화면 상단에 표시되는 최신 월간 결산 리포트 카드
+ *
+ * 상태별 렌더링:
+ * - 로딩 중: 스켈레톤
+ * - 리포트 없음(미자격): ReportEmptyState
+ * - pending/processing: ReportPendingState (30초마다 재폴링)
+ * - completed: 첫 번째 insight headline + 리포트 상세 링크
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { ChevronRight } from 'lucide-react'
+import { reportsApi } from '../../api/reports'
+import { useHouseholdStore } from '../../stores/useHouseholdStore'
+import ReportEmptyState from './ReportEmptyState'
+import ReportPendingState from './ReportPendingState'
+
+export default function MonthlyReportCard() {
+  const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['report-latest', activeHouseholdId],
+    queryFn: async () => {
+      const res = await reportsApi.getLatest(activeHouseholdId ?? undefined)
+      return res.data
+    },
+    staleTime: 5 * 60 * 1000,
+    // pending/processing 상태면 30초마다 재폴링하여 완료 시 자동 갱신
+    refetchInterval: (query) => {
+      const status = query.state.data?.report?.status
+      return status === 'pending' || status === 'processing' ? 30_000 : false
+    },
+  })
+
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl bg-[var(--surface-elevated)] p-4 animate-pulse h-24" />
+    )
+  }
+
+  if (!data?.report) {
+    return <ReportEmptyState eligibility={data?.eligibility ?? null} />
+  }
+
+  const { report } = data
+
+  if (report.status !== 'completed') {
+    return <ReportPendingState />
+  }
+
+  const headline = report.insights?.findings?.[0]?.what ?? ''
+  const monthLabel = formatMonthLabel(report.month)
+
+  return (
+    <Link
+      to={`/insights/reports/${report.month}`}
+      className="block rounded-2xl bg-gradient-to-br from-grape-50 to-grape-100 border border-grape-200 p-4 space-y-2 hover:opacity-90 transition-opacity"
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-grape-500">📬 {monthLabel} 결산 리포트</span>
+        <ChevronRight className="w-4 h-4 text-grape-400" />
+      </div>
+      <p className="text-sm font-semibold text-[var(--text-primary)] line-clamp-2">{headline}</p>
+      {report.completed_at && (
+        <p className="text-xs text-[var(--text-tertiary)]">
+          {formatRelative(report.completed_at)}에 도착
+        </p>
+      )}
+    </Link>
+  )
+}
+
+/** "2026-03" → "2026년 3월호" */
+function formatMonthLabel(month: string): string {
+  const [year, m] = month.split('-')
+  return `${year}년 ${parseInt(m)}월호`
+}
+
+/** ISO 날짜 문자열 → "오늘" | "어제" | "N일 전" */
+function formatRelative(dateStr: string): string {
+  const diffDays = Math.floor(
+    (new Date().getTime() - new Date(dateStr).getTime()) / (1000 * 60 * 60 * 24)
+  )
+  if (diffDays === 0) return '오늘'
+  if (diffDays === 1) return '어제'
+  return `${diffDays}일 전`
+}

--- a/frontend/src/components/reports/ReportContent.tsx
+++ b/frontend/src/components/reports/ReportContent.tsx
@@ -3,7 +3,7 @@
 import { Lightbulb, Target } from 'lucide-react'
 import type { StructuredInsights } from '../../types'
 
-interface Props {
+type Props = {
   insights: StructuredInsights
   month: string
   completedAt: string | null

--- a/frontend/src/components/reports/ReportContent.tsx
+++ b/frontend/src/components/reports/ReportContent.tsx
@@ -1,0 +1,100 @@
+/* 결산 리포트 본문 컴포넌트 — 완성된 리포트의 findings, action_items 렌더링 */
+
+import { Lightbulb, Target } from 'lucide-react'
+import type { StructuredInsights } from '../../types'
+
+interface Props {
+  insights: StructuredInsights
+  month: string
+  completedAt: string | null
+}
+
+export default function ReportContent({ insights, month, completedAt }: Props) {
+  const [year, m] = month.split('-')
+  const monthLabel = `${year}년 ${parseInt(m)}월호`
+  const dateLabel = completedAt
+    ? new Date(completedAt).toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })
+    : ''
+
+  return (
+    <article className="max-w-[640px] mx-auto px-4 pb-16 space-y-12">
+      {/* 표지 헤더 */}
+      <header className="pt-6 space-y-3">
+        <p className="text-xs text-[var(--text-muted)] font-medium tracking-wider uppercase">
+          {monthLabel}
+        </p>
+        {insights.findings[0] && (
+          <h1 className="text-3xl font-bold text-[var(--text-primary)] leading-snug">
+            {insights.findings[0].what}
+          </h1>
+        )}
+        {dateLabel && (
+          <p className="text-sm text-[var(--text-tertiary)]">📬 {dateLabel}에 도착</p>
+        )}
+        <div className="h-px bg-gradient-to-r from-grape-300 to-transparent" />
+      </header>
+
+      {/* 격려 메시지 */}
+      {insights.encouragement && (
+        <blockquote className="border-l-4 border-grape-400 pl-4">
+          <p className="text-lg text-[var(--text-secondary)] leading-relaxed italic">
+            {insights.encouragement}
+          </p>
+        </blockquote>
+      )}
+
+      {/* 핵심 발견 */}
+      <section className="space-y-8">
+        <h2 className="flex items-center gap-2 text-sm font-bold text-[var(--text-tertiary)] uppercase tracking-wider">
+          <Lightbulb className="w-4 h-4 text-grape-500" />
+          핵심 발견
+        </h2>
+        {insights.findings.map((f, i) => (
+          <div key={i} className="space-y-3">
+            <h3 className="text-xl font-semibold text-[var(--text-primary)] leading-snug">
+              {i + 1}. {f.what}
+            </h3>
+            <p className="text-base text-[var(--text-secondary)] leading-relaxed">
+              {f.so_what}
+            </p>
+            <div className="bg-leaf-50 rounded-xl p-4">
+              <p className="text-sm text-leaf-700 font-medium">
+                → {f.now_what}
+              </p>
+            </div>
+          </div>
+        ))}
+      </section>
+
+      {/* 이번 달 액션 */}
+      {insights.action_items.length > 0 && (
+        <section className="space-y-4">
+          <h2 className="flex items-center gap-2 text-sm font-bold text-[var(--text-tertiary)] uppercase tracking-wider">
+            <Target className="w-4 h-4 text-grape-500" />
+            이번 달 액션
+          </h2>
+          <div className="space-y-3">
+            {insights.action_items.map((item, i) => (
+              <div key={i} className="flex gap-3 items-start">
+                <span className="shrink-0 w-6 h-6 rounded-full bg-grape-100 text-grape-600 text-sm font-bold flex items-center justify-center mt-0.5">
+                  {i + 1}
+                </span>
+                <div>
+                  <p className="text-base font-semibold text-[var(--text-primary)]">{item.title}</p>
+                  <p className="text-sm text-[var(--text-secondary)] leading-relaxed mt-0.5">
+                    {item.description}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* 일반 정보 고지 */}
+      <p className="text-xs text-[var(--text-muted)] leading-relaxed border-t border-[var(--border-subtle)] pt-4">
+        ⓘ 이 정보는 일반적인 재무 정보이며, 개인 맞춤 투자 자문이 아닙니다.
+      </p>
+    </article>
+  )
+}

--- a/frontend/src/components/reports/ReportEmptyState.tsx
+++ b/frontend/src/components/reports/ReportEmptyState.tsx
@@ -1,0 +1,84 @@
+/* 결산 리포트 자격 미달 시 표시되는 빈 상태 컴포넌트 */
+import { useNavigate } from 'react-router-dom'
+import type { ReportEligibility, ReportBlocker } from '../../types/report'
+
+interface Props {
+  eligibility: ReportEligibility | null
+}
+
+type BlockerContent = {
+  title: string
+  description: string
+  ctaLabel: string | null
+  ctaPath: string | null
+}
+
+/** blocker 유형별 안내 문구 매핑 */
+function resolveContent(eligibility: ReportEligibility | null): BlockerContent {
+  if (!eligibility) {
+    return {
+      title: '결산 리포트를 준비 중이에요',
+      description: '매달 1일에 지난 달 결산 리포트가 자동으로 도착해요.',
+      ctaLabel: null,
+      ctaPath: null,
+    }
+  }
+
+  const blocker: ReportBlocker = eligibility.blocker
+
+  switch (blocker) {
+    case 'profile_missing':
+      return {
+        title: '가구 프로필을 완성해주세요',
+        description: '프로필을 완성하면 개인화된 결산 리포트를 다음 달 1일에 받아보실 수 있어요.',
+        ctaLabel: '프로필 완성하기',
+        ctaPath: '/settings',
+      }
+    case 'transactions_short':
+      return {
+        title: '다음 달부터 결산 리포트를 받아보세요',
+        description: `이번 달 거래를 15건 이상 입력하시면 다음 달 1일에 결산 리포트가 도착해요. (현재 ${eligibility.transaction_count}건)`,
+        ctaLabel: '거래 입력하기',
+        ctaPath: '/home',
+      }
+    case 'first_month':
+      return {
+        title: '첫 결산 리포트가 준비 중이에요',
+        description: '다음 달 1일에 첫 결산 리포트가 도착해요. 그동안 거래를 입력해주세요.',
+        ctaLabel: '거래 입력하기',
+        ctaPath: '/home',
+      }
+    case 'categories_short':
+    case 'spend_short':
+    default:
+      return {
+        title: '이번 달은 결산 리포트가 없어요',
+        description: '거래를 꾸준히 입력하시면 다음 달부터 결산 리포트를 받아보실 수 있어요.',
+        ctaLabel: null,
+        ctaPath: null,
+      }
+  }
+}
+
+export default function ReportEmptyState({ eligibility }: Props) {
+  const navigate = useNavigate()
+  const { title, description, ctaLabel, ctaPath } = resolveContent(eligibility)
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-8 px-4 text-center">
+      <span className="text-4xl">📬</span>
+      <div className="space-y-1.5">
+        <p className="font-semibold text-[var(--text-primary)]">{title}</p>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed">{description}</p>
+      </div>
+      {ctaLabel && ctaPath && (
+        <button
+          onClick={() => navigate(ctaPath)}
+          className="mt-2 text-sm text-grape-600 font-medium underline underline-offset-2"
+        >
+          {ctaLabel} →
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/reports/ReportPendingState.tsx
+++ b/frontend/src/components/reports/ReportPendingState.tsx
@@ -1,0 +1,15 @@
+/**
+ * @file ReportPendingState.tsx
+ * @description 결산 리포트가 pending/processing 상태일 때 표시하는 컴포넌트
+ * 리포트 생성이 완료될 때까지 잠시 기다리도록 안내한다.
+ */
+
+export default function ReportPendingState() {
+  return (
+    <div className="flex flex-col items-center gap-3 py-8 px-4 text-center">
+      <span className="text-4xl animate-bounce">📬</span>
+      <p className="font-semibold text-[var(--text-primary)]">결산 리포트를 준비하고 있어요</p>
+      <p className="text-sm text-[var(--text-secondary)]">잠시 후 자동으로 업데이트돼요</p>
+    </div>
+  )
+}

--- a/frontend/src/components/reports/__tests__/MonthlyReportCard.test.tsx
+++ b/frontend/src/components/reports/__tests__/MonthlyReportCard.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import MonthlyReportCard from '../MonthlyReportCard'
 
 vi.mock('../../../stores/useHouseholdStore', () => ({
-  useHouseholdStore: (selector?: Function) => {
+  useHouseholdStore: (selector?: (s: { activeHouseholdId: number }) => unknown) => {
     const state = { activeHouseholdId: 1 }
     return selector ? selector(state) : state
   },

--- a/frontend/src/components/reports/__tests__/MonthlyReportCard.test.tsx
+++ b/frontend/src/components/reports/__tests__/MonthlyReportCard.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import MonthlyReportCard from '../MonthlyReportCard'
+
+vi.mock('../../../stores/useHouseholdStore', () => ({
+  useHouseholdStore: (selector?: Function) => {
+    const state = { activeHouseholdId: 1 }
+    return selector ? selector(state) : state
+  },
+}))
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    <MemoryRouter>{children}</MemoryRouter>
+  </QueryClientProvider>
+)
+
+describe('MonthlyReportCard', () => {
+  it('completed 리포트가 있으면 카드 헤드라인이 표시된다', async () => {
+    render(<MonthlyReportCard />, { wrapper })
+    // MSW 핸들러가 mockStructuredInsights.findings[0].what 반환
+    expect(await screen.findByText(/식비가 전체 지출의 37\.5%를 차지합니다/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/reports/__tests__/ReportEmptyState.test.tsx
+++ b/frontend/src/components/reports/__tests__/ReportEmptyState.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import ReportEmptyState from '../ReportEmptyState'
+import type { ReportEligibility } from '../../../types/report'
+
+// useNavigate mock
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useNavigate: () => vi.fn(),
+}))
+
+const baseEligibility: ReportEligibility = {
+  has_profile: true,
+  transaction_count: 8,
+  transactions_needed: 7,
+  category_count: 2,
+  total_spend: 80000,
+  is_eligible: false,
+  blocker: 'transactions_short',
+}
+
+describe('ReportEmptyState', () => {
+  it('거래 부족 시 15건 이상 안내가 표시된다', () => {
+    render(
+      <MemoryRouter>
+        <ReportEmptyState eligibility={baseEligibility} />
+      </MemoryRouter>
+    )
+    expect(screen.getByText(/15건 이상/)).toBeInTheDocument()
+  })
+
+  it('프로필 미완성 시 프로필 완성 안내가 표시된다', () => {
+    render(
+      <MemoryRouter>
+        <ReportEmptyState
+          eligibility={{ ...baseEligibility, has_profile: false, blocker: 'profile_missing' }}
+        />
+      </MemoryRouter>
+    )
+    // 제목과 설명 및 CTA 모두 "프로필" 포함 — 최소 1개 이상 있으면 통과
+    expect(screen.getAllByText(/프로필/).length).toBeGreaterThan(0)
+  })
+
+  it('첫 달 가입 시 다음달 안내가 표시된다', () => {
+    render(
+      <MemoryRouter>
+        <ReportEmptyState
+          eligibility={{ ...baseEligibility, blocker: 'first_month' }}
+        />
+      </MemoryRouter>
+    )
+    expect(screen.getByText(/다음 달/)).toBeInTheDocument()
+  })
+
+  it('eligibility null이면 기본 안내 표시', () => {
+    render(
+      <MemoryRouter>
+        <ReportEmptyState eligibility={null} />
+      </MemoryRouter>
+    )
+    // "결산 리포트를 준비 중이에요" 제목 텍스트로 검증
+    expect(screen.getByText(/결산 리포트를 준비 중이에요/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/reports/__tests__/ReportPendingState.test.tsx
+++ b/frontend/src/components/reports/__tests__/ReportPendingState.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import ReportPendingState from '../ReportPendingState'
+
+describe('ReportPendingState', () => {
+  it('준비 중 메시지가 표시된다', () => {
+    render(<ReportPendingState />)
+    expect(screen.getByText(/준비하고 있어요/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -902,4 +902,38 @@ export const handlers = [
       expires_at: new Date(Date.now() + 600000).toISOString(),
     })
   }),
+
+  // ==================== 결산 리포트 API ====================
+
+  /**
+   * GET /api/reports/monthly - 특정 월 결산 리포트 조회
+   */
+  http.get(`${BASE_URL}/reports/monthly`, () => {
+    return HttpResponse.json({
+      report: {
+        id: 1,
+        month: '2026-03',
+        status: 'completed',
+        insights: mockStructuredInsights,
+        completed_at: '2026-04-01T03:30:00Z',
+      },
+      eligibility: null,
+    })
+  }),
+
+  /**
+   * GET /api/reports/latest - 최근 결산 리포트 조회
+   */
+  http.get(`${BASE_URL}/reports/latest`, () => {
+    return HttpResponse.json({
+      report: {
+        id: 1,
+        month: '2026-03',
+        status: 'completed',
+        insights: mockStructuredInsights,
+        completed_at: '2026-04-01T03:30:00Z',
+      },
+      eligibility: null,
+    })
+  }),
 ]

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -12,22 +12,19 @@
 
 import { useState, useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Sparkles, Settings } from 'lucide-react'
-import { useQuery, useQueries, useQueryClient, useMutation } from '@tanstack/react-query'
+import { Settings } from 'lucide-react'
+import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query'
 import ErrorState from '../components/ErrorState'
-import { useToast } from '../hooks/useToast'
-import { TOAST } from '../constants/toastMessages'
 import EmptyState from '../components/EmptyState'
 
 // API
-import { statsApi, insightsApi } from '../api/insights'
+import { statsApi } from '../api/insights'
 import { expenseApi } from '../api/expenses'
 import { incomeApi } from '../api/income'
 import { getMonthlyStats } from '../api/budgets'
 import { categoryApi } from '../api/categories'
 import { paymentMethodApi } from '../api/paymentMethods'
 import { recurringApi } from '../api/recurring'
-import { getHouseholdProfile, upsertHouseholdProfile } from '../api/householdProfiles'
 import { useHouseholdStore } from '../stores/useHouseholdStore'
 
 // 컴포넌트
@@ -39,7 +36,6 @@ import BudgetVsActual from '../components/stats/BudgetVsActual'
 import RecurringManageSection from '../components/stats/RecurringManageSection'
 import CardUsageSummary from '../components/stats/CardUsageSummary'
 import MonthlyHighlights from '../components/stats/MonthlyHighlights'
-import StructuredInsightsView from '../components/stats/StructuredInsightsView'
 import SectionToggleModal, {
   loadSectionSettings,
   saveSectionSettings,
@@ -50,18 +46,12 @@ import LayerDivider from '../components/stats/LayerDivider'
 import InsightsOnboarding from '../components/stats/InsightsOnboarding'
 import SavingsSection from '../components/stats/SavingsSection'
 import MonthlyComparison from '../components/stats/MonthlyComparison'
-import ProfileCollectionFlow from '../components/stats/ProfileCollectionFlow'
+import MonthlyReportCard from '../components/reports/MonthlyReportCard'
 
 // 유틸
 import { calculateFinancialScore } from '../utils/financialScore'
-import { trackEvent } from '../utils/analytics'
 import { getHeroLabel } from '../utils/heroLabel'
 
-// 타입
-import type {
-  StructuredInsights,
-  HouseholdProfileInput,
-} from '../types'
 
 // ── 날짜 유틸 ──
 
@@ -138,7 +128,6 @@ const FULL_REPORT_THRESHOLD = 5
 
 export default function InsightsPage() {
   const navigate = useNavigate()
-  const { addToast } = useToast()
   const queryClient = useQueryClient()
   const [monthStr, setMonthStr] = useState(toMonthStr(new Date()))
   const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
@@ -151,13 +140,6 @@ export default function InsightsPage() {
     setSectionVisibility(updated)
     saveSectionSettings(updated)
   }, [])
-
-  // AI 분석 상태 (사용자 트리거 — 캐시 불필요)
-  const [structuredInsights, setStructuredInsights] = useState<StructuredInsights | null>(null)
-  const [aiLoading, setAiLoading] = useState(false)
-
-  // 프로필 수집 모달 표시 상태
-  const [showProfileFlow, setShowProfileFlow] = useState(false)
 
   const dateStr = `${monthStr}-15`
 
@@ -250,23 +232,7 @@ export default function InsightsPage() {
     enabled: !!activeHouseholdId && sectionVisibility.recurring,
   })
 
-  // ── Group 7: 가구 프로필 — AI 분석 개인화용 (404는 정상, 프로필 미설정 상태) ──
-
-  const { data: householdProfile, refetch: refetchProfile } = useQuery({
-    queryKey: ['householdProfile', activeHouseholdId],
-    queryFn: () => getHouseholdProfile(activeHouseholdId!),
-    enabled: !!activeHouseholdId,
-    retry: false,
-  })
-
-  // 프로필 저장 mutation
-  const saveProfile = useMutation({
-    mutationFn: (input: HouseholdProfileInput) =>
-      upsertHouseholdProfile(activeHouseholdId!, input),
-    onSuccess: () => refetchProfile(),
-  })
-
-  // ── Group 8: 직전 3개월 지출 통계 — 지출 안정성(spendingStability) 지표용 ──
+  // ── Group 7: 직전 3개월 지출 통계 — 지출 안정성(spendingStability) 지표용 ──
 
   const prev3Months = useMemo(() => getPrev3Months(monthStr), [monthStr])
 
@@ -449,95 +415,6 @@ export default function InsightsPage() {
   // 핵심 데이터가 모두 undefined이고 로딩도 끝났으면 에러 (네트워크/서버 오류)
   const error = !expenseStats && !incomeStats && !expLoading && !incLoading && !!activeHouseholdId
 
-  // 프로필 저장 핸들러 (ProfileCollectionFlow → Step 완료 시 호출)
-  async function handleProfileComplete(input: HouseholdProfileInput) {
-    await saveProfile.mutateAsync(input)
-  }
-
-  // 프로필 수집 완료 후 AI 분석 시작
-  function handleProfileFlowDone() {
-    setShowProfileFlow(false)
-    void handleGenerateAI()
-  }
-
-  // AI 분석 버튼 클릭 — 프로필 없으면 수집 플로우, 있으면 바로 분석
-  function handleAIAnalysisClick() {
-    if (!householdProfile) {
-      setShowProfileFlow(true)
-    } else {
-      void handleGenerateAI()
-    }
-  }
-
-  // AI 분석 생성 (사용자 트리거 — React Query 불필요)
-  const handleGenerateAI = useCallback(async () => {
-    if (!expenseStats && !incomeStats) {
-      addToast('error', TOAST.AI_NO_DATA)
-      return
-    }
-
-    setAiLoading(true)
-    try {
-      const requestData: Record<string, unknown> = {
-        month: monthStr,
-        income_total: incomeStats?.total ?? 0,
-        expense_total: expenseStats?.total ?? 0,
-        top_expense_categories: (expenseStats?.by_category ?? []).slice(0, 5).map(c => ({
-          name: c.category,
-          amount: c.amount,
-          percentage: c.percentage,
-        })),
-        savings_rate: incomeStats && incomeStats.total > 0
-          ? (savingsTotal !== undefined
-              ? (savingsTotal / incomeStats.total) * 100
-              : ((incomeStats.total - (expenseStats?.total ?? 0)) / incomeStats.total) * 100)
-          : 0,
-        previous_month_expense: comparison?.previous?.total ?? null,
-        previous_month_income: incomeComparison?.previous?.total ?? null,
-        // 직전 3개월 트렌드 (income은 현재 expense stats만 있어 0 — TODO: income API 연결)
-        trend: prev3MonthsStats
-          .filter((q) => q.isSuccess && q.data)
-          .map((q, i) => ({
-            month: prev3Months[i],
-            income: 0,
-            expense: q.data?.total ?? 0,
-          })),
-        savings_total: savingsTotal ?? undefined,
-        recurring_total: recurringNonSavingsTotal ?? undefined,
-        financial_score: financialScore
-          ? {
-              savings_rate: financialScore.savingsRate,
-              budget_adherence: financialScore.budgetAdherence,
-              fixed_expense_ratio: financialScore.fixedExpenseRatio,
-              spending_stability: financialScore.spendingStability,
-              overall: financialScore.overall,
-              grade: financialScore.grade,
-            }
-          : undefined,
-      }
-
-      // 예산 데이터
-      if (budgetStats?.total_budget) {
-        requestData.budget = {
-          total_budget: budgetStats.total_budget,
-          total_spent: budgetStats.total_spent,
-          over_categories: budgetStats.categories
-            .filter(c => c.is_exceeded)
-            .map(c => c.category_name),
-        }
-      }
-
-      const result = await insightsApi.generateComprehensive(requestData, activeHouseholdId ?? undefined)
-      setStructuredInsights(result.insights)
-      trackEvent('ai_analysis_requested')
-      addToast('success', TOAST.AI_ANALYSIS_COMPLETE)
-    } catch {
-      addToast('error', TOAST.AI_ANALYSIS_FAILED)
-    } finally {
-      setAiLoading(false)
-    }
-  }, [monthStr, expenseStats, incomeStats, budgetStats, financialScore, comparison, incomeComparison, savingsTotal, recurringNonSavingsTotal, prev3MonthsStats, prev3Months, activeHouseholdId, addToast])
-
   // monthStr에서 파생된 연/월 (PeriodNavigator + HeroSummary에서 공유)
   const { currentYear, currentMonth } = useMemo(() => {
     const [y, m] = monthStr.split('-').map(Number)
@@ -552,15 +429,12 @@ export default function InsightsPage() {
 
   const handlePrev = useCallback(() => {
     setMonthStr(m => shiftMonth(m, -1))
-    setStructuredInsights(null) // 월 이동 시 AI 분석 초기화
   }, [])
   const handleNext = useCallback(() => {
     setMonthStr(m => shiftMonth(m, 1))
-    setStructuredInsights(null) // 월 이동 시 AI 분석 초기화
   }, [])
   const handleMonthSelect = useCallback((year: number, month: number) => {
     setMonthStr(toMonthStr(new Date(year, month, 1)))
-    setStructuredInsights(null) // 월 이동 시 AI 분석 초기화
   }, [])
 
   return (
@@ -627,21 +501,6 @@ export default function InsightsPage() {
           hasRecurring={activeRecurringItems.length > 0}
           hasSavingsCategory={expenseCategories.some(c => c.is_savings)}
         />
-      )}
-
-      {/* 프로필 수집 모달 — AI 분석 전 가구 프로필 미설정 시 표시 */}
-      {showProfileFlow && (
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-end">
-          <div className="bg-white rounded-t-2xl p-6 w-full max-h-[85vh] overflow-y-auto">
-            <h3 className="text-base font-semibold text-warm-900 mb-4">AI 분석을 위한 정보</h3>
-            <ProfileCollectionFlow
-              onComplete={handleProfileComplete}
-              onAnalysisReady={handleProfileFlowDone}
-              onCancel={() => setShowProfileFlow(false)}
-              isLoading={saveProfile.isPending}
-            />
-          </div>
-        </div>
       )}
 
       {/* 풀 리포트 — 거래 5건 이상 */}
@@ -740,47 +599,12 @@ export default function InsightsPage() {
             </div>
           )}
 
-          {/* AI 상세 분석 */}
+          {/* 결산 리포트 */}
           {sectionVisibility.ai && (
-            <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-4">
-              <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center gap-2">
-                  <Sparkles className="w-5 h-5 text-grape-600" />
-                  <h2 className="text-base font-semibold text-[var(--text-primary)]">AI 상세 분석</h2>
-                </div>
-                {!structuredInsights && (
-                  <button
-                    onClick={handleAIAnalysisClick}
-                    disabled={aiLoading}
-                    className="px-4 py-1.5 text-sm font-medium text-white bg-grape-600 rounded-lg hover:bg-grape-700 disabled:bg-warm-400 disabled:cursor-not-allowed transition-colors"
-                  >
-                    {aiLoading ? '분석 중...' : '분석하기'}
-                  </button>
-                )}
-              </div>
-
-              {/* AI 로딩 */}
-              {aiLoading && (
-                <div className="flex flex-col items-center gap-3 py-8">
-                  <div className="animate-spin rounded-full border-b-2 border-grape-600 h-8 w-8" />
-                  <p className="text-sm text-[var(--text-secondary)]">AI가 가계 데이터를 분석하고 있습니다...</p>
-                </div>
-              )}
-
-              {/* 구조화된 AI 인사이트 */}
-              {!aiLoading && structuredInsights && (
-                <div className="mt-4">
-                  <StructuredInsightsView insights={structuredInsights} />
-                </div>
-              )}
-
-              {/* 분석 전 안내 */}
-              {!aiLoading && !structuredInsights && (
-                <p className="text-sm text-[var(--text-tertiary)] mt-3">
-                  AI가 수입, 지출, 예산, 자산을 분석하여 맞춤 인사이트를 제공합니다.
-                </p>
-              )}
-            </div>
+            <section>
+              <h2 className="text-base font-semibold text-[var(--text-primary)] mb-3">결산 리포트</h2>
+              <MonthlyReportCard />
+            </section>
           )}
         </>
       )}

--- a/frontend/src/pages/ReportDetailPage.tsx
+++ b/frontend/src/pages/ReportDetailPage.tsx
@@ -53,13 +53,13 @@ export default function ReportDetailPage() {
         <div className="max-w-[640px] mx-auto">
           <ReportEmptyState eligibility={data?.eligibility ?? null} />
         </div>
-      ) : data.report.status !== 'completed' ? (
+      ) : data.report.status !== 'completed' || !data.report.insights ? (
         <div className="max-w-[640px] mx-auto">
           <ReportPendingState />
         </div>
       ) : (
         <ReportContent
-          insights={data.report.insights!}
+          insights={data.report.insights}
           month={data.report.month}
           completedAt={data.report.completed_at}
         />

--- a/frontend/src/pages/ReportDetailPage.tsx
+++ b/frontend/src/pages/ReportDetailPage.tsx
@@ -1,0 +1,69 @@
+/* 결산 리포트 상세 페이지 — /insights/reports/:month 경로 */
+
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { ChevronLeft } from 'lucide-react'
+import { reportsApi } from '../api/reports'
+import { useHouseholdStore } from '../stores/useHouseholdStore'
+import ReportContent from '../components/reports/ReportContent'
+import ReportEmptyState from '../components/reports/ReportEmptyState'
+import ReportPendingState from '../components/reports/ReportPendingState'
+
+export default function ReportDetailPage() {
+  const { month } = useParams<{ month: string }>()
+  const navigate = useNavigate()
+  const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['report', activeHouseholdId, month],
+    queryFn: async () => {
+      const res = await reportsApi.getMonthly(month!, activeHouseholdId ?? undefined)
+      return res.data
+    },
+    enabled: !!month,
+    staleTime: 5 * 60 * 1000,
+    // pending/processing 상태이면 30초마다 폴링 (completed 되면 중단)
+    refetchInterval: (query) => {
+      const status = query.state.data?.report?.status
+      return status === 'pending' || status === 'processing' ? 30_000 : false
+    },
+  })
+
+  return (
+    <div className="min-h-screen bg-[var(--bg-primary)]">
+      {/* 네비게이션 헤더 */}
+      <div className="sticky top-0 z-10 bg-[var(--bg-primary)] border-b border-[var(--border-subtle)] px-4 py-3 flex items-center gap-2">
+        <button
+          onClick={() => navigate('/insights')}
+          className="flex items-center gap-1 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+        >
+          <ChevronLeft className="w-4 h-4" />
+          모아보기로
+        </button>
+      </div>
+
+      {/* 콘텐츠 — 상태별 분기 */}
+      {isLoading ? (
+        <div className="max-w-[640px] mx-auto px-4 pt-8 space-y-4 animate-pulse">
+          <div className="h-4 bg-[var(--surface-elevated)] rounded w-24" />
+          <div className="h-8 bg-[var(--surface-elevated)] rounded w-3/4" />
+          <div className="h-4 bg-[var(--surface-elevated)] rounded w-1/2" />
+        </div>
+      ) : !data?.report ? (
+        <div className="max-w-[640px] mx-auto">
+          <ReportEmptyState eligibility={data?.eligibility ?? null} />
+        </div>
+      ) : data.report.status !== 'completed' ? (
+        <div className="max-w-[640px] mx-auto">
+          <ReportPendingState />
+        </div>
+      ) : (
+        <ReportContent
+          insights={data.report.insights!}
+          month={data.report.month}
+          completedAt={data.report.completed_at}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/__tests__/InsightsPage.test.tsx
+++ b/frontend/src/pages/__tests__/InsightsPage.test.tsx
@@ -65,43 +65,10 @@ describe('InsightsPage', () => {
     })
   })
 
-  it('AI 상세 분석 버튼이 표시된다', async () => {
+  it('결산 리포트 섹션이 표시된다', async () => {
     renderWithQuery(<InsightsPage />)
     await waitFor(() => {
-      expect(screen.getByText('AI 상세 분석')).toBeInTheDocument()
-    })
-    expect(screen.getByText('분석하기')).toBeInTheDocument()
-  })
-
-  it('AI 분석 버튼 클릭 시 로딩 후 결과가 표시된다', async () => {
-    // 프로필이 이미 존재하는 상태로 오버라이드 — 바로 AI 분석이 실행되어야 함
-    server.use(
-      http.get('/api/household-profiles/:householdId', () => {
-        return HttpResponse.json({
-          id: 1,
-          household_id: 1,
-          household_type: 'dual_income',
-          housing_type: 'jeonse',
-          income_types: ['salary'],
-          age_range: '30s',
-          created_at: '2026-04-14T00:00:00',
-          updated_at: '2026-04-14T00:00:00',
-        })
-      }),
-    )
-
-    const user = userEvent.setup()
-    renderWithQuery(<InsightsPage />)
-
-    await waitFor(() => {
-      expect(screen.getByText('분석하기')).toBeInTheDocument()
-    })
-
-    await user.click(screen.getByText('분석하기'))
-
-    await waitFor(() => {
-      // 구조화된 인사이트가 표시됨
-      expect(screen.getByText('핵심 발견')).toBeInTheDocument()
+      expect(screen.getByText('결산 리포트')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/__tests__/ReportDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReportDetailPage.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import ReportDetailPage from '../ReportDetailPage'
+
+vi.mock('../../stores/useHouseholdStore', () => ({
+  useHouseholdStore: (selector?: Function) => {
+    const state = { activeHouseholdId: 1 }
+    return selector ? selector(state) : state
+  },
+}))
+
+function makeWrapper(month: string) {
+  return (
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })}
+    >
+      <MemoryRouter initialEntries={[`/insights/reports/${month}`]}>
+        <Routes>
+          <Route path="/insights/reports/:month" element={<ReportDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('ReportDetailPage', () => {
+  it('completed 리포트의 핵심 발견이 표시된다', async () => {
+    render(makeWrapper('2026-03'))
+    // MSW 핸들러: findings[0].what = '식비가 전체 지출의 37.5%를 차지합니다'
+    expect(await screen.findByText('식비가 전체 지출의 37.5%를 차지합니다')).toBeInTheDocument()
+  })
+
+  it('뒤로가기 버튼이 있다', async () => {
+    render(makeWrapper('2026-03'))
+    expect(await screen.findByText('모아보기로')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/ReportDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReportDetailPage.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import ReportDetailPage from '../ReportDetailPage'
 
 vi.mock('../../stores/useHouseholdStore', () => ({
-  useHouseholdStore: (selector?: Function) => {
+  useHouseholdStore: (selector?: (s: { activeHouseholdId: number }) => unknown) => {
     const state = { activeHouseholdId: 1 }
     return selector ? selector(state) : state
   },

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -1,0 +1,54 @@
+/* 결산 리포트 관련 타입 정의 */
+
+import type { StructuredInsights } from './index'
+
+/** 리포트 생성 상태 */
+export type ReportStatus = 'pending' | 'processing' | 'completed' | 'failed'
+
+/**
+ * 리포트 생성 불가 원인
+ * - profile_missing: 프로필(이름/성별/연령대) 미설정
+ * - transactions_short: 거래 건수 부족
+ * - categories_short: 카테고리 다양성 부족
+ * - spend_short: 지출 총액 부족
+ * - first_month: 첫 달 (비교 데이터 없음)
+ * - null: 생성 가능 (eligible)
+ */
+export type ReportBlocker =
+  | 'profile_missing'
+  | 'transactions_short'
+  | 'categories_short'
+  | 'spend_short'
+  | 'first_month'
+  | null
+
+/** 월간 결산 리포트 */
+export interface MonthlyReport {
+  id: number
+  /** YYYY-MM 형식 */
+  month: string
+  status: ReportStatus
+  insights: StructuredInsights | null
+  completed_at: string | null
+}
+
+/** 리포트 생성 자격 요건 충족 여부 */
+export interface ReportEligibility {
+  has_profile: boolean
+  transaction_count: number
+  transactions_needed: number
+  category_count: number
+  total_spend: number
+  is_eligible: boolean
+  blocker: ReportBlocker
+}
+
+/**
+ * GET /reports/monthly, GET /reports/latest 응답 타입
+ * 리포트가 있으면 report + eligibility null,
+ * 리포트가 없으면 report null + eligibility 포함
+ */
+export interface MonthlyReportOrEligibility {
+  report: MonthlyReport | null
+  eligibility: ReportEligibility | null
+}


### PR DESCRIPTION
## Summary

- Supabase pg_cron webhook → HMAC-SHA256 인증 → Phase 1 (자격 통과 가구 pending 생성) → Phase 2 (Semaphore(5) 병렬 LLM 호출) 구조로 매월 1일 자동 결산 리포트 생성
- 자격 기준: 전월 거래 15건 이상, 카테고리 3종 이상, 지출 20만원 이상인 가구
- 결과는 `monthly_reports` 테이블에 영구 저장, 프론트에서 React Query polling으로 실시간 상태 표시
- InsightsPage의 AI 분석 섹션 → MonthlyReportCard 교체, `/insights/reports/:month` 상세 페이지 추가

## Changes

**Backend:**
- `MonthlyReport` 모델 + Alembic 마이그레이션 (status machine: pending/processing/completed/failed)
- HMAC-SHA256 webhook 인증 (`core/webhook_auth.py`)
- 자격 검증 서비스 (`report_eligibility.py`) — JOIN+GROUP BY+HAVING 단일 쿼리
- 데이터 집계 서비스 (`report_data_builder.py`) — 재무 건강 점수 포함
- LLM 생성 서비스 (`report_generator.py`) — asyncio.wait_for 30s timeout
- 스케줄러 (`report_scheduler.py`) — SELECT FOR UPDATE SKIP LOCKED + Semaphore(5)
- Webhook API (`POST /internal/webhooks/monthly-reports`)
- 사용자 조회 API (`GET /api/reports/monthly`, `GET /api/reports/latest`)
- Admin API (`POST /api/admin/reports/{id}/retry`, `POST /api/admin/reports/manual-trigger`)

**Frontend:**
- TypeScript 타입 + Axios API 클라이언트 + MSW 핸들러
- `ReportEmptyState` / `ReportPendingState` / `MonthlyReportCard` (polling 30s)
- `ReportContent` (잡지형 레이아웃) + `ReportDetailPage`
- InsightsPage AI 섹션 → MonthlyReportCard 교체
- App.tsx 라우트 추가

## Test Plan

- [ ] 백엔드: `pytest` — 1763 passed (1 pre-existing failure in unrelated test)
- [ ] 프론트엔드: `npm run lint && npm run test:run && npm run build` — 132 files, 1657 tests passed
- [ ] Supabase 대시보드에서 pg_cron 설정 (Task 17, 수동): `SELECT cron.schedule('monthly-report', '0 18 L * *', $$SELECT net.http_post(...)$$)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)