### PR TITLE
fix: 정정 신호 유사도 기반 upsert — 자연어 표현 변형 충돌 방지

### DIFF
--- a/backend/app/services/correction_service.py
+++ b/backend/app/services/correction_service.py
@@ -3,12 +3,17 @@
 사용자가 거래 카테고리를 수정할 때 정정 신호를 저장하고 조회합니다.
 """
 
+from datetime import UTC, datetime
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.category import Category
 from app.models.category_correction import CategoryCorrection
 from app.services.embedding_service import cosine_similarity, get_embedding
+
+# 유사도 0.9 이상이면 "같은 개념의 다른 표현"으로 간주해 기존 행을 갱신
+_UPSERT_SIMILARITY_THRESHOLD = 0.9
 
 
 async def save_correction(
@@ -19,7 +24,10 @@ async def save_correction(
     user_id: int | None = None,
     source: str = "edit",
 ) -> CategoryCorrection | None:
-    """카테고리 정정 신호 저장
+    """카테고리 정정 신호 저장 (유사도 기반 upsert)
+
+    동일 개념의 다른 표현("스타벅스 베이글" / "베이글 스타벅스")은
+    별도 행 대신 기존 행을 최신 의도로 갱신해 충돌 힌트를 방지합니다.
 
     Args:
         db: DB 세션
@@ -42,6 +50,17 @@ async def save_correction(
     except Exception:
         pass  # 임베딩 실패는 무시 — 정정 신호 저장이 더 중요
 
+    # 유사도 기반 upsert: 임베딩이 있으면 기존 정정 중 매우 유사한 행을 갱신
+    if embedding is not None:
+        existing = await _find_duplicate_correction(db, embedding, household_id)
+        if existing is not None:
+            existing.category_id = category_id  # type: ignore[assignment]
+            existing.input_text = input_text.strip()  # type: ignore[assignment]
+            existing.embedding = embedding  # type: ignore[assignment]
+            existing.created_at = datetime.now(UTC).replace(tzinfo=None)  # type: ignore[assignment]
+            await db.flush()
+            return existing
+
     correction = CategoryCorrection(
         household_id=household_id,
         user_id=user_id,
@@ -53,6 +72,37 @@ async def save_correction(
     db.add(correction)
     await db.flush()
     return correction
+
+
+async def _find_duplicate_correction(
+    db: AsyncSession,
+    embedding: list[float],
+    household_id: int,
+) -> CategoryCorrection | None:
+    """유사도 0.9 이상인 기존 정정 행 탐색 (가장 유사한 1건 반환)"""
+    result = await db.execute(
+        select(CategoryCorrection)
+        .where(
+            CategoryCorrection.household_id == household_id,
+            CategoryCorrection.embedding.isnot(None),
+        )
+        .order_by(CategoryCorrection.created_at.desc())
+        .limit(500)
+    )
+    rows = result.scalars().all()
+
+    best: CategoryCorrection | None = None
+    best_sim = _UPSERT_SIMILARITY_THRESHOLD
+
+    for row in rows:
+        if not row.embedding:
+            continue
+        sim = cosine_similarity(embedding, row.embedding)  # type: ignore[arg-type]
+        if sim >= best_sim:
+            best_sim = sim
+            best = row
+
+    return best
 
 
 async def find_similar_corrections(

--- a/backend/tests/unit/test_correction_service.py
+++ b/backend/tests/unit/test_correction_service.py
@@ -175,6 +175,60 @@ async def test_find_similar_corrections_returns_top_matches(db_session, test_hou
 
 
 @pytest.mark.asyncio
+async def test_save_correction_upserts_on_high_similarity(db_session, test_household):
+    """유사도 0.9 이상인 기존 정정이 있으면 새 행 추가 대신 기존 행을 갱신한다"""
+    from unittest.mock import AsyncMock, patch
+
+    food_cat = Category(name="식비", household_id=None, user_id=None)
+    cafe_cat = Category(name="카페/음료", household_id=None, user_id=None)
+    db_session.add_all([food_cat, cafe_cat])
+    await db_session.flush()
+
+    base_vector = [1.0, 0.0] + [0.0] * 1534  # "스타벅스 베이글" 벡터
+
+    # 1차 저장: 스타벅스 베이글 → 식비
+    with patch("app.services.correction_service.get_embedding", new=AsyncMock(return_value=base_vector)):
+        first = await save_correction(db_session, "스타벅스 베이글", food_cat.id, test_household.id)
+    assert first is not None
+    first_id = first.id
+
+    # 거의 동일한 벡터 (단어 순서만 다른 "베이글 스타벅스")
+    similar_vector = [0.99, 0.01] + [0.0] * 1534
+
+    # 2차 저장: 베이글 스타벅스 → 카페/음료 (upsert 기대)
+    with patch("app.services.correction_service.get_embedding", new=AsyncMock(return_value=similar_vector)):
+        second = await save_correction(db_session, "베이글 스타벅스", cafe_cat.id, test_household.id)
+
+    assert second is not None
+    assert second.id == first_id  # 새 행이 아닌 기존 행 갱신
+    assert second.category_id == cafe_cat.id  # 카테고리가 최신 의도로 변경됨
+    assert second.input_text == "베이글 스타벅스"  # 텍스트도 최신으로
+
+
+@pytest.mark.asyncio
+async def test_save_correction_inserts_when_not_similar(db_session, test_household):
+    """유사도 0.9 미만인 경우 기존 행 갱신 없이 새 행으로 추가된다"""
+    from unittest.mock import AsyncMock, patch
+
+    food_cat = Category(name="식비", household_id=None, user_id=None)
+    transport_cat = Category(name="교통", household_id=None, user_id=None)
+    db_session.add_all([food_cat, transport_cat])
+    await db_session.flush()
+
+    food_vector = [1.0, 0.0] + [0.0] * 1534
+    transport_vector = [0.0, 1.0] + [0.0] * 1534  # 직교 → 유사도 0.0
+
+    with patch("app.services.correction_service.get_embedding", new=AsyncMock(return_value=food_vector)):
+        first = await save_correction(db_session, "편의점 도시락", food_cat.id, test_household.id)
+
+    with patch("app.services.correction_service.get_embedding", new=AsyncMock(return_value=transport_vector)):
+        second = await save_correction(db_session, "버스 정기권", transport_cat.id, test_household.id)
+
+    assert second is not None
+    assert second.id != first.id  # 별도 행으로 추가됨
+
+
+@pytest.mark.asyncio
 async def test_find_similar_corrections_no_embeddings_returns_empty(db_session, test_household):
     """임베딩 없는 정정 데이터만 있을 때 빈 리스트 반환"""
     from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
## Summary

- "스타벅스 베이글" → 식비로 정정 후 "베이글 스타벅스" → 카페/음료로 정정 시, 기존에는 두 행이 쌓여 LLM에 상충하는 힌트를 주입하는 문제 수정
- 저장 시 유사도 0.9 이상인 기존 정정이 있으면 insert 대신 update (upsert)
- 가장 최근 사용자 의도 1개만 유지되어 RAG 힌트 일관성 보장

## Test plan

- [ ] `test_save_correction_upserts_on_high_similarity` — 유사한 표현은 기존 행 갱신 확인
- [ ] `test_save_correction_inserts_when_not_similar` — 다른 개념은 별도 행으로 추가 확인
- [ ] 기존 테스트 전체 통과

close #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)