### PR TITLE
improve: 모아보기 카드 간격 통일

### DIFF
--- a/frontend/src/components/reports/MonthlyReportCard.tsx
+++ b/frontend/src/components/reports/MonthlyReportCard.tsx
@@ -56,15 +56,15 @@ export default function MonthlyReportCard() {
   return (
     <Link
       to={`/insights/reports/${report.month}`}
-      className="block rounded-2xl bg-gradient-to-br from-grape-50 to-grape-100 border border-grape-200 p-4 space-y-2 hover:opacity-90 transition-opacity"
+      className="block rounded-2xl shadow-sm bg-gradient-to-br from-grape-50 to-grape-100 border border-grape-200 p-4 sm:p-6 hover:opacity-90 transition-opacity"
     >
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-grape-500">📬 {monthLabel} 결산 리포트</span>
         <ChevronRight className="w-4 h-4 text-grape-400" />
       </div>
-      <p className="text-sm font-semibold text-[var(--text-primary)] line-clamp-2">{headline}</p>
+      <p className="text-sm font-semibold text-[var(--text-primary)] line-clamp-2 mt-2">{headline}</p>
       {report.completed_at && (
-        <p className="text-xs text-[var(--text-tertiary)]">
+        <p className="text-xs text-[var(--text-tertiary)] mt-1">
           {formatRelative(report.completed_at)}에 도착
         </p>
       )}

--- a/frontend/src/components/stats/CardUsageSummary.tsx
+++ b/frontend/src/components/stats/CardUsageSummary.tsx
@@ -71,7 +71,7 @@ export default function CardUsageSummary({ usage }: CardUsageSummaryProps) {
 
       {/* 펼침: 카드별 상세 */}
       {expanded && (
-        <div className="mt-4 space-y-3">
+        <div className="mt-3 space-y-3">
           {targetUsage.map((item) => {
             const pct = item.usage_percentage ?? 0
             return (

--- a/frontend/src/components/stats/CategoryTopList.tsx
+++ b/frontend/src/components/stats/CategoryTopList.tsx
@@ -76,7 +76,7 @@ export default function CategoryTopList({ categories, maxItems = 5 }: CategoryTo
       {/* 리스트 뷰 */}
       {viewMode === 'list' && (
         <>
-          <div className="space-y-2.5">
+          <div className="space-y-3">
             {visible.map((cat, i) => {
               return (
                 <div key={cat.category} className="-mx-2 px-2 py-1 rounded-lg">

--- a/frontend/src/components/stats/HeroSummary.tsx
+++ b/frontend/src/components/stats/HeroSummary.tsx
@@ -338,9 +338,9 @@ export default function HeroSummary({
         role: 'button' as const,
         tabIndex: 0,
         onKeyDown: (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') onProgressClick() },
-        className: `card-surface p-6 bg-gradient-to-b from-grape-50/60 to-transparent dark:from-grape-900/30 dark:to-transparent cursor-pointer ${className}`,
+        className: `card-surface border border-[var(--border-default)] p-6 bg-gradient-to-b from-grape-50/60 to-transparent dark:from-grape-900/30 dark:to-transparent cursor-pointer ${className}`,
       }
-    : { className: `card-surface p-6 bg-gradient-to-b from-grape-50/60 to-transparent dark:from-grape-900/30 dark:to-transparent ${className}` }
+    : { className: `card-surface border border-[var(--border-default)] p-6 bg-gradient-to-b from-grape-50/60 to-transparent dark:from-grape-900/30 dark:to-transparent ${className}` }
 
   return (
     <div {...cardClickProps}>

--- a/frontend/src/components/stats/MonthlyComparison.tsx
+++ b/frontend/src/components/stats/MonthlyComparison.tsx
@@ -181,17 +181,15 @@ export default function MonthlyComparison({
       className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6"
     >
       {/* 헤더 */}
-      <div className="mb-4">
-        <SectionHeader
-          icon="📈"
-          title="지난달 비교"
-          expanded={expanded}
-          onToggle={() => setExpanded(prev => !prev)}
-        />
-      </div>
+      <SectionHeader
+        icon="📈"
+        title="지난달 비교"
+        expanded={expanded}
+        onToggle={() => setExpanded(prev => !prev)}
+      />
 
       {/* 2열 비교 행 */}
-      <div className="space-y-3">
+      <div className="mt-3 space-y-3">
         {incomeComparison && (
           <ComparisonRow
             label="수입"

--- a/frontend/src/components/stats/MonthlyHighlights.tsx
+++ b/frontend/src/components/stats/MonthlyHighlights.tsx
@@ -139,7 +139,7 @@ export default function MonthlyHighlights({
   return (
     <div className="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)] shadow-sm p-4 sm:p-6">
       <h2 className="text-base font-semibold text-[var(--text-primary)] mb-3">💡 이번 달 주목할 점</h2>
-      <ul className="space-y-2">
+      <ul className="space-y-3">
         {highlights.map((h, i) => (
           <li key={i} className={`text-sm flex items-start gap-2 ${colorMap[h.type]}`}>
             <span className="mt-0.5 flex-shrink-0">{iconMap[h.type]}</span>

--- a/frontend/src/components/stats/RecurringManageSection.tsx
+++ b/frontend/src/components/stats/RecurringManageSection.tsx
@@ -148,7 +148,7 @@ export default function RecurringManageSection({ items, monthStr, executedAmount
 
       {/* 접힌 상태: 상태 칩 오버뷰 */}
       {!expanded && (
-        <div className="mt-2">
+        <div className="mt-3">
           <OverviewChips items={items} monthStr={monthStr} executedAmountMap={executedAmountMap} />
         </div>
       )}

--- a/frontend/src/components/stats/SavingsSection.tsx
+++ b/frontend/src/components/stats/SavingsSection.tsx
@@ -32,7 +32,7 @@ function IncomeFlowBar({
     const total = savingsPct + fixedPct + variablePct || 1
     return (
       <div data-testid="income-flow-bar" className="space-y-1">
-        <div className="flex h-2 rounded-full overflow-hidden w-full">
+        <div className="flex h-1.5 rounded-full overflow-hidden w-full">
           <div className="bg-leaf-500 transition-all" style={{ width: `${(savingsPct / total) * 100}%` }} />
           <div className="bg-amber-400 transition-all" style={{ width: `${(fixedPct / total) * 100}%` }} />
           <div className="bg-grape-400 transition-all" style={{ width: `${(variablePct / total) * 100}%` }} />
@@ -45,7 +45,7 @@ function IncomeFlowBar({
   }
 
   return (
-    <div data-testid="income-flow-bar" className="flex h-2 rounded-full overflow-hidden w-full">
+    <div data-testid="income-flow-bar" className="flex h-1.5 rounded-full overflow-hidden w-full">
       <div className="bg-leaf-500 transition-all" style={{ width: `${savingsPct}%` }} />
       <div className="bg-amber-400 transition-all" style={{ width: `${fixedPct}%` }} />
       <div className="bg-grape-400 transition-all" style={{ width: `${variablePct}%` }} />

--- a/frontend/src/components/stats/SavingsSection.tsx
+++ b/frontend/src/components/stats/SavingsSection.tsx
@@ -127,7 +127,7 @@ export default function SavingsSection({
           )}
 
           {expanded && (
-            <div className="mt-3 space-y-2 pt-3 border-t border-[var(--border-default)]">
+            <div className="mt-3 space-y-3 pt-3 border-t border-[var(--border-default)]">
               {savingsCategories.map(c => (
                 <div key={c.category} className="flex items-center justify-between">
                   <span className="text-sm text-[var(--text-secondary)]">{c.category}</span>


### PR DESCRIPTION
## Summary
- 헤더 → 본문 여백 mt-3 통일 (RecurringManageSection, CardUsageSummary, MonthlyComparison)
- 아이템 목록 간격 space-y-3 통일 (MonthlyHighlights, SavingsSection, CategoryTopList)
- 프로그레스바 높이 h-1.5 통일 (SavingsSection 2곳)
- MonthlyReportCard shadow-sm 추가, p-4 sm:p-6 반응형 패딩 통일
- HeroSummary 라이트모드 border 누락 수정

## Test plan
- [ ] 카드 간 여백 시각적으로 균일함
- [ ] 모바일/데스크톱 패딩 자연스러움
- [ ] \`npm run lint && npm run test:run && npm run build\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)