### PR TITLE
fix: 카테고리 추가/편집 폼 입력 필드 표시 안됨 수정

### DIFF
--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -304,7 +304,7 @@ export default function CategoryManager() {
       {/* 추가 폼 */}
       {isAdding && (
         <div className="bg-[var(--surface-elevated)] rounded-2xl border border-[var(--border-default)] p-4 space-y-3">
-          <div className="flex items-start gap-3">
+          <div className="grid grid-cols-[3.5rem_1fr] gap-3 items-start">
             <input
               type="text"
               value={newEmoji}
@@ -312,10 +312,10 @@ export default function CategoryManager() {
                 const val = e.target.value
                 if (val.length <= 2) setNewEmoji(val || '📌')
               }}
-              className="input-base w-14 text-center text-xl p-2 flex-shrink-0"
+              className="input-base text-center text-xl p-2"
               maxLength={2}
             />
-            <div className="flex-1 min-w-0 space-y-2 overflow-hidden">
+            <div className="space-y-2">
               <input
                 type="text"
                 value={newName}
@@ -389,7 +389,7 @@ export default function CategoryManager() {
                 {isEditing ? (
                   /* 인라인 편집 폼 */
                   <div className="px-4 py-4 space-y-3">
-                    <div className="flex items-start gap-3">
+                    <div className="grid grid-cols-[3.5rem_1fr] gap-3 items-start">
                       <input
                         type="text"
                         value={editForm.emoji}
@@ -397,10 +397,10 @@ export default function CategoryManager() {
                           const val = e.target.value
                           if (val.length <= 2) setEditForm({ ...editForm, emoji: val || '📌' })
                         }}
-                        className="input-base w-14 text-center text-xl p-2 flex-shrink-0"
+                        className="input-base text-center text-xl p-2"
                         maxLength={2}
                       />
-                      <div className="flex-1 min-w-0 space-y-2 overflow-hidden">
+                      <div className="space-y-2">
                         <input
                           type="text"
                           value={editForm.name}


### PR DESCRIPTION
## 문제

`input-base` CSS 클래스가 `@layer` 밖에 정의되어 있어 Tailwind 유틸리티 레이어보다 명시도가 높음. 이 클래스의 `@apply w-full`이 `w-14` 유틸리티를 덮어써서 이모지 입력창이 전체 너비를 차지함. 결과적으로 오른쪽 `flex-1` 컨테이너의 너비가 0이 되고 `overflow-hidden`으로 이름/설명 입력 필드가 완전히 가려짐. 라이트/다크모드 모두 동일하게 깨짐.

## 수정

`flex items-start gap-3` → `grid grid-cols-[3.5rem_1fr] gap-3` 로 변경.

그리드 셀이 너비를 직접 결정하므로 입력창의 `width: 100%`가 셀 너비 안에서만 동작함. CSS 명시도 충돌 자체가 제거됨.

## Test Plan

- [ ] 카테고리 관리 → 추가 버튼 → 이모지(좌) + 이름/설명 입력 필드(우) 정상 표시 확인
- [ ] 카테고리 수정 버튼 → 인라인 편집 폼 동일하게 정상 표시 확인
- [ ] 라이트/다크 모드 모두 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)