### PR TITLE
fix: 결산 리포트 eligibility 기준월 오류 수정

### DIFF
--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -17,7 +17,7 @@ from app.schemas.monthly_report import (
     MonthlyReportResponse,
 )
 from app.services.report_eligibility import EligibilityResult, check_household_eligibility
-from app.services.report_month_utils import previous_month_kst
+from app.services.report_month_utils import current_month_kst, previous_month_kst
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -80,8 +80,12 @@ async def get_latest_report(
 ) -> object:
     """직전 마감 월의 결산 리포트 조회 (모아보기 상단 카드용)
 
-    KST 기준 직전 월의 completed 리포트를 반환한다.
-    리포트가 없으면 직전 월 기준 eligibility를 반환한다.
+    - 전월에 생성 중/완료된 리포트가 있으면 그 상태를 반환
+    - 없으면 현재 월 기준 eligibility(다음 달 리포트 자격)를 반환
+
+    Note: eligibility 기준을 전월이 아닌 현재 월로 쓰는 이유 —
+    전월 데이터는 이미 확정됐으므로 사용자가 추가 거래를 입력해도 반영되지 않는다.
+    현재 월 기준으로 보여야 "이번 달 15건 채우면 다음 달 리포트 생성" 진행 상황이 의미 있다.
     """
     if household_id is None:
         household_id = await get_user_active_household_id(current_user, db)
@@ -89,11 +93,12 @@ async def get_latest_report(
 
     prev_month = previous_month_kst()
 
+    # 전월 리포트가 생성 중이거나 완료된 경우 해당 상태 반환 (failed는 제외 — 현재 월 progress 표시가 더 유용)
     report = await db.scalar(
         select(MonthlyReport).where(
             MonthlyReport.household_id == household_id,
             MonthlyReport.month == prev_month,
-            MonthlyReport.status == "completed",
+            MonthlyReport.status.in_(["pending", "processing", "completed"]),
         )
     )
 
@@ -103,7 +108,9 @@ async def get_latest_report(
             eligibility=None,
         )
 
-    eligibility = await check_household_eligibility(db, household_id, prev_month)
+    # 전월 리포트가 없으면 현재 월 기준 eligibility 반환 (다음 달 리포트를 위한 진행 상황)
+    this_month = current_month_kst()
+    eligibility = await check_household_eligibility(db, household_id, this_month)
     return MonthlyReportOrEligibility(
         report=None,
         eligibility=_build_eligibility(eligibility),

--- a/backend/app/services/report_month_utils.py
+++ b/backend/app/services/report_month_utils.py
@@ -14,6 +14,12 @@ def previous_month_kst() -> str:
     return f"{now_kst.year}-{now_kst.month - 1:02d}"
 
 
+def current_month_kst() -> str:
+    """현재 KST 기준 현재 월을 YYYY-MM 형식으로 반환"""
+    now_kst = datetime.now(_KST)
+    return f"{now_kst.year}-{now_kst.month:02d}"
+
+
 def month_boundaries(month: str) -> tuple[date, date]:
     """YYYY-MM → (시작일 inclusive, 종료일 exclusive) 반환"""
     year, mon = map(int, month.split("-"))

--- a/backend/tests/integration/test_api_reports.py
+++ b/backend/tests/integration/test_api_reports.py
@@ -131,12 +131,40 @@ async def test_get_latest_report_returns_prev_month_completed(
 
 
 @pytest.mark.asyncio
+async def test_get_latest_report_returns_pending_report(
+    authenticated_client: AsyncClient,
+    db_session: AsyncSession,
+    test_household: Household,
+):
+    """직전 달 pending 리포트도 반환 (completed만 반환하던 버그 수정)"""
+    from app.services.report_month_utils import previous_month_kst
+
+    prev_month = previous_month_kst()
+    report = MonthlyReport(
+        household_id=test_household.id,
+        month=prev_month,
+        status="pending",
+        report_data={"expense_total": 200000},
+        insights=None,
+        insights_version=1,
+    )
+    db_session.add(report)
+    await db_session.commit()
+
+    resp = await authenticated_client.get("/api/reports/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["report"]["status"] == "pending"
+    assert data["report"]["month"] == prev_month
+
+
+@pytest.mark.asyncio
 async def test_get_latest_report_no_report_returns_eligibility(
     authenticated_client: AsyncClient,
     db_session: AsyncSession,
     test_household: Household,
 ):
-    """직전 달 리포트 없으면 eligibility 반환"""
+    """직전 달 리포트 없으면 현재 월 eligibility 반환"""
     resp = await authenticated_client.get("/api/reports/latest")
     assert resp.status_code == 200
     data = resp.json()


### PR DESCRIPTION
## Summary
- `GET /api/reports/latest` eligibility 조회 기준을 전월 → **현재 월**로 변경
- 전월 리포트 상태 필터에 `pending`, `processing` 포함 (`completed`만 보이던 버그 수정)
- `report_month_utils.py`에 `current_month_kst()` 함수 추가

## 문제
사용자가 이번 달(4월)에 15건 이상 거래를 입력해도, eligibility 체크가 전월(3월) 데이터 기준으로 동작해 "아직 N건 부족" 메시지가 사라지지 않음.

**원인:** `/api/reports/latest`에서 전월 리포트가 없을 때 eligibility를 `previous_month_kst()` (전월) 기준으로 체크함 → 전월 데이터는 고정이므로 현재 월 입력이 반영 안 됨.

**수정:** eligibility를 `current_month_kst()` (현재 월) 기준으로 체크 → "이번 달 15건 채우면 다음 달 리포트 생성" 진행 상황이 실시간 반영됨.

## Test Plan
- [ ] 8개 report API 통합 테스트 모두 통과
- [ ] `test_get_latest_report_returns_pending_report` 신규 테스트 포함

## Closes
<!-- 관련 이슈 없음 (사용자 직접 버그 신고) -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)