### PR TITLE
improve: 정기거래 일시정지 UX 개선 — 인라인 흐림 처리

### DIFF
--- a/frontend/src/pages/RecurringList.tsx
+++ b/frontend/src/pages/RecurringList.tsx
@@ -9,7 +9,7 @@ import { useGoBack } from '../hooks/useGoBack'
 import {
   ArrowLeft, Plus, Pencil, Trash2,
   ToggleLeft, ToggleRight, PlusCircle,
-  MoreVertical, Loader2, Check, ChevronDown, Repeat,
+  MoreVertical, Loader2, Check, Repeat,
 } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { TOAST } from '../constants/toastMessages'
@@ -89,7 +89,6 @@ interface RecurringCardProps {
   togglingIds: Set<number>
   executingIds: Set<number>
   executedIds: Set<number>
-  showExecute: boolean
   onToggle: (r: RecurringTransaction) => void
   onMenuOpen: (id: number | null) => void
   onEdit: (r: RecurringTransaction) => void
@@ -100,14 +99,15 @@ interface RecurringCardProps {
 }
 
 function RecurringCard({
-  r, openMenuId, deletingId, togglingIds, executingIds, executedIds, showExecute,
-  onToggle, onMenuOpen, onEdit, onDeleteRequest, onDeleteConfirm, onDeleteCancel, onExecute,
+  r, openMenuId, deletingId, togglingIds, executingIds, executedIds,
+  onToggle, onMenuOpen, onEdit, onDeleteRequest, onDeleteCancel, onDeleteConfirm, onExecute,
 }: RecurringCardProps) {
   const { text: dueText, isUrgent } = formatDueDate(r.next_due_date)
   const secondaryInfo = [r.category_name, r.payment_method_name].filter(Boolean).join(' · ')
 
   return (
-    <div>
+    /* 비활성 카드는 제자리에서 흐려짐 — 섹션 이동 없이 상태만 변경 */
+    <div className={!r.is_active ? 'opacity-60' : ''}>
       <div className="p-4 flex items-center gap-3">
         {/* 이모지 */}
         <div className="w-10 h-10 rounded-xl bg-[var(--surface-elevated)] flex items-center justify-center shrink-0 text-xl">
@@ -115,7 +115,14 @@ function RecurringCard({
         </div>
         {/* 설명 + 2차 정보 */}
         <div className="flex-1 min-w-0">
-          <p className="font-medium text-[var(--text-primary)] truncate">{r.description}</p>
+          <div className="flex items-center gap-2">
+            <p className="font-medium text-[var(--text-primary)] truncate">{r.description}</p>
+            {!r.is_active && (
+              <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded-md bg-[var(--surface-elevated)] text-[var(--text-muted)]">
+                일시정지
+              </span>
+            )}
+          </div>
           <p className="text-xs text-[var(--text-tertiary)] mt-0.5 truncate">
             {secondaryInfo || '카테고리 없음'}
           </p>
@@ -160,7 +167,7 @@ function RecurringCard({
             </button>
             {openMenuId === r.id && (
               <div className="absolute right-0 top-8 z-10 bg-[var(--surface-card)] rounded-xl shadow-lg border border-[var(--border-default)] py-1 min-w-36">
-                {showExecute && (
+                {r.is_active && (
                   <button
                     onClick={() => onExecute(r)}
                     className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]"
@@ -237,7 +244,8 @@ export default function RecurringList() {
   const [togglingIds, setTogglingIds] = useState<Set<number>>(new Set())
   const [executingIds, setExecutingIds] = useState<Set<number>>(new Set())
   const [executedIds, setExecutedIds] = useState<Set<number>>(new Set())
-  const [showInactive, setShowInactive] = useState(false)
+  /* 비활성 항목 표시 여부 — 기본 보임 (제자리에서 흐려지는 방식이므로 숨기는 게 명시적 선택) */
+  const [showInactive, setShowInactive] = useState(true)
   const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([])
 
   /* 데이터 로드 */
@@ -419,13 +427,12 @@ export default function RecurringList() {
     }
   }
 
-  /* 렌더링 직전 활성/비활성 분리 + 날짜 기준 정렬
-   * next_due_date(YYYY-MM-DD) 기준 정렬: day_of_month는 monthly 외 weekly/custom에서 null이므로 부정확 */
-  const activeItems = items
-    .filter((r) => r.is_active)
-    .sort((a, b) => a.next_due_date.localeCompare(b.next_due_date))
-  const inactiveItems = items
-    .filter((r) => !r.is_active)
+  /* 렌더링 직전 정렬 + 필터
+   * next_due_date(YYYY-MM-DD) 기준 정렬: day_of_month는 monthly 외 weekly/custom에서 null이므로 부정확
+   * 비활성 항목은 제자리에서 흐려지는 방식 — 섹션 분리 없이 통합 목록 */
+  const inactiveCount = items.filter((r) => !r.is_active).length
+  const visibleItems = items
+    .filter((r) => r.is_active || showInactive)
     .sort((a, b) => a.next_due_date.localeCompare(b.next_due_date))
 
   if (error) {
@@ -510,52 +517,28 @@ export default function RecurringList() {
         </div>
       ) : (
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 overflow-hidden">
-          {/* 활성 정기거래 */}
-          {activeItems.length === 0 ? (
-            <div className="p-8 text-center text-sm text-[var(--text-tertiary)]">
-              활성 정기거래가 없습니다
-            </div>
-          ) : (
-            <div className="divide-y divide-[var(--border-subtle)]">
-              {activeItems.map((r) => (
-                <RecurringCard
-                  key={r.id} r={r} openMenuId={openMenuId} deletingId={deletingId}
-                  togglingIds={togglingIds} executingIds={executingIds} executedIds={executedIds}
-                  showExecute={true}
-                  onToggle={handleToggle} onMenuOpen={setOpenMenuId} onEdit={openEdit}
-                  onDeleteRequest={setDeletingId} onDeleteConfirm={handleDelete}
-                  onDeleteCancel={() => setDeletingId(null)} onExecute={handleExecute}
-                />
-              ))}
-            </div>
-          )}
+          {/* 통합 목록 — 활성/비활성 모두 날짜순, 비활성은 제자리에서 흐려짐 */}
+          <div className="divide-y divide-[var(--border-subtle)]">
+            {visibleItems.map((r) => (
+              <RecurringCard
+                key={r.id} r={r} openMenuId={openMenuId} deletingId={deletingId}
+                togglingIds={togglingIds} executingIds={executingIds} executedIds={executedIds}
+                onToggle={handleToggle} onMenuOpen={setOpenMenuId} onEdit={openEdit}
+                onDeleteRequest={setDeletingId} onDeleteConfirm={handleDelete}
+                onDeleteCancel={() => setDeletingId(null)} onExecute={handleExecute}
+              />
+            ))}
+          </div>
 
-          {/* 비활성(일시정지) 정기거래 — 접기/펼치기 */}
-          {inactiveItems.length > 0 && (
-            <div className="border-t border-[var(--border-subtle)]">
-              <button
-                onClick={() => setShowInactive(!showInactive)}
-                className="w-full flex items-center justify-between px-4 py-3 text-sm text-[var(--text-tertiary)] hover:bg-[var(--surface-hover)] transition-colors"
-                data-testid="inactive-toggle"
-              >
-                <span>일시정지 {inactiveItems.length}건</span>
-                <ChevronDown className={`w-4 h-4 transition-transform ${showInactive ? 'rotate-180' : ''}`} />
-              </button>
-              {showInactive && (
-                <div className="divide-y divide-[var(--border-subtle)] opacity-60">
-                  {inactiveItems.map((r) => (
-                    <RecurringCard
-                      key={r.id} r={r} openMenuId={openMenuId} deletingId={deletingId}
-                      togglingIds={togglingIds} executingIds={executingIds} executedIds={executedIds}
-                      showExecute={false}
-                      onToggle={handleToggle} onMenuOpen={setOpenMenuId} onEdit={openEdit}
-                      onDeleteRequest={setDeletingId} onDeleteConfirm={handleDelete}
-                      onDeleteCancel={() => setDeletingId(null)} onExecute={handleExecute}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
+          {/* 일시정지 항목 숨기기/보기 — 항목이 있을 때만 표시 */}
+          {inactiveCount > 0 && (
+            <button
+              onClick={() => setShowInactive(!showInactive)}
+              className="w-full px-4 py-3 text-sm text-[var(--text-tertiary)] hover:bg-[var(--surface-hover)] transition-colors border-t border-[var(--border-subtle)]"
+              data-testid="inactive-toggle"
+            >
+              일시정지 {inactiveCount}개 {showInactive ? '숨기기' : '보기'}
+            </button>
           )}
         </div>
       )}

--- a/frontend/src/pages/__tests__/RecurringList.test.tsx
+++ b/frontend/src/pages/__tests__/RecurringList.test.tsx
@@ -285,11 +285,7 @@ describe('RecurringList', () => {
     const user = userEvent.setup()
     renderRecurringList()
 
-    // 일시정지 섹션 버튼이 나타날 때까지 대기 후 클릭
-    await waitFor(() => screen.getByTestId('inactive-toggle'))
-    await user.click(screen.getByTestId('inactive-toggle'))
-
-    // 비활성 항목 토글 클릭
+    // 비활성 항목이 목록에 표시될 때까지 대기
     await waitFor(() => screen.getByTestId('toggle-3'))
     await user.click(screen.getByTestId('toggle-3'))
 
@@ -687,9 +683,9 @@ describe('RecurringList', () => {
       // 클릭 전: 활성 상태 (title="일시정지")
       expect(screen.getByTestId('toggle-1')).toHaveAttribute('title', '일시정지')
       await user.click(screen.getByTestId('toggle-1'))
-      // 낙관적 업데이트: 클릭 직후 활성 항목이 비활성 섹션으로 이동 → 일시정지 섹션 버튼 표시
+      // 낙관적 업데이트: 클릭 직후 카드가 제자리에서 "다시 시작" 상태로 바뀜 (섹션 이동 없음)
       await waitFor(() => {
-        expect(screen.getByTestId('inactive-toggle')).toBeInTheDocument()
+        expect(screen.getByTestId('toggle-1')).toHaveAttribute('title', '다시 시작')
       })
     })
 
@@ -709,17 +705,34 @@ describe('RecurringList', () => {
     })
   })
 
-  // ==================== 일시정지 섹션 ====================
+  // ==================== 일시정지 인라인 표시 ====================
 
-  describe('일시정지 섹션', () => {
-    it('일시정지 항목이 있으면 섹션 버튼이 표시된다', async () => {
-      // 활성 항목 + 비활성 항목을 모두 반환해야 일시정지 섹션이 나타남
+  describe('일시정지 인라인 표시', () => {
+    it('비활성 항목이 있으면 같은 목록에 흐리게 표시되고 숨기기 버튼이 나타난다', async () => {
       server.use(
         http.get('/api/recurring', () => HttpResponse.json([mockItems[0], mockItems[2]]))
       )
       renderRecurringList()
-      await waitFor(() => expect(screen.getByTestId('inactive-toggle')).toBeInTheDocument())
-      expect(screen.getByText(/일시정지/)).toBeInTheDocument()
+      // 비활성 항목도 목록에 즉시 표시됨 (섹션 이동 없음)
+      await waitFor(() => expect(screen.getByTestId('toggle-3')).toBeInTheDocument())
+      // 숨기기 버튼 표시
+      expect(screen.getByTestId('inactive-toggle')).toHaveTextContent('일시정지')
+      expect(screen.getByTestId('inactive-toggle')).toHaveTextContent('숨기기')
+    })
+
+    it('숨기기 버튼 클릭 시 비활성 항목이 목록에서 제거된다', async () => {
+      server.use(
+        http.get('/api/recurring', () => HttpResponse.json([mockItems[0], mockItems[2]]))
+      )
+      const user = userEvent.setup()
+      renderRecurringList()
+      await waitFor(() => screen.getByTestId('inactive-toggle'))
+      // 비활성 항목이 보임
+      expect(screen.getByTestId('toggle-3')).toBeInTheDocument()
+      // 숨기기 클릭
+      await user.click(screen.getByTestId('inactive-toggle'))
+      // 비활성 항목이 사라짐
+      expect(screen.queryByTestId('toggle-3')).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## 변경 내용

일시정지 항목이 하단 별도 섹션으로 이동하는 레이아웃 점프 UX를 개선합니다.

### 변경 전
- 활성 섹션 / 비활성 collapsed 섹션으로 분리
- 토글 시 카드가 다른 섹션으로 점프 → 어색한 UX

### 변경 후 (HIG Continuity 원칙)
- 하나의 통합 목록, 날짜순 정렬
- 일시정지 항목은 **제자리에서 흐려짐** (opacity-60) + "일시정지" 뱃지
- 하단 "일시정지 N개 숨기기/보기" 버튼으로 필요 시 정리 가능

### 테스트
- 38개 전체 통과
- 새 테스트: 비활성 항목 인라인 표시 / 숨기기 버튼 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)