### PR TITLE
improve: 모아보기 카드 UX 패턴 통일

### DIFF
--- a/frontend/src/components/stats/BudgetVsActual.tsx
+++ b/frontend/src/components/stats/BudgetVsActual.tsx
@@ -70,11 +70,11 @@ export default function BudgetVsActual({ budgetStats, monthStr }: BudgetVsActual
             )}
           </>
         ) : (
-          <div className="py-2">
-            <p className="text-sm text-[var(--text-muted)]">예산이 설정되지 않았습니다</p>
+          <div className="text-center py-4 mt-3">
+            <p className="text-sm text-[var(--text-tertiary)]">예산이 설정되지 않았습니다</p>
             <Link
               to="/budgets"
-              className="text-xs text-grape-600 hover:text-grape-700 font-medium mt-1 inline-block"
+              className="text-sm font-medium text-grape-600 hover:text-grape-700 mt-1 inline-block"
             >
               설정하기 →
             </Link>

--- a/frontend/src/components/stats/CardUsageSummary.tsx
+++ b/frontend/src/components/stats/CardUsageSummary.tsx
@@ -88,7 +88,7 @@ export default function CardUsageSummary({ usage }: CardUsageSummaryProps) {
                 <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
                   <div
                     className={`h-1.5 rounded-full transition-all ${
-                      pct >= 100 ? 'bg-leaf-500' : pct >= 80 ? 'bg-grape-500' : 'bg-grape-400'
+                      pct >= 100 ? 'bg-leaf-500' : pct >= 80 ? 'bg-leaf-400' : 'bg-grape-400'
                     }`}
                     style={{ width: `${Math.min(pct, 100)}%` }}
                   />

--- a/frontend/src/components/stats/CategoryTopList.tsx
+++ b/frontend/src/components/stats/CategoryTopList.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { ChevronDown, ChevronUp, BarChart3, PieChart as PieChartIcon } from 'lucide-react'
+import { BarChart3, PieChart as PieChartIcon } from 'lucide-react'
 import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts'
 import type { CategoryStats } from '../../types'
 import { formatAmount } from '../../utils/format'
+import SectionHeader from './SectionHeader'
 
 // 카테고리가 이 수 이하이면 분석이 의미없어 추가 유도 메시지를 표시한다
 const MIN_CATEGORIES_FOR_ANALYSIS = 2
@@ -36,7 +37,6 @@ export default function CategoryTopList({ categories, maxItems = 5 }: CategoryTo
 
   if (categories.length === 0) return null
 
-  const hasMore = categories.length > maxItems
   const visible = expanded ? categories : categories.slice(0, maxItems)
   const totalAmount = categories.reduce((sum, c) => sum + c.amount, 0)
 
@@ -52,10 +52,17 @@ export default function CategoryTopList({ categories, maxItems = 5 }: CategoryTo
 
   return (
     <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6">
-      {/* 헤더: 제목 + 탭 전환 */}
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="text-base font-semibold text-[var(--text-primary)]">📋 지출 카테고리</h2>
-        <div className="flex items-center gap-1 bg-[var(--surface-elevated)] rounded-lg p-0.5">
+      {/* 헤더: SectionHeader(flex-1) + 뷰모드 토글(shrink-0) */}
+      <div className="flex items-center gap-2 mb-3">
+        <div className="flex-1">
+          <SectionHeader
+            icon="📋"
+            title="지출 카테고리"
+            expanded={expanded}
+            onToggle={() => setExpanded(!expanded)}
+          />
+        </div>
+        <div className="flex items-center gap-1 bg-[var(--surface-elevated)] rounded-lg p-0.5 shrink-0">
           <button
             onClick={() => setViewMode('list')}
             className={`p-1.5 rounded-md transition-colors ${viewMode === 'list' ? 'bg-[var(--surface-card)] shadow-sm text-grape-600' : 'text-[var(--text-muted)]'}`}
@@ -98,18 +105,6 @@ export default function CategoryTopList({ categories, maxItems = 5 }: CategoryTo
             })}
           </div>
 
-          {hasMore && (
-            <button
-              onClick={() => setExpanded(!expanded)}
-              className="flex items-center justify-center gap-1 w-full mt-3 py-1.5 text-xs text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
-            >
-              {expanded ? (
-                <>접기 <ChevronUp className="w-3.5 h-3.5" /></>
-              ) : (
-                <>더보기 ({categories.length - maxItems}) <ChevronDown className="w-3.5 h-3.5" /></>
-              )}
-            </button>
-          )}
         </>
       )}
 

--- a/frontend/src/components/stats/RecurringManageSection.tsx
+++ b/frontend/src/components/stats/RecurringManageSection.tsx
@@ -113,13 +113,11 @@ export default function RecurringManageSection({ items, monthStr, executedAmount
     return (
       <div id="section-recurring" className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)] p-4 sm:p-6">
         <SectionHeader icon="🔄" title="정기거래" manageTo="/recurring" expanded={false} collapsible={false} />
-        <p className="text-sm text-[var(--text-muted)] text-center py-2 mt-3">
-          정기거래를 등록하면 고정비 현황을 볼 수 있어요
-        </p>
-        <div className="text-center mt-2">
+        <div className="text-center py-4 mt-3">
+          <p className="text-sm text-[var(--text-tertiary)]">정기거래를 등록하면 고정비 현황을 볼 수 있어요</p>
           <Link
             to="/recurring"
-            className="text-xs text-grape-600 hover:text-grape-700 font-medium transition-colors"
+            className="text-sm font-medium text-grape-600 hover:text-grape-700 mt-1 inline-block"
           >
             등록하기 →
           </Link>

--- a/frontend/src/components/stats/__tests__/CategoryTopList.test.tsx
+++ b/frontend/src/components/stats/__tests__/CategoryTopList.test.tsx
@@ -50,19 +50,20 @@ describe('CategoryTopList', () => {
     expect(screen.getByText('37.5%')).toBeInTheDocument()
   })
 
-  it('리스트 뷰에서 6개 이상일 때 더보기 버튼을 표시한다', async () => {
+  it('리스트 뷰에서 6개 이상일 때 SectionHeader 펼치기 버튼이 있다', async () => {
     render(<MemoryRouter><CategoryTopList categories={mockCategories} /></MemoryRouter>)
     await switchToListView()
-    expect(screen.getByText(/더보기/)).toBeInTheDocument()
+    // SectionHeader chevron이 접기/펼치기를 담당
+    expect(screen.getByRole('button', { name: '펼치기' })).toBeInTheDocument()
   })
 
-  it('리스트 뷰에서 더보기 클릭 시 전체 목록을 표시한다', async () => {
+  it('리스트 뷰에서 SectionHeader chevron 클릭 시 전체 목록을 표시한다', async () => {
     render(<MemoryRouter><CategoryTopList categories={mockCategories} /></MemoryRouter>)
     const user = await switchToListView()
 
-    await user.click(screen.getByText(/더보기/))
+    await user.click(screen.getByRole('button', { name: '펼치기' }))
     expect(screen.getByText('기타')).toBeInTheDocument()
-    expect(screen.getByText(/접기/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '접기' })).toBeInTheDocument()
   })
 
   it('리스트 뷰에서 5개 이하이면 더보기 버튼이 없다', async () => {


### PR DESCRIPTION
## 변경 사항

모아보기 카드들의 UX 패턴을 통일합니다.

### Task 11 — CardUsageSummary 색상 시맨틱
- 카드 실적 80%+ 구간: `bg-grape-400` → `bg-leaf-400` (달성 임박을 긍정적 신호로)
- 100% 달성: 기존 `bg-leaf-500` 유지

### Task 12 — CategoryTopList SectionHeader chevron 패턴 적용
- 별도 "더보기/접기" 버튼 제거 → SectionHeader `expanded`/`onToggle` 방식으로 통일
- SectionHeader import 추가, ChevronDown/ChevronUp 제거

### Task 13 — 빈 상태 패턴 통일
- BudgetVsActual: 예산 미설정 빈 상태 → `text-center py-4 mt-3` 레이아웃
- RecurringManageSection: 정기거래 없음 빈 상태 → 동일 패턴

## 테스트
- CategoryTopList 테스트 2개 갱신 (더보기 버튼 → SectionHeader aria-label 방식)
- 전체 1691개 테스트 통과

## 관련 이슈
모아보기 UI 일관성 개선 시리즈 (PR4/5)