### PR TITLE
fix: 버그 배치 수정 + 다크모드 시맨틱 컬러 유틸리티

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -32,6 +32,6 @@
 ### 다크모드 색상 규칙
 - `text-warm-*`, `bg-warm-*` **직접 사용 금지** — 다크모드에서 색상이 깨짐
 - 텍스트: `text-primary` / `text-secondary` / `text-tertiary` / `text-muted`
-- 배경: `bg-surface` / `bg-elevated` / `bg-hover`
+- 배경: `bg-surface` (카드/컴포넌트 배경) / `bg-elevated` (섹션 배경) / `bg-hover` (호버 상태)
 - 보더: `border-default` / `border-subtle`
 - 위 유틸리티에 없는 경우: `text-[var(--text-primary)]` 형태의 arbitrary value 사용

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -28,3 +28,10 @@
 - Grape 디자인 시스템: grape/leaf/warm/cream 컬러 팔레트
 - 유틸리티 클래스 직접 사용 (CSS 파일 최소화)
 - 반응형: 모바일 퍼스트 (기본 모바일 → md/lg로 확장)
+
+### 다크모드 색상 규칙
+- `text-warm-*`, `bg-warm-*` **직접 사용 금지** — 다크모드에서 색상이 깨짐
+- 텍스트: `text-primary` / `text-secondary` / `text-tertiary` / `text-muted`
+- 배경: `bg-surface` / `bg-elevated` / `bg-hover`
+- 보더: `border-default` / `border-subtle`
+- 위 유틸리티에 없는 경우: `text-[var(--text-primary)]` 형태의 arbitrary value 사용

--- a/backend/fly.dev.toml
+++ b/backend/fly.dev.toml
@@ -19,7 +19,7 @@ primary_region = "nrt"
   force_https = true
   auto_stop_machines = true   # 트래픽 없으면 자동 중지
   auto_start_machines = true
-  min_machines_running = 1    # 항상 1대 유지 — 콜드스타트 방지, 프리 티어 범위
+  min_machines_running = 0    # cold start 허용 — 비용 절감
 
   [[http_service.checks]]
     grace_period = "120s"
@@ -28,8 +28,8 @@ primary_region = "nrt"
     timeout = "10s"
     path = "/health"
 
-# 256MB로 충분 — min_machines_running=1로 콜드스타트 없이 프리 티어 유지
+# 512MB — 개발 테스트 시 메모리 부족 방지. cold start 허용으로 비용 절감
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory_mb = 256
+  memory_mb = 512

--- a/frontend/src/components/settings/ProfileEditSection.tsx
+++ b/frontend/src/components/settings/ProfileEditSection.tsx
@@ -56,9 +56,9 @@ interface Props {
 /* ─── 프로필 미설정 상태 ─── */
 function EmptyProfileCard({ onEditClick }: { onEditClick: () => void }) {
   return (
-    <div className="rounded-xl border border-warm-200 p-4 space-y-3">
-      <h3 className="text-sm font-semibold text-warm-900">AI 분석 설정</h3>
-      <p className="text-sm text-warm-500">AI 분석을 사용하려면 가구 정보를 입력해주세요.</p>
+    <div className="rounded-xl border border-default p-4 space-y-3">
+      <h3 className="text-sm font-semibold text-primary">AI 분석 설정</h3>
+      <p className="text-sm text-secondary">AI 분석을 사용하려면 가구 정보를 입력해주세요.</p>
       <button
         onClick={onEditClick}
         className="text-sm text-grape-500 font-medium"
@@ -78,9 +78,9 @@ function ProfileSummaryCard({ profile, onEditClick }: { profile: HouseholdProfil
   const lastUpdated = new Date(profile.updatedAt).toLocaleDateString('ko-KR')
 
   return (
-    <div className="rounded-xl border border-warm-200 p-4 space-y-3">
+    <div className="rounded-xl border border-default p-4 space-y-3">
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-warm-900">AI 분석 설정</h3>
+        <h3 className="text-sm font-semibold text-primary">AI 분석 설정</h3>
         <button onClick={onEditClick} className="text-xs text-grape-500">
           수정
         </button>
@@ -88,36 +88,36 @@ function ProfileSummaryCard({ profile, onEditClick }: { profile: HouseholdProfil
 
       <div className="space-y-2 text-sm">
         <div className="flex justify-between">
-          <span className="text-warm-500">가구 유형</span>
-          <span className="text-warm-900">{PROFILE_LABELS.householdType[profile.householdType]}</span>
+          <span className="text-secondary">가구 유형</span>
+          <span className="text-primary">{PROFILE_LABELS.householdType[profile.householdType]}</span>
         </div>
         <div className="flex justify-between">
-          <span className="text-warm-500">주거 형태</span>
-          <span className="text-warm-900">{PROFILE_LABELS.housingType[profile.housingType]}</span>
+          <span className="text-secondary">주거 형태</span>
+          <span className="text-primary">{PROFILE_LABELS.housingType[profile.housingType]}</span>
         </div>
         <div className="flex justify-between">
-          <span className="text-warm-500">소득 유형</span>
-          <span className="text-warm-900">{incomeLabels}</span>
+          <span className="text-secondary">소득 유형</span>
+          <span className="text-primary">{incomeLabels}</span>
         </div>
         <div className="flex justify-between">
-          <span className="text-warm-500">연령대</span>
-          <span className="text-warm-900">{PROFILE_LABELS.ageRange[profile.ageRange]}</span>
+          <span className="text-secondary">연령대</span>
+          <span className="text-primary">{PROFILE_LABELS.ageRange[profile.ageRange]}</span>
         </div>
         {profile.financialGoal && profile.financialGoal !== 'none' && (
           <div className="flex justify-between">
-            <span className="text-warm-500">재무 목표</span>
-            <span className="text-warm-900">{PROFILE_LABELS.financialGoal[profile.financialGoal]}</span>
+            <span className="text-secondary">재무 목표</span>
+            <span className="text-primary">{PROFILE_LABELS.financialGoal[profile.financialGoal]}</span>
           </div>
         )}
         {profile.primaryConcern && profile.primaryConcern !== 'none' && (
           <div className="flex justify-between">
-            <span className="text-warm-500">주요 고민</span>
-            <span className="text-warm-900">{PROFILE_LABELS.primaryConcern[profile.primaryConcern]}</span>
+            <span className="text-secondary">주요 고민</span>
+            <span className="text-primary">{PROFILE_LABELS.primaryConcern[profile.primaryConcern]}</span>
           </div>
         )}
       </div>
 
-      <p className="text-xs text-warm-400">마지막 수정: {lastUpdated}</p>
+      <p className="text-xs text-muted">마지막 수정: {lastUpdated}</p>
     </div>
   )
 }

--- a/frontend/src/components/stats/MonthlyComparison.tsx
+++ b/frontend/src/components/stats/MonthlyComparison.tsx
@@ -11,6 +11,24 @@ type MonthlyComparisonProps = {
   savingsRatePrevious?: number
 }
 
+function ChartTooltip({ active, payload, label }: {
+  active?: boolean
+  payload?: Array<{ name: string; value: number; color: string }>
+  label?: string
+}) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="bg-surface border border-default rounded-xl shadow-md px-3 py-2 text-xs space-y-1">
+      <p className="font-semibold text-primary mb-1">{label}</p>
+      {payload.map(entry => (
+        <p key={entry.name} style={{ color: entry.color }}>
+          {entry.name} : {Math.round(entry.value / 10000).toLocaleString()}만원
+        </p>
+      ))}
+    </div>
+  )
+}
+
 /** 3개월 트렌드 BarChart — 수입/지출 비교 막대 */
 function TrendBarChart({
   expenseTrend,
@@ -42,17 +60,11 @@ function TrendBarChart({
           <YAxis
             tickFormatter={(v) => `${Math.round(v / 10000)}만`}
             tick={{ fontSize: 10 }}
-            width={32}
+            width={48}
             axisLine={false}
             tickLine={false}
           />
-          <Tooltip
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            formatter={(value: any, name: any) => [
-              `${Math.round(Number(value) / 10000).toLocaleString()}만원`,
-              name as string,
-            ]}
-          />
+          <Tooltip content={<ChartTooltip />} />
           <Bar dataKey="수입" fill="#4ade80" radius={[2, 2, 0, 0]} />
           <Bar dataKey="지출" fill="#a855f7" radius={[2, 2, 0, 0]} />
         </BarChart>

--- a/frontend/src/components/stats/ProfileCollectionFlow.tsx
+++ b/frontend/src/components/stats/ProfileCollectionFlow.tsx
@@ -84,7 +84,7 @@ function ChipGroup<T extends string>({
             className={`px-3 py-1.5 rounded-full text-sm border transition-colors ${
               selected
                 ? 'bg-grape-500 text-white border-grape-500'
-                : 'bg-white text-warm-700 border-warm-300 hover:border-grape-400'
+                : 'bg-elevated text-secondary border-default hover:border-grape-400'
             }`}
           >
             {opt.label}
@@ -169,32 +169,32 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
     return (
       <div className="space-y-5">
         <div>
-          <p className="text-sm font-medium text-warm-800 mb-2">AI가 더 정확한 분석을 하려면 가구 정보가 필요해요.</p>
-          <p className="text-xs text-warm-500">입력하신 정보는 AI 분석에만 사용되며, 언제든 수정할 수 있어요.</p>
+          <p className="text-sm font-medium text-primary mb-2">AI가 더 정확한 분석을 하려면 가구 정보가 필요해요.</p>
+          <p className="text-xs text-secondary">입력하신 정보는 AI 분석에만 사용되며, 언제든 수정할 수 있어요.</p>
         </div>
 
         <div className="space-y-4">
           <div>
-            <p className="text-sm font-medium text-warm-800 mb-2">가구 유형</p>
+            <p className="text-sm font-medium text-primary mb-2">가구 유형</p>
             <ChipGroup options={HOUSEHOLD_TYPE_OPTIONS} value={householdType} onChange={setHouseholdType} />
           </div>
           <div>
-            <p className="text-sm font-medium text-warm-800 mb-2">주거 형태</p>
+            <p className="text-sm font-medium text-primary mb-2">주거 형태</p>
             <ChipGroup options={HOUSING_TYPE_OPTIONS} value={housingType} onChange={setHousingType} />
           </div>
           <div>
-            <p className="text-sm font-medium text-warm-800 mb-2">소득 유형 (복수 선택 가능)</p>
+            <p className="text-sm font-medium text-primary mb-2">소득 유형 (복수 선택 가능)</p>
             <ChipGroup options={INCOME_TYPE_OPTIONS} value={incomeTypes} onChange={toggleIncomeType} multi />
           </div>
           <div>
-            <p className="text-sm font-medium text-warm-800 mb-2">연령대</p>
+            <p className="text-sm font-medium text-primary mb-2">연령대</p>
             <ChipGroup options={AGE_RANGE_OPTIONS} value={ageRange} onChange={setAgeRange} />
           </div>
         </div>
 
         <div className="flex gap-2 pt-2">
           {onCancel && (
-            <button type="button" onClick={onCancel} className="flex-1 py-2.5 rounded-xl border border-warm-300 text-warm-600 text-sm">
+            <button type="button" onClick={onCancel} className="flex-1 py-2.5 rounded-xl border border-default text-secondary text-sm">
               취소
             </button>
           )}
@@ -215,7 +215,7 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
     <div className="space-y-5">
       <div className="space-y-4">
         <div>
-          <p className="text-sm font-medium text-warm-800 mb-2">재무 목표 (선택)</p>
+          <p className="text-sm font-medium text-primary mb-2">재무 목표 (선택)</p>
           <ChipGroup
             options={FINANCIAL_GOAL_OPTIONS}
             value={financialGoal ?? ''}
@@ -232,9 +232,9 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
                 placeholder="목표 금액"
                 value={goalAmount}
                 onChange={(e) => handleGoalAmountChange(e.target.value)}
-                className="flex-1 px-3 py-2 rounded-lg border border-warm-300 text-sm"
+                className="flex-1 px-3 py-2 rounded-lg border border-default text-sm"
               />
-              <span className="text-sm text-warm-600 shrink-0">원</span>
+              <span className="text-sm text-secondary shrink-0">원</span>
             </div>
             {/* 날짜: 연도 + 월 드롭다운 */}
             <div className="flex gap-2">
@@ -242,7 +242,7 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
                 aria-label="목표 연도"
                 value={deadlineYearInput}
                 onChange={(e) => handleDeadlineYearChange(e.target.value)}
-                className="flex-1 px-3 py-2 rounded-lg border border-warm-300 text-sm bg-white"
+                className="flex-1 px-3 py-2 rounded-lg border border-default text-sm bg-white"
               >
                 <option value="">연도</option>
                 {yearOptions.map((y) => (
@@ -253,7 +253,7 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
                 aria-label="목표 월"
                 value={deadlineMonthInput}
                 onChange={(e) => handleDeadlineMonthChange(e.target.value)}
-                className="flex-1 px-3 py-2 rounded-lg border border-warm-300 text-sm bg-white"
+                className="flex-1 px-3 py-2 rounded-lg border border-default text-sm bg-white"
               >
                 <option value="">월</option>
                 {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
@@ -264,7 +264,7 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
           </div>
         )}
         <div>
-          <p className="text-sm font-medium text-warm-800 mb-2">가장 큰 재무 고민 (선택)</p>
+          <p className="text-sm font-medium text-primary mb-2">가장 큰 재무 고민 (선택)</p>
           <ChipGroup
             options={PRIMARY_CONCERN_OPTIONS}
             value={primaryConcern ?? ''}
@@ -277,7 +277,7 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
         <button
           type="button"
           onClick={() => handleStep2Submit(true)}
-          className="flex-1 py-2.5 rounded-xl border border-warm-300 text-warm-600 text-sm"
+          className="flex-1 py-2.5 rounded-xl border border-default text-secondary text-sm"
         >
           건너뛰기
         </button>

--- a/frontend/src/components/stats/ProfileCollectionFlow.tsx
+++ b/frontend/src/components/stats/ProfileCollectionFlow.tsx
@@ -242,7 +242,7 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
                 aria-label="목표 연도"
                 value={deadlineYearInput}
                 onChange={(e) => handleDeadlineYearChange(e.target.value)}
-                className="flex-1 px-3 py-2 rounded-lg border border-default text-sm bg-white"
+                className="flex-1 px-3 py-2 rounded-lg border border-default text-sm bg-[var(--input-bg)] text-primary"
               >
                 <option value="">연도</option>
                 {yearOptions.map((y) => (
@@ -253,7 +253,7 @@ export default function ProfileCollectionFlow({ onComplete, onAnalysisReady, onC
                 aria-label="목표 월"
                 value={deadlineMonthInput}
                 onChange={(e) => handleDeadlineMonthChange(e.target.value)}
-                className="flex-1 px-3 py-2 rounded-lg border border-default text-sm bg-white"
+                className="flex-1 px-3 py-2 rounded-lg border border-default text-sm bg-[var(--input-bg)] text-primary"
               >
                 <option value="">월</option>
                 {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (

--- a/frontend/src/components/stats/SavingsSection.tsx
+++ b/frontend/src/components/stats/SavingsSection.tsx
@@ -98,7 +98,7 @@ export default function SavingsSection({
       {hasData ? (
         <div className="mt-3">
           <div className="flex items-baseline gap-2 mb-2">
-            <span className="text-xl font-bold text-[var(--text-primary)]">
+            <span className="text-lg font-bold text-[var(--text-primary)]">
               {formatAmount(savingsTotal!)}
             </span>
             {savingsRate !== undefined && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -321,6 +321,18 @@ input[type="datetime-local"] {
 .animate-stagger > *:nth-child(5) { animation-delay: 160ms; }
 .animate-stagger > *:nth-child(n+6) { animation: none; }
 
+/* ─── 시맨틱 컬러 유틸리티 — 다크모드 자동 대응 ─── */
+/* text-warm-* 직접 사용 금지. 이 유틸리티를 사용할 것 */
+@utility text-primary   { color: var(--text-primary); }
+@utility text-secondary { color: var(--text-secondary); }
+@utility text-tertiary  { color: var(--text-tertiary); }
+@utility text-muted     { color: var(--text-muted); }
+@utility bg-surface     { background-color: var(--surface-card); }
+@utility bg-elevated    { background-color: var(--surface-elevated); }
+@utility bg-hover       { background-color: var(--surface-hover); }
+@utility border-default { border-color: var(--border-default); }
+@utility border-subtle  { border-color: var(--border-subtle); }
+
 @media (prefers-reduced-motion: reduce) {
   .animate-page-in,
   .animate-stagger > *,

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -315,7 +315,7 @@ export default function CategoryManager() {
               className="input-base w-14 text-center text-xl p-2 flex-shrink-0"
               maxLength={2}
             />
-            <div className="flex-1 min-w-0 space-y-2">
+            <div className="flex-1 min-w-0 space-y-2 overflow-hidden">
               <input
                 type="text"
                 value={newName}
@@ -400,7 +400,7 @@ export default function CategoryManager() {
                         className="input-base w-14 text-center text-xl p-2 flex-shrink-0"
                         maxLength={2}
                       />
-                      <div className="flex-1 min-w-0 space-y-2">
+                      <div className="flex-1 min-w-0 space-y-2 overflow-hidden">
                         <input
                           type="text"
                           value={editForm.name}

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -377,6 +377,20 @@ export default function InsightsPage() {
       .reduce((sum, r) => sum + r.amount, 0)
   }, [activeRecurringItems])
 
+  // 이번 달 실제 실행된 비저축성 정기거래 지출 합계
+  // 정기거래 템플릿 금액 대신 실제 거래 금액을 사용해야 변동비 계산이 정확함
+  const actualFixedExpense = useMemo(() => {
+    const savingsCategoryIds = new Set(
+      expenseCategories.filter(c => c.is_savings).map(c => c.id)
+    )
+    return monthlyExpenseList
+      .filter(e =>
+        e.recurring_transaction_id != null &&
+        (e.category_id == null || !savingsCategoryIds.has(e.category_id))
+      )
+      .reduce((sum, e) => sum + e.amount, 0)
+  }, [monthlyExpenseList, expenseCategories])
+
   // 전월 저축 합계 (MonthlyHighlights 규칙 #6 — 저축 감소 감지용)
   const prevSavingsTotal = useMemo(() => {
     const savingsCatNames = new Set(
@@ -576,7 +590,7 @@ export default function InsightsPage() {
               savingsTotal={savingsTotal}
               incomeTotal={incomeStats?.total ?? 0}
               savingsCategories={savingsCategories}
-              recurringTotal={recurringTotal}
+              recurringTotal={actualFixedExpense}
               expenseTotal={expenseStats?.total ?? 0}
             />
           )}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -257,7 +257,7 @@ export default function SettingsPage() {
         <SubPageWrapper>
           <div className="space-y-4">
             <h1 className="text-xl font-bold text-[var(--text-primary)]">AI 분석 설정</h1>
-            <p className="text-sm text-warm-500">
+            <p className="text-sm text-secondary">
               가구 정보를 입력하면 AI가 상황에 맞는 분석과 조언을 제공합니다.
             </p>
             <ProfileEditSection
@@ -270,7 +270,7 @@ export default function SettingsPage() {
           {showProfileFlow && (
             <div className="fixed inset-0 z-50 bg-black/40 flex items-end">
               <div className="w-full bg-[var(--surface-card)] rounded-t-2xl p-5 max-h-[90vh] overflow-y-auto">
-                <h2 className="text-base font-semibold text-warm-900 mb-4">가구 정보 설정</h2>
+                <h2 className="text-base font-semibold text-primary mb-4">가구 정보 설정</h2>
                 <ProfileCollectionFlow
                   onComplete={async (input) => {
                     await saveProfile.mutateAsync(input)


### PR DESCRIPTION
## Summary
- 시맨틱 컬러 유틸리티(`text-primary`, `bg-surface`, `border-default` 등) 정의 및 다크모드 코딩 규칙 확립 — `text-warm-*` 직접 사용 금지
- 다크모드에서 AI 분석 설정 텍스트/칩/드롭다운 안보이는 문제 수정 (ProfileEditSection, ProfileCollectionFlow, SettingsPage)
- 지난달 비교 그래프 Y축 잘림(`width 32→48`) 및 툴팁 스타일 개선 (커스텀 카드형)
- 지출구성 변동비 계산을 정기거래 템플릿 금액 → 실제 실행 금액 기반으로 수정
- 지출구성 저축 금액 폰트 크기 조정 (`text-xl` → `text-lg`) 및 카테고리 추가 폼 레이아웃 수정
- 개발환경 메모리 256MB → 512MB 증설, cold start 허용으로 비용 절감

## Test plan
- [ ] 다크모드에서 설정 > AI 분석 설정 진입 → 텍스트 정상 표시 확인
- [ ] 다크모드에서 가구 정보 수정 모달 → 텍스트/칩/드롭다운 정상 표시 확인
- [ ] 모아보기 > 지난달 비교 펼치기 → Y축 레이블 완전 표시, 툴팁 카드 스타일 확인
- [ ] 모아보기 > 지출구성 → 변동비 금액 정상 표시 확인
- [ ] 더보기 > 카테고리 관리 > + 추가 클릭 → UI 깨짐 없음 확인
- [ ] 개발환경 배포 후 메모리 관련 오류 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)