### PR TITLE
fix: UI 후속 수정 — 카테고리 다크모드, 지출구성 폰트, 차트 레이블

### DIFF
--- a/frontend/src/components/stats/MonthlyComparison.tsx
+++ b/frontend/src/components/stats/MonthlyComparison.tsx
@@ -52,7 +52,11 @@ function TrendBarChart({
               position="top"
               style={{ fontSize: 9, fill: 'var(--text-muted)' }}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              formatter={(v: any) => typeof v === 'number' && v > 0 ? `${Math.round(v / 10000)}만` : ''}
+              formatter={(v: any) => {
+                if (typeof v !== 'number' || v <= 0) return ''
+                const man = Math.round(v / 10000)
+                return man > 0 ? `${man}만` : ''
+              }}
             />
           </Bar>
           <Bar dataKey="지출" fill="#a855f7" radius={[2, 2, 0, 0]}>
@@ -61,7 +65,11 @@ function TrendBarChart({
               position="top"
               style={{ fontSize: 9, fill: 'var(--text-muted)' }}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              formatter={(v: any) => typeof v === 'number' && v > 0 ? `${Math.round(v / 10000)}만` : ''}
+              formatter={(v: any) => {
+                if (typeof v !== 'number' || v <= 0) return ''
+                const man = Math.round(v / 10000)
+                return man > 0 ? `${man}만` : ''
+              }}
             />
           </Bar>
         </BarChart>

--- a/frontend/src/components/stats/MonthlyComparison.tsx
+++ b/frontend/src/components/stats/MonthlyComparison.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts'
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, LabelList } from 'recharts'
 import type { ComparisonResponse, PeriodTotal } from '../../types'
 import SectionHeader from './SectionHeader'
 
@@ -9,24 +9,6 @@ type MonthlyComparisonProps = {
   /** 저축률 현재월 (제공 시에만 저축률 행 표시) */
   savingsRateCurrent?: number
   savingsRatePrevious?: number
-}
-
-function ChartTooltip({ active, payload, label }: {
-  active?: boolean
-  payload?: Array<{ name: string; value: number; color: string }>
-  label?: string
-}) {
-  if (!active || !payload?.length) return null
-  return (
-    <div className="bg-surface border border-default rounded-xl shadow-md px-3 py-2 text-xs space-y-1">
-      <p className="font-semibold text-primary mb-1">{label}</p>
-      {payload.map(entry => (
-        <p key={entry.name} style={{ color: entry.color }}>
-          {entry.name} : {Math.round(entry.value / 10000).toLocaleString()}만원
-        </p>
-      ))}
-    </div>
-  )
 }
 
 /** 3개월 트렌드 BarChart — 수입/지출 비교 막대 */
@@ -54,8 +36,8 @@ function TrendBarChart({
 
   return (
     <div data-testid="trend-bar-chart">
-      <ResponsiveContainer width="100%" height={120}>
-        <BarChart data={chartData} barCategoryGap="30%">
+      <ResponsiveContainer width="100%" height={150}>
+        <BarChart data={chartData} barCategoryGap="30%" margin={{ top: 18, right: 0, left: 0, bottom: 0 }}>
           <XAxis dataKey="name" tick={{ fontSize: 11 }} axisLine={false} tickLine={false} />
           <YAxis
             tickFormatter={(v) => `${Math.round(v / 10000)}만`}
@@ -64,9 +46,24 @@ function TrendBarChart({
             axisLine={false}
             tickLine={false}
           />
-          <Tooltip content={<ChartTooltip />} />
-          <Bar dataKey="수입" fill="#4ade80" radius={[2, 2, 0, 0]} />
-          <Bar dataKey="지출" fill="#a855f7" radius={[2, 2, 0, 0]} />
+          <Bar dataKey="수입" fill="#4ade80" radius={[2, 2, 0, 0]}>
+            <LabelList
+              dataKey="수입"
+              position="top"
+              style={{ fontSize: 9, fill: 'var(--text-muted)' }}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              formatter={(v: any) => typeof v === 'number' && v > 0 ? `${Math.round(v / 10000)}만` : ''}
+            />
+          </Bar>
+          <Bar dataKey="지출" fill="#a855f7" radius={[2, 2, 0, 0]}>
+            <LabelList
+              dataKey="지출"
+              position="top"
+              style={{ fontSize: 9, fill: 'var(--text-muted)' }}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              formatter={(v: any) => typeof v === 'number' && v > 0 ? `${Math.round(v / 10000)}만` : ''}
+            />
+          </Bar>
         </BarChart>
       </ResponsiveContainer>
       <div className="flex justify-center gap-4 mt-1">

--- a/frontend/src/components/stats/SavingsSection.tsx
+++ b/frontend/src/components/stats/SavingsSection.tsx
@@ -98,7 +98,7 @@ export default function SavingsSection({
       {hasData ? (
         <div className="mt-3">
           <div className="flex items-baseline gap-2 mb-2">
-            <span className="text-lg font-bold text-[var(--text-primary)]">
+            <span className="text-sm font-semibold text-[var(--text-primary)]">
               {formatAmount(savingsTotal!)}
             </span>
             {savingsRate !== undefined && (

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -484,7 +484,7 @@ export default function CategoryManager() {
                         </button>
                         <button
                           onClick={() => setDeleteTarget(category.id)}
-                          className="px-3 py-1.5 text-sm font-medium text-rose-600 bg-red-500/10 rounded-lg hover:bg-red-500/20 transition-colors"
+                          className="px-3 py-1.5 text-sm font-medium text-rose-600 bg-rose-500/10 rounded-lg hover:bg-rose-500/20 transition-colors"
                         >
                           삭제
                         </button>

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -283,7 +283,7 @@ export default function CategoryManager() {
           onClick={() => setActiveTab('expense')}
           className={`flex-1 py-2.5 rounded-xl text-sm font-medium transition-colors ${
             activeTab === 'expense'
-              ? 'bg-grape-100 text-grape-700'
+              ? 'bg-grape-500/20 text-grape-600'
               : 'bg-[var(--surface-elevated)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]'
           }`}
         >
@@ -293,7 +293,7 @@ export default function CategoryManager() {
           onClick={() => setActiveTab('income')}
           className={`flex-1 py-2.5 rounded-xl text-sm font-medium transition-colors ${
             activeTab === 'income'
-              ? 'bg-leaf-100 text-leaf-700'
+              ? 'bg-leaf-500/20 text-leaf-600'
               : 'bg-[var(--surface-elevated)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]'
           }`}
         >
@@ -303,7 +303,7 @@ export default function CategoryManager() {
 
       {/* 추가 폼 */}
       {isAdding && (
-        <div className="bg-grape-50 rounded-2xl border border-grape-200 p-4 space-y-3">
+        <div className="bg-[var(--surface-elevated)] rounded-2xl border border-[var(--border-default)] p-4 space-y-3">
           <div className="flex items-start gap-3">
             <input
               type="text"
@@ -385,7 +385,7 @@ export default function CategoryManager() {
           {categories.map((category, index) => {
             const isEditing = editingId === category.id
             return (
-              <div key={category.id} className={isEditing ? 'bg-grape-50' : undefined}>
+              <div key={category.id} className={isEditing ? 'bg-[var(--surface-elevated)]' : undefined}>
                 {isEditing ? (
                   /* 인라인 편집 폼 */
                   <div className="px-4 py-4 space-y-3">
@@ -460,7 +460,7 @@ export default function CategoryManager() {
                       <div className="flex items-center gap-1.5">
                         <span className="font-medium text-[var(--text-primary)]">{category.name}</span>
                         {category.is_savings && (
-                          <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium text-leaf-700 bg-leaf-100 rounded">
+                          <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium text-leaf-600 bg-leaf-500/15 rounded">
                             저축
                           </span>
                         )}
@@ -478,13 +478,13 @@ export default function CategoryManager() {
                       <div className="flex gap-2 flex-shrink-0">
                         <button
                           onClick={() => startEdit(category)}
-                          className="px-3 py-1.5 text-sm font-medium text-grape-600 bg-grape-50 rounded-lg hover:bg-grape-100 transition-colors"
+                          className="px-3 py-1.5 text-sm font-medium text-grape-600 bg-grape-500/10 rounded-lg hover:bg-grape-500/20 transition-colors"
                         >
                           수정
                         </button>
                         <button
                           onClick={() => setDeleteTarget(category.id)}
-                          className="px-3 py-1.5 text-sm font-medium text-rose-600 bg-rose-50 rounded-lg hover:bg-rose-100 transition-colors"
+                          className="px-3 py-1.5 text-sm font-medium text-rose-600 bg-red-500/10 rounded-lg hover:bg-red-500/20 transition-colors"
                         >
                           삭제
                         </button>


### PR DESCRIPTION
## Summary

- **카테고리 추가/편집 다크모드 수정**: form 컨테이너·탭·수정/삭제 버튼에 하드코딩된 `bg-grape-50`, `bg-rose-50`, `bg-leaf-100` 등을 CSS 변수(`var(--surface-elevated)`) 및 opacity 기반 클래스(`bg-grape-500/10`, `bg-red-500/10`)로 교체. 다크모드에서 텍스트/버튼이 정상 표시됨.
- **지출구성 폰트 통일**: SavingsSection 저축 총액 `text-lg font-bold` → `text-sm font-semibold` 으로 예산상황 카드(BudgetVsActual)와 크기 일치.
- **모바일 차트 수치 개선**: MonthlyComparison hover-only 툴팁 → `LabelList`로 막대 위에 항상 금액 표시 (`120만` 형식). 터치 기기에서도 별도 상호작용 없이 수치 확인 가능.

## Test Plan

- [ ] 카테고리 관리 페이지 → 추가 버튼 클릭 → 다크모드에서 폼이 정상 렌더링되는지 확인
- [ ] 카테고리 수정 클릭 → 인라인 편집 폼 다크모드 확인
- [ ] 종합 재무 리포트 → 지출구성 섹션 폰트 크기가 예산상황 카드와 유사한지 확인
- [ ] 종합 재무 리포트 → 지난달 비교 섹션 펼치기 → 차트 막대 위 금액 레이블 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)