### PR TITLE
feat: 결산 리포트 이전/다음 달 네비게이션 추가

### DIFF
--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -911,17 +911,97 @@ export const handlers = [
 
   /**
    * GET /api/reports/monthly - 특정 월 결산 리포트 조회
+   *
+   * 테스트 시나리오별 응답:
+   * - 2026-03: completed (기본 테스트용)
+   * - 2026-02: completed (이전 달 리포트 존재 시나리오)
+   * - 2026-04: completed (다음 달 리포트 존재 시나리오)
+   * - 2025-12: pending (이전 달 pending 시나리오)
+   * - 그 외: null report (리포트 없음 시나리오)
    */
-  http.get(`${BASE_URL}/reports/monthly`, () => {
+  http.get(`${BASE_URL}/reports/monthly`, ({ request }) => {
+    const url = new URL(request.url)
+    const month = url.searchParams.get('month')
+
+    // 2026-03: 기본 completed 리포트
+    if (!month || month === '2026-03') {
+      return HttpResponse.json({
+        report: {
+          id: 1,
+          month: '2026-03',
+          status: 'completed',
+          insights: mockStructuredInsights,
+          completed_at: '2026-04-01T03:30:00Z',
+        },
+        eligibility: null,
+      })
+    }
+
+    // 2026-02: 이전 달 completed 리포트 (nav 테스트용)
+    if (month === '2026-02') {
+      return HttpResponse.json({
+        report: {
+          id: 2,
+          month: '2026-02',
+          status: 'completed',
+          insights: mockStructuredInsights,
+          completed_at: '2026-03-01T03:30:00Z',
+        },
+        eligibility: null,
+      })
+    }
+
+    // 2026-04: 다음 달 completed 리포트 (nav 테스트용)
+    if (month === '2026-04') {
+      return HttpResponse.json({
+        report: {
+          id: 3,
+          month: '2026-04',
+          status: 'completed',
+          insights: mockStructuredInsights,
+          completed_at: '2026-05-01T03:30:00Z',
+        },
+        eligibility: null,
+      })
+    }
+
+    // 2026-01: completed 리포트 — 이전 달(2025-12)이 pending인 시나리오 테스트용
+    if (month === '2026-01') {
+      return HttpResponse.json({
+        report: {
+          id: 5,
+          month: '2026-01',
+          status: 'completed',
+          insights: mockStructuredInsights,
+          completed_at: '2026-02-01T03:30:00Z',
+        },
+        eligibility: null,
+      })
+    }
+
+    // 2025-12: pending 리포트 (nav 미표시 시나리오)
+    if (month === '2025-12') {
+      return HttpResponse.json({
+        report: {
+          id: 4,
+          month: '2025-12',
+          status: 'pending',
+          insights: null,
+          completed_at: null,
+        },
+        eligibility: null,
+      })
+    }
+
+    // 그 외: 리포트 없음
     return HttpResponse.json({
-      report: {
-        id: 1,
-        month: '2026-03',
-        status: 'completed',
-        insights: mockStructuredInsights,
-        completed_at: '2026-04-01T03:30:00Z',
+      report: null,
+      eligibility: {
+        is_eligible: false,
+        reason: '거래 데이터가 부족합니다',
+        transaction_count: 0,
+        required_count: 5,
       },
-      eligibility: null,
     })
   }),
 

--- a/frontend/src/pages/ReportDetailPage.tsx
+++ b/frontend/src/pages/ReportDetailPage.tsx
@@ -45,7 +45,7 @@ export default function ReportDetailPage() {
       const res = await reportsApi.getMonthly(prevMonthStr, activeHouseholdId ?? undefined)
       return res.data
     },
-    enabled: isCompleted && !!prevMonthStr,
+    enabled: isCompleted && !!prevMonthStr && !!activeHouseholdId,
     staleTime: 5 * 60 * 1000,
   })
 
@@ -56,7 +56,7 @@ export default function ReportDetailPage() {
       const res = await reportsApi.getMonthly(nextMonthStr, activeHouseholdId ?? undefined)
       return res.data
     },
-    enabled: isCompleted && !!nextMonthStr && nextMonthStr <= currentMonthKst(),
+    enabled: isCompleted && !!nextMonthStr && !!activeHouseholdId && nextMonthStr <= currentMonthKst(),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/frontend/src/pages/ReportDetailPage.tsx
+++ b/frontend/src/pages/ReportDetailPage.tsx
@@ -1,6 +1,6 @@
 /* 결산 리포트 상세 페이지 — /insights/reports/:month 경로 */
 
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ChevronLeft } from 'lucide-react'
 import { reportsApi } from '../api/reports'
@@ -8,12 +8,18 @@ import { useHouseholdStore } from '../stores/useHouseholdStore'
 import ReportContent from '../components/reports/ReportContent'
 import ReportEmptyState from '../components/reports/ReportEmptyState'
 import ReportPendingState from '../components/reports/ReportPendingState'
+import { prevMonth, nextMonth, currentMonthKst } from '../utils/monthUtils'
 
 export default function ReportDetailPage() {
   const { month } = useParams<{ month: string }>()
   const navigate = useNavigate()
   const activeHouseholdId = useHouseholdStore((s) => s.activeHouseholdId)
 
+  // 이전/다음 월 문자열 계산
+  const prevMonthStr = month ? prevMonth(month) : ''
+  const nextMonthStr = month ? nextMonth(month) : ''
+
+  // 현재 리포트 쿼리
   const { data, isLoading } = useQuery({
     queryKey: ['report', activeHouseholdId, month],
     queryFn: async () => {
@@ -28,6 +34,43 @@ export default function ReportDetailPage() {
       return status === 'pending' || status === 'processing' ? 30_000 : false
     },
   })
+
+  // 현재 리포트가 완성된 경우에만 nav 쿼리 실행
+  const isCompleted = data?.report?.status === 'completed' && !!data.report.insights
+
+  // 이전 달 리포트 존재 여부 확인
+  const { data: prevData } = useQuery({
+    queryKey: ['report', activeHouseholdId, prevMonthStr],
+    queryFn: async () => {
+      const res = await reportsApi.getMonthly(prevMonthStr, activeHouseholdId ?? undefined)
+      return res.data
+    },
+    enabled: isCompleted && !!prevMonthStr,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // 다음 달 리포트 존재 여부 확인 — 미래 월은 쿼리 자체를 막음
+  const { data: nextData } = useQuery({
+    queryKey: ['report', activeHouseholdId, nextMonthStr],
+    queryFn: async () => {
+      const res = await reportsApi.getMonthly(nextMonthStr, activeHouseholdId ?? undefined)
+      return res.data
+    },
+    enabled: isCompleted && !!nextMonthStr && nextMonthStr <= currentMonthKst(),
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // nav 버튼 노출 여부: 해당 달 리포트가 completed일 때만 표시
+  const hasPrevReport = prevData?.report?.status === 'completed'
+  const hasNextReport = nextData?.report?.status === 'completed'
+
+  // 월 레이블 포맷: "YYYY년 M월" (앞 0 제거)
+  const formatMonthLabel = (monthStr: string): string => {
+    const [yearStr, monthNum] = monthStr.split('-')
+    return `${yearStr}년 ${parseInt(monthNum, 10)}월`
+  }
+  const prevMonthLabel = prevMonthStr ? formatMonthLabel(prevMonthStr) : ''
+  const nextMonthLabel = nextMonthStr ? formatMonthLabel(nextMonthStr) : ''
 
   return (
     <div className="min-h-screen bg-[var(--bg-primary)]">
@@ -58,11 +101,35 @@ export default function ReportDetailPage() {
           <ReportPendingState />
         </div>
       ) : (
-        <ReportContent
-          insights={data.report.insights}
-          month={data.report.month}
-          completedAt={data.report.completed_at}
-        />
+        <>
+          <ReportContent
+            insights={data.report.insights}
+            month={data.report.month}
+            completedAt={data.report.completed_at}
+          />
+
+          {/* 이전/다음 달 네비게이션 — prev/next 중 하나라도 있을 때만 표시 */}
+          {(hasPrevReport || hasNextReport) && (
+            <div className="max-w-[640px] mx-auto px-4 py-8 flex border-t border-[var(--border-subtle)]">
+              {hasPrevReport && (
+                <Link
+                  to={`/insights/reports/${prevMonthStr}`}
+                  className="text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                >
+                  ← {prevMonthLabel} 리포트
+                </Link>
+              )}
+              {hasNextReport && (
+                <Link
+                  to={`/insights/reports/${nextMonthStr}`}
+                  className="ml-auto text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                >
+                  {nextMonthLabel} 리포트 →
+                </Link>
+              )}
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/pages/__tests__/ReportDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReportDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -80,8 +80,10 @@ describe('ReportDetailPage', () => {
       render(makeWrapper('2026-01'))
       await screen.findByText('식비가 전체 지출의 37.5%를 차지합니다')
 
-      // 이전 달 2025-12는 pending이므로 링크 없음
-      expect(screen.queryByText(/2025년 12월 리포트/)).not.toBeInTheDocument()
+      // prev 쿼리 응답까지 비동기 대기 후 assertion (pending이므로 링크 없음)
+      await waitFor(() => {
+        expect(screen.queryByText(/2025년 12월 리포트/)).not.toBeInTheDocument()
+      })
     })
 
     it('completed 리포트 + prev 없음(null) → 이전 달 링크가 없다', async () => {

--- a/frontend/src/pages/__tests__/ReportDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReportDetailPage.test.tsx
@@ -2,6 +2,9 @@ import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../mocks/server'
+import { mockStructuredInsights } from '../../mocks/fixtures'
 import ReportDetailPage from '../ReportDetailPage'
 
 vi.mock('../../stores/useHouseholdStore', () => ({
@@ -82,15 +85,43 @@ describe('ReportDetailPage', () => {
     })
 
     it('completed 리포트 + prev 없음(null) → 이전 달 링크가 없다', async () => {
-      // 2026-03 조회 시 이전 달 2026-02 핸들러는 completed를 반환하지만
-      // 이 테스트는 핸들러 오버라이드 없이 "null" 케이스를 확인하기 위해
-      // 2026-05 기준으로 테스트 (이전 달 2026-04가 없는 시나리오는 직접 null 반환하는 달 필요)
-      // MSW에서 그 외 month → null report 반환: 2099-01 조회하면 이전 달 2098-12가 null
-      render(makeWrapper('2099-01'))
-      // 2099-01은 null report이므로 EmptyState 또는 별도 처리
-      // nav 없음 확인
-      expect(screen.queryByText(/리포트 →/)).not.toBeInTheDocument()
-      expect(screen.queryByText(/← .* 리포트/)).not.toBeInTheDocument()
+      // 2026-03 completed 리포트를 조회하되,
+      // 이전 달 2026-02가 null report인 시나리오를 server.use()로 오버라이드
+      server.use(
+        http.get('/api/reports/monthly', ({ request }) => {
+          const url = new URL(request.url)
+          const month = url.searchParams.get('month')
+          if (month === '2026-02') {
+            return HttpResponse.json({
+              report: null,
+              eligibility: {
+                is_eligible: false,
+                reason: '거래 데이터가 부족합니다',
+                transaction_count: 0,
+                required_count: 5,
+              },
+            })
+          }
+          // 나머지는 기본 핸들러에 위임하지 않으므로 2026-03 completed 직접 반환
+          return HttpResponse.json({
+            report: {
+              id: 1,
+              month: '2026-03',
+              status: 'completed',
+              insights: mockStructuredInsights,
+              completed_at: '2026-04-01T03:30:00Z',
+            },
+            eligibility: null,
+          })
+        }),
+      )
+
+      render(makeWrapper('2026-03'))
+      // completed 리포트가 렌더링될 때까지 대기 (이전 달 null → 이전 달 링크 없음)
+      await screen.findByText('식비가 전체 지출의 37.5%를 차지합니다')
+
+      // 이전 달 2026-02는 null이므로 이전 달 링크 없음
+      expect(screen.queryByText(/← 2026년 2월 리포트/)).not.toBeInTheDocument()
     })
 
     it('completed 리포트 + next가 미래 월 → 다음 달 링크가 없다', async () => {

--- a/frontend/src/pages/__tests__/ReportDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReportDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import ReportDetailPage from '../ReportDetailPage'
@@ -10,6 +10,18 @@ vi.mock('../../stores/useHouseholdStore', () => ({
     return selector ? selector(state) : state
   },
 }))
+
+// currentMonthKst를 모킹하여 테스트 시점을 2026-04로 고정
+// (미래 월 방지 조건 테스트에서 제어 가능하도록)
+vi.mock('../../utils/monthUtils', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/monthUtils')>(
+    '../../utils/monthUtils',
+  )
+  return {
+    ...actual,
+    currentMonthKst: vi.fn(() => '2026-04'),
+  }
+})
 
 function makeWrapper(month: string) {
   return (
@@ -26,6 +38,10 @@ function makeWrapper(month: string) {
 }
 
 describe('ReportDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('completed 리포트의 핵심 발견이 표시된다', async () => {
     render(makeWrapper('2026-03'))
     // MSW 핸들러: findings[0].what = '식비가 전체 지출의 37.5%를 차지합니다'
@@ -35,5 +51,65 @@ describe('ReportDetailPage', () => {
   it('뒤로가기 버튼이 있다', async () => {
     render(makeWrapper('2026-03'))
     expect(await screen.findByText('모아보기로')).toBeInTheDocument()
+  })
+
+  describe('이전/다음 달 네비게이션', () => {
+    it('completed 리포트 + prev completed → 이전 달 링크가 표시된다', async () => {
+      // 2026-03 조회 시 이전 달 2026-02도 completed
+      render(makeWrapper('2026-03'))
+      await screen.findByText('식비가 전체 지출의 37.5%를 차지합니다')
+
+      // "← 2026년 2월 리포트" 링크 표시
+      expect(await screen.findByText('← 2026년 2월 리포트')).toBeInTheDocument()
+    })
+
+    it('completed 리포트 + next completed + 현재 월 이하 → 다음 달 링크가 표시된다', async () => {
+      // 2026-03 조회 시 다음 달 2026-04도 completed, currentMonthKst는 2026-04로 모킹
+      render(makeWrapper('2026-03'))
+      await screen.findByText('식비가 전체 지출의 37.5%를 차지합니다')
+
+      // "2026년 4월 리포트 →" 링크 표시
+      expect(await screen.findByText('2026년 4월 리포트 →')).toBeInTheDocument()
+    })
+
+    it('completed 리포트 + prev pending → 이전 달 링크가 없다', async () => {
+      // 2026-01 조회 시 이전 달 2025-12는 pending
+      render(makeWrapper('2026-01'))
+      await screen.findByText('식비가 전체 지출의 37.5%를 차지합니다')
+
+      // 이전 달 2025-12는 pending이므로 링크 없음
+      expect(screen.queryByText(/2025년 12월 리포트/)).not.toBeInTheDocument()
+    })
+
+    it('completed 리포트 + prev 없음(null) → 이전 달 링크가 없다', async () => {
+      // 2026-03 조회 시 이전 달 2026-02 핸들러는 completed를 반환하지만
+      // 이 테스트는 핸들러 오버라이드 없이 "null" 케이스를 확인하기 위해
+      // 2026-05 기준으로 테스트 (이전 달 2026-04가 없는 시나리오는 직접 null 반환하는 달 필요)
+      // MSW에서 그 외 month → null report 반환: 2099-01 조회하면 이전 달 2098-12가 null
+      render(makeWrapper('2099-01'))
+      // 2099-01은 null report이므로 EmptyState 또는 별도 처리
+      // nav 없음 확인
+      expect(screen.queryByText(/리포트 →/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/← .* 리포트/)).not.toBeInTheDocument()
+    })
+
+    it('completed 리포트 + next가 미래 월 → 다음 달 링크가 없다', async () => {
+      // currentMonthKst가 2026-04로 모킹됨
+      // 2026-04 리포트를 보면 다음 달 2026-05는 미래이므로 링크 없음
+      render(makeWrapper('2026-04'))
+      await screen.findByText('식비가 전체 지출의 37.5%를 차지합니다')
+
+      // 다음 달 2026-05는 미래이므로 링크 없음
+      expect(screen.queryByText(/2026년 5월 리포트/)).not.toBeInTheDocument()
+    })
+
+    it('pending 리포트 → 네비게이션 전체가 없다', async () => {
+      // 2025-12는 pending 리포트
+      render(makeWrapper('2025-12'))
+      // pending 상태이면 ReportPendingState 표시, nav 쿼리 미실행
+      // pending 리포트엔 ReportPendingState가 렌더링됨
+      expect(screen.queryByText(/← .* 리포트/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/.* 리포트 →/)).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/utils/__tests__/monthUtils.test.ts
+++ b/frontend/src/utils/__tests__/monthUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { prevMonth, nextMonth, currentMonthKst } from '../monthUtils'
+
+describe('prevMonth', () => {
+  it('일반 월은 전월을 반환한다', () => {
+    expect(prevMonth('2026-03')).toBe('2026-02')
+    expect(prevMonth('2026-06')).toBe('2026-05')
+    expect(prevMonth('2026-12')).toBe('2026-11')
+  })
+
+  it('1월이면 전년도 12월을 반환한다', () => {
+    expect(prevMonth('2026-01')).toBe('2025-12')
+    expect(prevMonth('2000-01')).toBe('1999-12')
+  })
+})
+
+describe('nextMonth', () => {
+  it('일반 월은 다음 월을 반환한다', () => {
+    expect(nextMonth('2026-03')).toBe('2026-04')
+    expect(nextMonth('2026-01')).toBe('2026-02')
+    expect(nextMonth('2026-11')).toBe('2026-12')
+  })
+
+  it('12월이면 다음 연도 1월을 반환한다', () => {
+    expect(nextMonth('2025-12')).toBe('2026-01')
+    expect(nextMonth('1999-12')).toBe('2000-01')
+  })
+})
+
+describe('currentMonthKst', () => {
+  it('YYYY-MM 형식으로 반환한다', () => {
+    const result = currentMonthKst()
+    expect(result).toMatch(/^\d{4}-\d{2}$/)
+  })
+})

--- a/frontend/src/utils/__tests__/monthUtils.test.ts
+++ b/frontend/src/utils/__tests__/monthUtils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { prevMonth, nextMonth, currentMonthKst } from '../monthUtils'
 
 describe('prevMonth', () => {
@@ -31,5 +31,12 @@ describe('currentMonthKst', () => {
   it('YYYY-MM 형식으로 반환한다', () => {
     const result = currentMonthKst()
     expect(result).toMatch(/^\d{4}-\d{2}$/)
+  })
+
+  it('UTC 자정 이후에도 KST 기준 월을 반환한다', () => {
+    // UTC 2026-03-31 15:30 = KST 2026-04-01 00:30 → 4월이어야 함
+    vi.setSystemTime(new Date('2026-03-31T15:30:00Z'))
+    expect(currentMonthKst()).toBe('2026-04')
+    vi.useRealTimers()
   })
 })

--- a/frontend/src/utils/monthUtils.ts
+++ b/frontend/src/utils/monthUtils.ts
@@ -1,0 +1,62 @@
+/**
+ * 월 계산 유틸리티
+ * - "YYYY-MM" 문자열 기반으로 이전/다음 월 계산
+ * - KST(UTC+9) 기준 현재 월 조회
+ */
+
+/**
+ * 주어진 월의 이전 월을 반환한다.
+ * 1월이면 전년도 12월로 감소한다.
+ * @example prevMonth("2026-03") → "2026-02"
+ * @example prevMonth("2026-01") → "2025-12"
+ */
+export function prevMonth(month: string): string {
+  const [yearStr, monthStr] = month.split('-')
+  let year = parseInt(yearStr, 10)
+  let m = parseInt(monthStr, 10)
+
+  m -= 1
+  // 1월에서 감소하면 전년도 12월
+  if (m < 1) {
+    m = 12
+    year -= 1
+  }
+
+  return `${year}-${String(m).padStart(2, '0')}`
+}
+
+/**
+ * 주어진 월의 다음 월을 반환한다.
+ * 12월이면 다음 연도 1월로 증가한다.
+ * @example nextMonth("2026-03") → "2026-04"
+ * @example nextMonth("2025-12") → "2026-01"
+ */
+export function nextMonth(month: string): string {
+  const [yearStr, monthStr] = month.split('-')
+  let year = parseInt(yearStr, 10)
+  let m = parseInt(monthStr, 10)
+
+  m += 1
+  // 12월에서 증가하면 다음 연도 1월
+  if (m > 12) {
+    m = 1
+    year += 1
+  }
+
+  return `${year}-${String(m).padStart(2, '0')}`
+}
+
+/**
+ * KST(UTC+9) 기준 현재 월을 "YYYY-MM" 형식으로 반환한다.
+ * 서버 타임존과 무관하게 한국 기준 월을 보장한다.
+ */
+export function currentMonthKst(): string {
+  const KST_OFFSET_MS = 9 * 60 * 60 * 1000
+  const nowKst = new Date(Date.now() + KST_OFFSET_MS)
+
+  // UTC 기준으로 KST 날짜를 구한 뒤 연월 추출
+  const year = nowKst.getUTCFullYear()
+  const month = nowKst.getUTCMonth() + 1 // getUTCMonth()는 0-indexed
+
+  return `${year}-${String(month).padStart(2, '0')}`
+}

--- a/frontend/src/utils/monthUtils.ts
+++ b/frontend/src/utils/monthUtils.ts
@@ -4,6 +4,9 @@
  * - KST(UTC+9) 기준 현재 월 조회
  */
 
+// KST는 UTC+9 — 서버 타임존과 무관하게 한국 기준 시간을 계산할 때 사용
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000
+
 /**
  * 주어진 월의 이전 월을 반환한다.
  * 1월이면 전년도 12월로 감소한다.
@@ -51,7 +54,6 @@ export function nextMonth(month: string): string {
  * 서버 타임존과 무관하게 한국 기준 월을 보장한다.
  */
 export function currentMonthKst(): string {
-  const KST_OFFSET_MS = 9 * 60 * 60 * 1000
   const nowKst = new Date(Date.now() + KST_OFFSET_MS)
 
   // UTC 기준으로 KST 날짜를 구한 뒤 연월 추출


### PR DESCRIPTION
## Summary
- 결산 리포트 상세 페이지 하단에 이전/다음 달 리포트 네비게이션 추가
- `completed` 리포트가 있는 달만 버튼 표시 (pending/null 달은 미표시)
- 미래 월 방지 — `nextMonthStr <= currentMonthKst()` 조건
- 월 계산 유틸 `monthUtils.ts` 신규 추가 (`prevMonth`, `nextMonth`, `currentMonthKst`)

## Test Plan
- [ ] 6개 nav 케이스 테스트 통과 (completed prev/next, pending, null, 미래 월, pending 현재 달)
- [ ] `monthUtils` 6개 테스트 통과 (경계 케이스 + KST 자정 경계 포함)
- [ ] 전체 1691개 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)