### PR TITLE
fix: 더보기 서브페이지 헤더/탭 컬러 통일

### DIFF
--- a/frontend/src/pages/BudgetManager.tsx
+++ b/frontend/src/pages/BudgetManager.tsx
@@ -356,6 +356,7 @@ export default function BudgetManager() {
         <button onClick={() => goBack()} className="p-2.5 -ml-2.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors">
           <ArrowLeft className="w-5 h-5 text-[var(--text-secondary)]" />
         </button>
+        <PiggyBank className="w-5 h-5 text-grape-500 flex-shrink-0" />
         <h1 className="text-lg font-semibold text-[var(--text-primary)]">예산 관리</h1>
       </div>
 

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -294,7 +294,7 @@ export default function CategoryManager() {
           onClick={() => setActiveTab('income')}
           className={`flex-1 py-2.5 rounded-xl text-sm font-medium transition-colors ${
             activeTab === 'income'
-              ? 'bg-leaf-500/20 text-leaf-600'
+              ? 'bg-grape-500/20 text-grape-600'
               : 'bg-[var(--surface-elevated)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]'
           }`}
         >


### PR DESCRIPTION
## Summary
- BudgetManager 정상 상태 헤더에 PiggyBank 아이콘 추가 (에러 상태와 일치)
- CategoryManager 수입 탭 선택 컬러 leaf → grape (4페이지 탭 컬러 통일)

## Test plan
- [ ] BudgetManager 헤더에 아이콘이 표시되는지 확인
- [ ] CategoryManager 지출/수입 탭 전환 시 선택 컬러가 동일한지 확인
- [ ] 다크모드에서 탭 선택 상태 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)