### PR TITLE
fix: 카테고리 이모지 입력 불가 수정

### DIFF
--- a/frontend/src/components/EmojiPicker.tsx
+++ b/frontend/src/components/EmojiPicker.tsx
@@ -1,0 +1,71 @@
+import { useState, useRef, useEffect } from 'react'
+
+const EMOJI_LIST = [
+  // 음식/식비
+  '🍔', '🍕', '🍜', '🍱', '☕', '🍺', '🍷', '🛒', '🥗', '🍣', '🥩', '🍦',
+  // 교통
+  '🚗', '🚌', '🚇', '⛽', '✈️', '🚲', '🛵', '🚕',
+  // 쇼핑/패션
+  '👕', '👗', '👟', '🛍️', '💄', '👜',
+  // 건강/의료
+  '💊', '🏥', '🏃', '💪', '🧴',
+  // 집/주거
+  '🏠', '🛋️', '🔧', '💡', '🧹',
+  // 금융/저축
+  '💰', '💳', '📈', '🏦', '💵', '💎',
+  // 교육/여가
+  '🎓', '📚', '🎬', '🎮', '🎵', '🎾',
+  // 기타
+  '📌', '🎁', '⭐', '🌿', '🔑', '💼', '🐶', '🐱', '🌏', '🏖️',
+]
+
+type EmojiPickerProps = {
+  value: string
+  onChange: (emoji: string) => void
+}
+
+export default function EmojiPicker({ value, onChange }: EmojiPickerProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handle = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [open])
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(p => !p)}
+        className="input-base text-center text-xl p-2 w-full cursor-pointer"
+        aria-label="이모지 선택"
+      >
+        {value}
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 mt-1 z-50 bg-[var(--surface-card)] border border-[var(--border-default)] rounded-xl shadow-lg p-2 w-56">
+          <div className="grid grid-cols-8 gap-0.5">
+            {EMOJI_LIST.map(emoji => (
+              <button
+                key={emoji}
+                type="button"
+                onClick={() => { onChange(emoji); setOpen(false) }}
+                className="text-xl p-1 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-center leading-none"
+                aria-label={emoji}
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/EmojiPicker.tsx
+++ b/frontend/src/components/EmojiPicker.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 
-const EMOJI_LIST = [
+const EMOJI_LIST = Array.from(new Set([
   // 음식/식비
   '🍔', '🍕', '🍜', '🍱', '☕', '🍺', '🍷', '🛒', '🥗', '🍣', '🥩', '🍦',
   // 교통
@@ -17,7 +17,7 @@ const EMOJI_LIST = [
   '🎓', '📚', '🎬', '🎮', '🎵', '🎾',
   // 기타
   '📌', '🎁', '⭐', '🌿', '🔑', '💼', '🐶', '🐱', '🌏', '🏖️',
-]
+]))
 
 type EmojiPickerProps = {
   value: string
@@ -30,13 +30,20 @@ export default function EmojiPicker({ value, onChange }: EmojiPickerProps) {
 
   useEffect(() => {
     if (!open) return
-    const handle = (e: MouseEvent) => {
+    const handleMouseDown = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         setOpen(false)
       }
     }
-    document.addEventListener('mousedown', handle)
-    return () => document.removeEventListener('mousedown', handle)
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
   }, [open])
 
   return (
@@ -46,16 +53,24 @@ export default function EmojiPicker({ value, onChange }: EmojiPickerProps) {
         onClick={() => setOpen(p => !p)}
         className="input-base text-center text-xl p-2 w-full cursor-pointer"
         aria-label="이모지 선택"
+        aria-expanded={open}
+        aria-haspopup="listbox"
       >
         {value}
       </button>
       {open && (
-        <div className="absolute top-full left-0 mt-1 z-50 bg-[var(--surface-card)] border border-[var(--border-default)] rounded-xl shadow-lg p-2 w-56">
+        <div
+          role="listbox"
+          aria-label="이모지 목록"
+          className="absolute top-full left-0 mt-1 z-50 bg-[var(--surface-card)] border border-[var(--border-default)] rounded-xl shadow-lg p-2 w-56"
+        >
           <div className="grid grid-cols-8 gap-0.5">
             {EMOJI_LIST.map(emoji => (
               <button
                 key={emoji}
                 type="button"
+                role="option"
+                aria-selected={emoji === value}
                 onClick={() => { onChange(emoji); setOpen(false) }}
                 className="text-xl p-1 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-center leading-none"
                 aria-label={emoji}

--- a/frontend/src/components/__tests__/EmojiPicker.test.tsx
+++ b/frontend/src/components/__tests__/EmojiPicker.test.tsx
@@ -10,10 +10,10 @@ describe('EmojiPicker', () => {
 
   it('버튼 클릭 시 이모지 그리드가 열린다', () => {
     render(<EmojiPicker value="📌" onChange={vi.fn()} />)
-    expect(screen.queryByRole('button', { name: '🍔' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: '🍔' })).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
-    expect(screen.getByRole('button', { name: '🍔' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '🍔' })).toBeInTheDocument()
   })
 
   it('이모지 선택 시 onChange가 호출되고 피커가 닫힌다', () => {
@@ -21,34 +21,54 @@ describe('EmojiPicker', () => {
     render(<EmojiPicker value="📌" onChange={onChange} />)
 
     fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
-    fireEvent.click(screen.getByRole('button', { name: '🍔' }))
+    fireEvent.click(screen.getByRole('option', { name: '🍔' }))
 
     expect(onChange).toHaveBeenCalledWith('🍔')
-    expect(screen.queryByRole('button', { name: '🍔' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: '🍔' })).not.toBeInTheDocument()
   })
 
-  it('외부 클릭 시 피커가 닫힌다', () => {
+  it('외부 클릭 시 onChange 미호출 + 피커가 닫힌다', () => {
+    const onChange = vi.fn()
     render(
       <div>
-        <EmojiPicker value="📌" onChange={vi.fn()} />
+        <EmojiPicker value="📌" onChange={onChange} />
         <button>외부 버튼</button>
       </div>
     )
 
     fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
-    expect(screen.getByRole('button', { name: '🍔' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '🍔' })).toBeInTheDocument()
 
     fireEvent.mouseDown(screen.getByRole('button', { name: '외부 버튼' }))
-    expect(screen.queryByRole('button', { name: '🍔' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: '🍔' })).not.toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('Escape 키로 피커가 닫힌다', () => {
+    render(<EmojiPicker value="📌" onChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
+    expect(screen.getByRole('option', { name: '🍔' })).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('option', { name: '🍔' })).not.toBeInTheDocument()
   })
 
   it('버튼을 다시 클릭하면 피커가 닫힌다', () => {
     render(<EmojiPicker value="📌" onChange={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
-    expect(screen.getByRole('button', { name: '🍔' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '🍔' })).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
-    expect(screen.queryByRole('button', { name: '🍔' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: '🍔' })).not.toBeInTheDocument()
+  })
+
+  it('현재 선택된 이모지에 aria-selected가 표시된다', () => {
+    render(<EmojiPicker value="🍔" onChange={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
+
+    expect(screen.getByRole('option', { name: '🍔' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('option', { name: '🍕' })).toHaveAttribute('aria-selected', 'false')
   })
 })

--- a/frontend/src/components/__tests__/EmojiPicker.test.tsx
+++ b/frontend/src/components/__tests__/EmojiPicker.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import EmojiPicker from '../EmojiPicker'
+
+describe('EmojiPicker', () => {
+  it('현재 이모지를 버튼으로 렌더링한다', () => {
+    render(<EmojiPicker value="🍔" onChange={vi.fn()} />)
+    expect(screen.getByRole('button', { name: '이모지 선택' })).toHaveTextContent('🍔')
+  })
+
+  it('버튼 클릭 시 이모지 그리드가 열린다', () => {
+    render(<EmojiPicker value="📌" onChange={vi.fn()} />)
+    expect(screen.queryByRole('button', { name: '🍔' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
+    expect(screen.getByRole('button', { name: '🍔' })).toBeInTheDocument()
+  })
+
+  it('이모지 선택 시 onChange가 호출되고 피커가 닫힌다', () => {
+    const onChange = vi.fn()
+    render(<EmojiPicker value="📌" onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
+    fireEvent.click(screen.getByRole('button', { name: '🍔' }))
+
+    expect(onChange).toHaveBeenCalledWith('🍔')
+    expect(screen.queryByRole('button', { name: '🍔' })).not.toBeInTheDocument()
+  })
+
+  it('외부 클릭 시 피커가 닫힌다', () => {
+    render(
+      <div>
+        <EmojiPicker value="📌" onChange={vi.fn()} />
+        <button>외부 버튼</button>
+      </div>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
+    expect(screen.getByRole('button', { name: '🍔' })).toBeInTheDocument()
+
+    fireEvent.mouseDown(screen.getByRole('button', { name: '외부 버튼' }))
+    expect(screen.queryByRole('button', { name: '🍔' })).not.toBeInTheDocument()
+  })
+
+  it('버튼을 다시 클릭하면 피커가 닫힌다', () => {
+    render(<EmojiPicker value="📌" onChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
+    expect(screen.getByRole('button', { name: '🍔' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '이모지 선택' }))
+    expect(screen.queryByRole('button', { name: '🍔' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -312,8 +312,8 @@ export default function CategoryManager() {
                 const val = e.target.value
                 if (val.length <= 2) setNewEmoji(val || '📌')
               }}
+              onFocus={(e) => e.target.select()}
               className="input-base text-center text-xl p-2"
-              maxLength={2}
             />
             <div className="space-y-2">
               <input
@@ -397,8 +397,8 @@ export default function CategoryManager() {
                           const val = e.target.value
                           if (val.length <= 2) setEditForm({ ...editForm, emoji: val || '📌' })
                         }}
+                        onFocus={(e) => e.target.select()}
                         className="input-base text-center text-xl p-2"
-                        maxLength={2}
                       />
                       <div className="space-y-2">
                         <input

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -13,6 +13,7 @@ import { categoryApi } from '../api/categories'
 import EmptyState from '../components/EmptyState'
 import ErrorState from '../components/ErrorState'
 import { Skeleton } from '../components/skeleton/Skeleton'
+import EmojiPicker from '../components/EmojiPicker'
 import type { Category } from '../types'
 
 function CategoryManagerSkeleton() {
@@ -305,16 +306,7 @@ export default function CategoryManager() {
       {isAdding && (
         <div className="bg-[var(--surface-elevated)] rounded-2xl border border-[var(--border-default)] p-4 space-y-3">
           <div className="grid grid-cols-[3.5rem_1fr] gap-3 items-start">
-            <input
-              type="text"
-              value={newEmoji}
-              onChange={(e) => {
-                const val = e.target.value
-                if (val.length <= 2) setNewEmoji(val || '📌')
-              }}
-              onFocus={(e) => e.target.select()}
-              className="input-base text-center text-xl p-2"
-            />
+            <EmojiPicker value={newEmoji} onChange={setNewEmoji} />
             <div className="space-y-2">
               <input
                 type="text"
@@ -390,15 +382,9 @@ export default function CategoryManager() {
                   /* 인라인 편집 폼 */
                   <div className="px-4 py-4 space-y-3">
                     <div className="grid grid-cols-[3.5rem_1fr] gap-3 items-start">
-                      <input
-                        type="text"
+                      <EmojiPicker
                         value={editForm.emoji}
-                        onChange={(e) => {
-                          const val = e.target.value
-                          if (val.length <= 2) setEditForm({ ...editForm, emoji: val || '📌' })
-                        }}
-                        onFocus={(e) => e.target.select()}
-                        className="input-base text-center text-xl p-2"
+                        onChange={(emoji) => setEditForm({ ...editForm, emoji })}
                       />
                       <div className="space-y-2">
                         <input


### PR DESCRIPTION
## 문제

`maxLength={2}`가 설정된 상태에서 이모지(📌)가 이미 2 UTF-16 코드 유닛을 차지하고 있어 브라우저가 추가 입력을 완전히 차단함. 기존 이모지를 직접 선택/삭제하지 않으면 새 이모지 입력 불가.

## 수정

- `maxLength` 속성 제거 (onChange의 `val.length <= 2` 체크로 길이 제한 유지)
- `onFocus={(e) => e.target.select()}` 추가 — 클릭/탭 시 기존 이모지 자동 선택, 새 이모지 타이핑 즉시 대체됨

## Test Plan

- [ ] 카테고리 추가 폼 → 이모지 필드 클릭 → 새 이모지 타이핑으로 교체 확인
- [ ] 카테고리 수정 폼 → 동일하게 확인
- [ ] 모바일에서 이모지 피커로 교체 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)