### PR TITLE
fix: 더보기 삭제 플로우 통일 + 행 액션 아이콘화 + 결제수단 목록 구조

### DIFF
--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -196,6 +196,7 @@ export default function CategoryManager() {
       fetchCategories()
     } catch {
       addToast('error', TOAST.DELETE_FAILED)
+      setDeleteTarget(null)  // 에러 시에도 확인 행 닫기
     }
   }
 
@@ -469,7 +470,7 @@ export default function CategoryManager() {
                           수정
                         </button>
                         <button
-                          onClick={() => setDeleteTarget(category.id)}
+                          onClick={() => { setDeleteTarget(category.id); setEditingId(null) }}
                           className="px-3 py-1.5 text-sm font-medium text-rose-600 bg-rose-500/10 rounded-lg hover:bg-rose-500/20 transition-colors"
                         >
                           삭제
@@ -478,43 +479,34 @@ export default function CategoryManager() {
                     )}
                   </div>
                 )}
+                {/* 삭제 인라인 확인 */}
+                {deleteTarget === category.id && (
+                  <div className="px-3 py-2.5 bg-rose-500/5 flex items-center justify-between border-t border-rose-200/50">
+                    <p className="text-sm text-[var(--text-secondary)]">
+                      삭제하면 연결된 거래가 '분류 안 됨'이 돼요
+                    </p>
+                    <div className="flex gap-2 flex-shrink-0">
+                      <button
+                        onClick={() => setDeleteTarget(null)}
+                        className="px-3 py-1.5 text-xs rounded-lg bg-[var(--surface-hover)] text-[var(--text-secondary)]"
+                      >
+                        취소
+                      </button>
+                      <button
+                        onClick={() => handleDelete(category.id)}
+                        className="px-3 py-1.5 text-xs rounded-lg bg-rose-500 text-white font-medium"
+                      >
+                        삭제
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
             )
           })}
         </div>
       )}
 
-      {/* 삭제 확인 모달 */}
-      {deleteTarget !== null && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-[var(--surface-card)] rounded-2xl shadow-xl max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-2">
-              카테고리 삭제
-            </h3>
-            <p className="text-[var(--text-secondary)] mb-6">
-              정말로 이 카테고리를 삭제하시겠습니까?
-              <br />
-              <span className="text-sm text-rose-600">
-                이 카테고리에 연결된 지출 내역은 '분류 안 됨' 상태가 됩니다.
-              </span>
-            </p>
-            <div className="flex gap-3 justify-end">
-              <button
-                onClick={() => setDeleteTarget(null)}
-                className="px-4 py-2 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-lg hover:bg-[var(--surface-hover)] transition-colors"
-              >
-                취소
-              </button>
-              <button
-                onClick={() => handleDelete(deleteTarget)}
-                className="px-4 py-2 text-sm font-medium text-white bg-rose-600 rounded-lg hover:bg-rose-700 transition-colors"
-              >
-                삭제
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useState } from 'react'
 import { useGoBack } from '../hooks/useGoBack'
-import { ArrowLeft, Lock, Plus, Tags } from 'lucide-react'
+import { ArrowLeft, Lock, Pencil, Plus, Tags, Trash2 } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { TOAST } from '../constants/toastMessages'
 import { categoryApi } from '../api/categories'
@@ -462,18 +462,20 @@ export default function CategoryManager() {
                         기본
                       </span>
                     ) : (
-                      <div className="flex gap-2 flex-shrink-0">
+                      <div className="flex items-center gap-1 flex-shrink-0">
                         <button
                           onClick={() => startEdit(category)}
-                          className="px-3 py-1.5 text-sm font-medium text-grape-600 bg-grape-500/10 rounded-lg hover:bg-grape-500/20 transition-colors"
+                          aria-label="수정"
+                          className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-grape-600"
                         >
-                          수정
+                          <Pencil className="w-4 h-4" />
                         </button>
                         <button
                           onClick={() => { setDeleteTarget(category.id); setEditingId(null) }}
-                          className="px-3 py-1.5 text-sm font-medium text-rose-600 bg-rose-500/10 rounded-lg hover:bg-rose-500/20 transition-colors"
+                          aria-label="삭제"
+                          className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-rose-500"
                         >
-                          삭제
+                          <Trash2 className="w-4 h-4" />
                         </button>
                       </div>
                     )}

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -54,6 +54,9 @@ export default function PaymentMethodManager() {
   const [showDetailSettings, setShowDetailSettings] = useState(false)
   const [saving, setSaving] = useState(false)
 
+  // 삭제 확인 상태
+  const [deletingId, setDeletingId] = useState<number | null>(null)
+
   // 편집 폼 상태
   const [editingMethod, setEditingMethod] = useState<PaymentMethod | null>(null)
   const [editName, setEditName] = useState('')
@@ -358,94 +361,116 @@ export default function PaymentMethodManager() {
             <div
               key={method.id}
               data-testid={`payment-method-${method.id}`}
-              className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-4"
+              className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 overflow-hidden"
             >
-              {/* 편집 중인 항목 */}
-              {editingMethod?.id === method.id ? (
-                <div className="space-y-3">
-                  <input
-                    type="text"
-                    value={editName}
-                    onChange={(e) => setEditName(e.target.value)}
-                    className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                    placeholder="결제수단 이름"
-                  />
-                  <select
-                    value={editType}
-                    onChange={(e) => setEditType(e.target.value as PaymentMethodType)}
-                    className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm"
-                  >
-                    {TYPE_OPTIONS.map((opt) => (
-                      <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                  </select>
-                  <div className="relative">
-                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] text-sm">₩</span>
+              <div className="p-4">
+                {/* 편집 중인 항목 */}
+                {editingMethod?.id === method.id ? (
+                  <div className="space-y-3">
                     <input
-                      type="number"
-                      inputMode="numeric"
-                      value={editTarget}
-                      onChange={(e) => setEditTarget(e.target.value)}
-                      placeholder="월 실적 목표 (선택)"
-                      min="0"
-                      className="w-full pl-7 pr-3 py-2 border border-[var(--input-border)] rounded-xl text-sm"
+                      type="text"
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                      placeholder="결제수단 이름"
                     />
+                    <select
+                      value={editType}
+                      onChange={(e) => setEditType(e.target.value as PaymentMethodType)}
+                      className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm"
+                    >
+                      {TYPE_OPTIONS.map((opt) => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                    <div className="relative">
+                      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] text-sm">₩</span>
+                      <input
+                        type="number"
+                        inputMode="numeric"
+                        value={editTarget}
+                        onChange={(e) => setEditTarget(e.target.value)}
+                        placeholder="월 실적 목표 (선택)"
+                        min="0"
+                        className="w-full pl-7 pr-3 py-2 border border-[var(--input-border)] rounded-xl text-sm"
+                      />
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => setEditingMethod(null)}
+                        className="flex-1 px-3 py-2 text-sm text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-xl"
+                      >
+                        취소
+                      </button>
+                      <button
+                        onClick={handleSaveEdit}
+                        disabled={editSaving || !editName.trim()}
+                        className="flex-1 px-3 py-2 text-sm font-medium text-white bg-grape-600 rounded-xl hover:bg-grape-700 disabled:opacity-50"
+                      >
+                        {editSaving ? '저장 중...' : '저장'}
+                      </button>
+                    </div>
                   </div>
-                  <div className="flex gap-2">
+                ) : (
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      {/* 순서 변경 버튼 */}
+                      <div className="flex flex-col gap-0.5">
+                        <button
+                          onClick={() => handleReorder(index, 'up')}
+                          disabled={index === 0}
+                          aria-label="위로"
+                          className="p-0.5 rounded hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-30"
+                        >
+                          <ChevronUp className="w-4 h-4 text-[var(--text-muted)]" />
+                        </button>
+                        <button
+                          onClick={() => handleReorder(index, 'down')}
+                          disabled={index === methods.filter((m) => !m.is_system).length - 1}
+                          aria-label="아래로"
+                          className="p-0.5 rounded hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-30"
+                        >
+                          <ChevronDown className="w-4 h-4 text-[var(--text-muted)]" />
+                        </button>
+                      </div>
+                      <span className="text-sm font-semibold text-[var(--text-primary)]">{method.name}</span>
+                      <span className="text-xs text-[var(--text-muted)]">{TYPE_LABELS[method.type]}</span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <button
+                        onClick={() => handleStartEdit(method)}
+                        aria-label="편집"
+                        className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-grape-600"
+                      >
+                        <Pencil className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => setDeletingId(method.id)}
+                        aria-label="삭제"
+                        className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-rose-500"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+              {/* 삭제 인라인 확인 */}
+              {deletingId === method.id && (
+                <div className="px-4 py-2.5 bg-rose-500/5 flex items-center justify-between border-t border-rose-200/50">
+                  <p className="text-sm text-[var(--text-secondary)]">'{method.name}'을 삭제할까요?</p>
+                  <div className="flex gap-2 flex-shrink-0">
                     <button
-                      onClick={() => setEditingMethod(null)}
-                      className="flex-1 px-3 py-2 text-sm text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-xl"
+                      onClick={() => setDeletingId(null)}
+                      className="px-3 py-1.5 text-xs rounded-lg bg-[var(--surface-hover)] text-[var(--text-secondary)]"
                     >
                       취소
                     </button>
                     <button
-                      onClick={handleSaveEdit}
-                      disabled={editSaving || !editName.trim()}
-                      className="flex-1 px-3 py-2 text-sm font-medium text-white bg-grape-600 rounded-xl hover:bg-grape-700 disabled:opacity-50"
+                      onClick={async () => { await handleDelete(method); setDeletingId(null) }}
+                      className="px-3 py-1.5 text-xs rounded-lg bg-rose-500 text-white font-medium"
                     >
-                      {editSaving ? '저장 중...' : '저장'}
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    {/* 순서 변경 버튼 */}
-                    <div className="flex flex-col gap-0.5">
-                      <button
-                        onClick={() => handleReorder(index, 'up')}
-                        disabled={index === 0}
-                        aria-label="위로"
-                        className="p-0.5 rounded hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-30"
-                      >
-                        <ChevronUp className="w-4 h-4 text-[var(--text-muted)]" />
-                      </button>
-                      <button
-                        onClick={() => handleReorder(index, 'down')}
-                        disabled={index === methods.filter((m) => !m.is_system).length - 1}
-                        aria-label="아래로"
-                        className="p-0.5 rounded hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-30"
-                      >
-                        <ChevronDown className="w-4 h-4 text-[var(--text-muted)]" />
-                      </button>
-                    </div>
-                    <span className="text-sm font-semibold text-[var(--text-primary)]">{method.name}</span>
-                    <span className="text-xs text-[var(--text-muted)]">{TYPE_LABELS[method.type]}</span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <button
-                      onClick={() => handleStartEdit(method)}
-                      aria-label="편집"
-                      className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-grape-600"
-                    >
-                      <Pencil className="w-4 h-4" />
-                    </button>
-                    <button
-                      onClick={() => handleDelete(method)}
-                      aria-label="삭제"
-                      className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-rose-500"
-                    >
-                      <Trash2 className="w-4 h-4" />
+                      삭제
                     </button>
                   </div>
                 </div>

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -292,63 +292,65 @@ export default function PaymentMethodManager() {
           {/* 내 결제수단 목록 — 일반 모드 */}
           <div>
             <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-3">내 결제수단</h2>
-            <div className="space-y-3">
-              {methods.map((method) => {
-                const usage = usageMap.get(method.id)
-                const hasTarget = method.monthly_target && method.monthly_target > 0
-                const remaining = hasTarget && usage ? method.monthly_target! - usage.spent_amount : null
-                const isAchieved = hasTarget && usage && (usage.usage_percentage ?? 0) >= 100
+            <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 overflow-hidden">
+              <div className="divide-y divide-[var(--border-subtle)]">
+                {methods.map((method) => {
+                  const usage = usageMap.get(method.id)
+                  const hasTarget = method.monthly_target && method.monthly_target > 0
+                  const remaining = hasTarget && usage ? method.monthly_target! - usage.spent_amount : null
+                  const isAchieved = hasTarget && usage && (usage.usage_percentage ?? 0) >= 100
 
-                return (
-                  <div
-                    key={method.id}
-                    data-testid={`payment-method-${method.id}`}
-                    className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-4"
-                  >
-                    <div className="flex items-center justify-between mb-1">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-semibold text-[var(--text-primary)]">{method.name}</span>
-                        <span className="text-xs text-[var(--text-muted)]">{TYPE_LABELS[method.type]}</span>
-                        {method.is_system && (
-                          <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[var(--surface-elevated)] text-[var(--text-muted)]">기본</span>
-                        )}
+                  return (
+                    <div
+                      key={method.id}
+                      data-testid={`payment-method-${method.id}`}
+                      className="p-4"
+                    >
+                      <div className="flex items-center justify-between mb-1">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-semibold text-[var(--text-primary)]">{method.name}</span>
+                          <span className="text-xs text-[var(--text-muted)]">{TYPE_LABELS[method.type]}</span>
+                          {method.is_system && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-[var(--surface-elevated)] text-[var(--text-muted)]">기본</span>
+                          )}
+                        </div>
                       </div>
+
+                      {/* 실적 프로그레스 바: monthly_target이 있는 경우만 */}
+                      {hasTarget && usage && (
+                        <div className="mt-2" data-testid={`usage-bar-${method.id}`}>
+                          <div className="flex justify-between items-center mb-1">
+                            <span className="text-xs text-[var(--text-secondary)] tabular-nums">
+                              {formatAmount(usage.spent_amount)} / {formatAmount(method.monthly_target!)}
+                            </span>
+                            <span className={`text-xs tabular-nums ${isAchieved ? 'text-leaf-600 font-medium' : 'text-[var(--text-muted)]'}`}>
+                              {isAchieved ? '실적 달성' : `잔여 ${formatAmount(usage.remaining ?? 0)}`}
+                            </span>
+                          </div>
+                          <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
+                            <div
+                              className={`h-1.5 rounded-full transition-all ${
+                                isAchieved
+                                  ? 'bg-leaf-500'
+                                  : (usage.usage_percentage ?? 0) >= 80
+                                    ? 'bg-grape-500'
+                                    : 'bg-grape-400'
+                              }`}
+                              style={{ width: `${Math.min(usage.usage_percentage ?? 0, 100)}%` }}
+                            />
+                          </div>
+                          {/* 실적 넛지 */}
+                          {!isAchieved && remaining !== null && remaining > 0 && (
+                            <p className="text-xs text-grape-600 mt-1 tabular-nums" data-testid={`nudge-${method.id}`}>
+                              실적까지 {formatAmount(remaining)} 남음
+                            </p>
+                          )}
+                        </div>
+                      )}
                     </div>
-
-                    {/* 실적 프로그레스 바: monthly_target이 있는 경우만 */}
-                    {hasTarget && usage && (
-                      <div className="mt-2" data-testid={`usage-bar-${method.id}`}>
-                        <div className="flex justify-between items-center mb-1">
-                          <span className="text-xs text-[var(--text-secondary)] tabular-nums">
-                            {formatAmount(usage.spent_amount)} / {formatAmount(method.monthly_target!)}
-                          </span>
-                          <span className={`text-xs tabular-nums ${isAchieved ? 'text-leaf-600 font-medium' : 'text-[var(--text-muted)]'}`}>
-                            {isAchieved ? '실적 달성' : `잔여 ${formatAmount(usage.remaining ?? 0)}`}
-                          </span>
-                        </div>
-                        <div className="w-full bg-[var(--border-default)] rounded-full h-1.5 overflow-hidden">
-                          <div
-                            className={`h-1.5 rounded-full transition-all ${
-                              isAchieved
-                                ? 'bg-leaf-500'
-                                : (usage.usage_percentage ?? 0) >= 80
-                                  ? 'bg-grape-500'
-                                  : 'bg-grape-400'
-                            }`}
-                            style={{ width: `${Math.min(usage.usage_percentage ?? 0, 100)}%` }}
-                          />
-                        </div>
-                        {/* 실적 넛지 */}
-                        {!isAchieved && remaining !== null && remaining > 0 && (
-                          <p className="text-xs text-grape-600 mt-1 tabular-nums" data-testid={`nudge-${method.id}`}>
-                            실적까지 {formatAmount(remaining)} 남음
-                          </p>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )
-              })}
+                  )
+                })}
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/__tests__/CategoryManager.test.tsx
+++ b/frontend/src/pages/__tests__/CategoryManager.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 import CategoryManager from '../CategoryManager'
@@ -304,7 +304,7 @@ describe('CategoryManager', () => {
   })
 
   describe('카테고리 삭제', () => {
-    it('삭제 버튼을 클릭하면 삭제 확인 모달이 표시된다', async () => {
+    it('삭제 버튼을 클릭하면 인라인 확인 행이 표시된다', async () => {
       const user = userEvent.setup()
       renderCategoryManager()
 
@@ -316,12 +316,11 @@ describe('CategoryManager', () => {
       await user.click(deleteButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('카테고리 삭제')).toBeInTheDocument()
-        expect(screen.getByText(/정말로 이 카테고리를 삭제하시겠습니까/i)).toBeInTheDocument()
+        expect(screen.getByText(/삭제하면 연결된 거래가/i)).toBeInTheDocument()
       })
     })
 
-    it('삭제 모달에서 취소를 클릭하면 모달이 닫힌다', async () => {
+    it('인라인 확인 행에서 취소를 클릭하면 닫힌다', async () => {
       const user = userEvent.setup()
       renderCategoryManager()
 
@@ -333,19 +332,18 @@ describe('CategoryManager', () => {
       await user.click(deleteButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('카테고리 삭제')).toBeInTheDocument()
+        expect(screen.getByText(/삭제하면 연결된 거래가/i)).toBeInTheDocument()
       })
 
-      const cancelButtons = screen.getAllByRole('button', { name: '취소' })
-      const modalCancelButton = cancelButtons[cancelButtons.length - 1]
-      await user.click(modalCancelButton)
+      const confirmRow = screen.getByText(/삭제하면 연결된 거래가/i).closest('div')!
+      await user.click(within(confirmRow).getByRole('button', { name: '취소' }))
 
       await waitFor(() => {
-        expect(screen.queryByText('카테고리 삭제')).not.toBeInTheDocument()
+        expect(screen.queryByText(/삭제하면 연결된 거래가/i)).not.toBeInTheDocument()
       })
     })
 
-    it('삭제 모달에서 삭제를 클릭하면 카테고리를 삭제한다', async () => {
+    it('인라인 확인 행에서 삭제를 클릭하면 카테고리를 삭제한다', async () => {
       const user = userEvent.setup()
 
       renderCategoryManager()
@@ -358,12 +356,11 @@ describe('CategoryManager', () => {
       await user.click(deleteButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('카테고리 삭제')).toBeInTheDocument()
+        expect(screen.getByText(/삭제하면 연결된 거래가/i)).toBeInTheDocument()
       })
 
-      const modalDeleteButtons = screen.getAllByRole('button', { name: '삭제' })
-      const modalDeleteButton = modalDeleteButtons[modalDeleteButtons.length - 1]
-      await user.click(modalDeleteButton)
+      const confirmRow = screen.getByText(/삭제하면 연결된 거래가/i).closest('div')!
+      await user.click(within(confirmRow).getByRole('button', { name: '삭제' }))
 
       await waitFor(() => {
         expect(mockAddToast).toHaveBeenCalledWith('success', '카테고리를 삭제했어요')
@@ -437,12 +434,11 @@ describe('CategoryManager', () => {
       await user.click(deleteButtons[0])
 
       await waitFor(() => {
-        expect(screen.getByText('카테고리 삭제')).toBeInTheDocument()
+        expect(screen.getByText(/삭제하면 연결된 거래가/i)).toBeInTheDocument()
       })
 
-      const modalDeleteButtons = screen.getAllByRole('button', { name: '삭제' })
-      const modalDeleteButton = modalDeleteButtons[modalDeleteButtons.length - 1]
-      await user.click(modalDeleteButton)
+      const confirmRow = screen.getByText(/삭제하면 연결된 거래가/i).closest('div')!
+      await user.click(within(confirmRow).getByRole('button', { name: '삭제' }))
 
       await waitFor(() => {
         expect(mockAddToast).toHaveBeenCalledWith('error', '삭제에 실패했어요')

--- a/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
+++ b/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
@@ -226,6 +226,14 @@ describe('PaymentMethodManager', () => {
       const deleteBtn = within(userItem).getByRole('button', { name: '삭제' })
       await user.click(deleteBtn)
 
+      // 인라인 확인 행이 노출되면 확인 삭제 버튼 클릭
+      await waitFor(() => {
+        expect(within(userItem).getByText(/을 삭제할까요/i)).toBeInTheDocument()
+      })
+
+      const confirmRow = within(userItem).getByText(/을 삭제할까요/i).closest('div')!
+      await user.click(within(confirmRow).getByRole('button', { name: '삭제' }))
+
       await waitFor(() => {
         expect(mockAddToast).toHaveBeenCalledWith('success', expect.stringContaining('삭제'))
       })


### PR DESCRIPTION
## Summary
**삭제 플로우 통일 (PR2)**
- CategoryManager 전체화면 모달 → RecurringList 패턴의 인라인 행 확인으로 교체
- PaymentMethodManager 편집 모드에서 확인 없이 바로 삭제되던 문제 수정 → 인라인 행 확인 추가
- 4개 페이지 삭제 플로우가 인라인 행 패턴으로 통일됨

**행 액션 아이콘화 + 목록 구조 통일 (PR3)**
- CategoryManager 행 액션 '수정'·'삭제' 텍스트 버튼 → Pencil/Trash2 아이콘 버튼 (PaymentMethodManager 편집 모드 패턴과 통일)
- PaymentMethodManager 일반 모드 결제수단 목록을 개별 카드 → 단일 카드+divide-y 구조로 변경 (카테고리·예산·정기거래와 통일)

## Test plan
- [ ] CategoryManager: 삭제 아이콘 → 인라인 확인 행 노출 확인
- [ ] CategoryManager: 확인 행 '취소' → 확인 행 사라짐, 삭제 안 됨
- [ ] CategoryManager: 확인 행 '삭제' → 카테고리 삭제됨
- [ ] CategoryManager: 수정 아이콘 → 편집 폼 활성화 확인
- [ ] PaymentMethodManager: 편집 모드에서 삭제 아이콘 → 인라인 확인 행 노출
- [ ] PaymentMethodManager: 확인 행 '삭제' → 결제수단 삭제됨
- [ ] PaymentMethodManager: 결제수단 목록이 단일 컨테이너로 묶이는지 확인
- [ ] 다크모드에서 결제수단 목록 divide-y 구분선 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)