### PR TITLE
refactor: 포맷 함수 중앙화 — formatCompact/formatChange utils로 이동

### DIFF
--- a/frontend/src/components/stats/HeroSummary.tsx
+++ b/frontend/src/components/stats/HeroSummary.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
-import { formatAmount, formatCompactAmount } from '../../utils/format'
+import { formatAmount, formatCompact } from '../../utils/format'
 import type { FinancialScore } from '../../types'
 import FinancialHealthScore from './FinancialHealthScore'
 
@@ -23,10 +23,10 @@ type HeroSummaryProps = {
   className?: string
 }
 
-/** 금액 축약 포맷 (₩ 접두사 포함) */
+/** 금액 축약 포맷 (₩ 접두사 포함) — 0원 특수 처리 후 formatCompact 위임 */
 function formatWon(amount: number): string {
   if (amount === 0) return '₩0'
-  return `₩${formatCompactAmount(amount)}`
+  return `₩${formatCompact(amount)}`
 }
 
 // ─── 상태 분류 ───

--- a/frontend/src/components/stats/MonthlyComparison.tsx
+++ b/frontend/src/components/stats/MonthlyComparison.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, LabelList } from 'recharts'
 import type { ComparisonResponse, PeriodTotal } from '../../types'
+import { formatCompact, formatChange } from '../../utils/format'
 import SectionHeader from './SectionHeader'
 
 type MonthlyComparisonProps = {
@@ -86,17 +87,6 @@ function TrendBarChart({
   )
 }
 
-function formatCompact(amount: number): string {
-  const abs = Math.abs(amount)
-  if (abs >= 100_000_000) return `${(abs / 100_000_000).toFixed(1)}억원`
-  if (abs >= 10_000) return `${Math.round(abs / 10_000).toLocaleString()}만원`
-  return `${abs.toLocaleString('ko-KR')}원`
-}
-
-function formatChange(amount: number): string {
-  const sign = amount >= 0 ? '+' : '-'
-  return `${sign}${formatCompact(Math.abs(amount))}`
-}
 
 type ComparisonRowProps = {
   label: string

--- a/frontend/src/components/stats/UnifiedSummaryCards.tsx
+++ b/frontend/src/components/stats/UnifiedSummaryCards.tsx
@@ -6,6 +6,7 @@
 
 import { Link } from 'react-router-dom'
 import { FEATURES } from '../../config/features'
+import { formatAmount, formatCompact } from '../../utils/format'
 
 type UnifiedSummaryCardsProps = {
   incomeTotal: number
@@ -13,19 +14,6 @@ type UnifiedSummaryCardsProps = {
   /** 저축성 지출 합계 (적금, 투자, 보험 등). 제공 시 저축률 = savingsTotal / incomeTotal */
   savingsTotal?: number
   netWorth?: number | null
-}
-
-function formatAmount(amount: number): string {
-  const abs = Math.abs(amount)
-  const formatted = `₩${abs.toLocaleString('ko-KR')}`
-  return amount < 0 ? `-${formatted}` : formatted
-}
-
-function formatLargeAmount(amount: number): string {
-  const abs = Math.abs(amount)
-  if (abs >= 100000000) return `${(amount / 100000000).toFixed(1)}억원`
-  if (abs >= 10000) return `${Math.round(amount / 10000).toLocaleString()}만원`
-  return formatAmount(amount)
 }
 
 export default function UnifiedSummaryCards({
@@ -61,7 +49,7 @@ export default function UnifiedSummaryCards({
       {FEATURES.assets && netWorth != null && (
         <Link to="/assets" className={`col-span-2 lg:col-span-4 bg-gradient-to-br from-warm-50 to-warm-100 border border-[var(--border-default)] ${cardBase} text-center`}>
           <p className="text-sm text-[var(--text-tertiary)] mb-0.5">순자산</p>
-          <p className="text-xl sm:text-2xl font-bold text-[var(--text-primary)]">{formatLargeAmount(netWorth)}</p>
+          <p className="text-xl sm:text-2xl font-bold text-[var(--text-primary)]">{formatCompact(netWorth)}</p>
         </Link>
       )}
 

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -66,6 +66,27 @@ export function formatKoreanAmount(amount: number): string {
   return `${prefix}${man.toLocaleString('ko-KR')}만원`
 }
 
+/**
+ * 금액을 부호 없이 축약 포맷 (억/만원/원)
+ * 예: 50_000 → "5만원", 200_000_000 → "2.0억원", 9_000 → "9,000원"
+ * 음수는 절댓값으로 처리 — 부호 표시가 필요하면 formatChange 사용
+ */
+export function formatCompact(amount: number): string {
+  const abs = Math.abs(amount)
+  if (abs >= 100_000_000) return `${(abs / 100_000_000).toFixed(1)}억원`
+  if (abs >= 10_000) return `${Math.round(abs / 10_000).toLocaleString()}만원`
+  return `${abs.toLocaleString('ko-KR')}원`
+}
+
+/**
+ * 금액 변화를 +/- 부호 포함 축약 포맷
+ * 예: 50_000 → "+5만원", -30_000 → "-3만원"
+ */
+export function formatChange(amount: number): string {
+  const sign = amount >= 0 ? '+' : '-'
+  return `${sign}${formatCompact(Math.abs(amount))}`
+}
+
 /** 금액을 축약 형태로 포맷 (캘린더 셀용) */
 export function formatCompactAmount(amount: number): string {
   if (amount < 10000) {


### PR DESCRIPTION
## 변경 사항

여러 컴포넌트에 중복 정의된 포맷 함수를 `utils/format.ts`로 중앙화합니다.

### Task 14 — format.ts에 공통 함수 추가
- `formatCompact(amount)` — 부호 없이 축약 포맷 (5만원, 2.0억원, 9,000원)
- `formatChange(amount)` — +/- 부호 포함 축약 포맷 (+5만원, -3만원)

### Task 15 — UnifiedSummaryCards 중복 제거
- 로컬 `formatAmount`/`formatLargeAmount` 제거 → `utils/format` import

### Task 16 — MonthlyComparison 중복 제거
- 로컬 `formatCompact`/`formatChange` 제거 → `utils/format` import

### Task 17 — HeroSummary 정리
- `formatWon` 내부를 `formatCompact` 위임 (₩0 엣지케이스 래퍼 유지)
- `formatCompactAmount` import 제거 (미사용)

## 테스트
- 1691개 테스트 통과
- 동작 변화 없음 (순수 리팩토링)