### PR TITLE
improve: 모아보기 카드 타이포그래피 통일

### DIFF
--- a/frontend/src/components/stats/CategoryTopList.tsx
+++ b/frontend/src/components/stats/CategoryTopList.tsx
@@ -86,7 +86,7 @@ export default function CategoryTopList({ categories, maxItems = 5 }: CategoryTo
                       <span className="text-sm font-medium text-[var(--text-primary)]">{cat.category}</span>
                     </div>
                     <div className="flex items-center gap-2">
-                      <span className="text-sm text-[var(--text-secondary)]">{formatAmount(cat.amount)}</span>
+                      <span className="text-sm font-medium tabular-nums text-[var(--text-secondary)]">{formatAmount(cat.amount)}</span>
                       <span className="text-xs text-[var(--text-tertiary)] w-12 text-right">{cat.percentage.toFixed(1)}%</span>
                     </div>
                   </div>

--- a/frontend/src/components/stats/RecurringManageSection.tsx
+++ b/frontend/src/components/stats/RecurringManageSection.tsx
@@ -197,7 +197,7 @@ export default function RecurringManageSection({ items, monthStr, executedAmount
 
                 <div className="flex items-center gap-3 shrink-0 ml-2 text-right">
                   <div>
-                    <span className={`text-sm font-medium ${isExpense ? 'text-[var(--text-secondary)]' : 'text-leaf-600'}`}>
+                    <span className={`text-sm font-medium tabular-nums ${isExpense ? 'text-[var(--text-secondary)]' : 'text-leaf-600'}`}>
                       {formatAmount(displayAmount)}
                     </span>
                     {amountChanged && (

--- a/frontend/src/components/stats/UnifiedSummaryCards.tsx
+++ b/frontend/src/components/stats/UnifiedSummaryCards.tsx
@@ -68,7 +68,7 @@ export default function UnifiedSummaryCards({
       {/* 총 수입 */}
       <div className={`bg-gradient-to-br from-leaf-50 to-leaf-100 border border-leaf-200/60 ${cardBase}`}>
         <p className="text-sm text-leaf-600/70">총 수입</p>
-        <p className="text-xl sm:text-2xl font-bold tracking-tight text-[var(--text-primary)] mt-1">
+        <p className="text-xl sm:text-2xl font-bold tabular-nums text-[var(--text-primary)] mt-1">
           {formatAmount(incomeTotal)}
         </p>
       </div>
@@ -76,7 +76,7 @@ export default function UnifiedSummaryCards({
       {/* 총 지출 */}
       <div className={`bg-gradient-to-br from-grape-50 to-grape-100 border border-grape-200/60 ${cardBase}`}>
         <p className="text-sm text-grape-600/70">총 지출</p>
-        <p className="text-xl sm:text-2xl font-bold tracking-tight text-[var(--text-primary)] mt-1">
+        <p className="text-xl sm:text-2xl font-bold tabular-nums text-[var(--text-primary)] mt-1">
           {formatAmount(expenseTotal)}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- tracking-tight 제거, tabular-nums로 통일 (UnifiedSummaryCards 수입·지출 카드)
- 아이템 금액 font-medium + tabular-nums 통일 (CategoryTopList, RecurringManageSection)

## Test plan
- [ ] 금액 숫자 정렬 일정함 (tabular-nums)
- [ ] 카드별 금액 굵기 시각적으로 동일함
- [ ] \`npm run lint && npm run test:run && npm run build\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)