### PR TITLE
fix: PaymentMethodManager 추가 UX 개선 — 헤더 + 버튼, 인라인 상단 폼

### DIFF
--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -51,7 +51,6 @@ export default function PaymentMethodManager() {
   const [formName, setFormName] = useState('')
   const [formType, setFormType] = useState<PaymentMethodType>('credit_card')
   const [formTarget, setFormTarget] = useState('')
-  const [showDetailSettings, setShowDetailSettings] = useState(false)
   const [saving, setSaving] = useState(false)
 
   // 삭제 확인 상태
@@ -142,7 +141,6 @@ export default function PaymentMethodManager() {
       setFormName('')
       setFormType('credit_card')
       setFormTarget('')
-      setShowDetailSettings(false)
       await fetchData()
     } catch {
       addToast('error', TOAST.SAVE_FAILED)
@@ -227,14 +225,25 @@ export default function PaymentMethodManager() {
             <h1 className="text-lg font-semibold text-[var(--text-primary)]">결제수단</h1>
           </div>
         </div>
-        {!loading && methods.length > 0 && (
-          <button
-            onClick={() => setEditMode(!editMode)}
-            className="text-sm font-medium text-grape-600 hover:text-grape-700 transition-colors"
-          >
-            {editMode ? '완료' : '편집'}
-          </button>
-        )}
+        <div className="flex items-center gap-3">
+          {!loading && !editMode && !showForm && (
+            <button
+              onClick={() => setShowForm(true)}
+              aria-label="결제수단 추가"
+              className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-grape-600"
+            >
+              <Plus className="w-5 h-5" />
+            </button>
+          )}
+          {!loading && methods.length > 0 && (
+            <button
+              onClick={() => { setEditMode(!editMode); setShowForm(false) }}
+              className="text-sm font-medium text-grape-600 hover:text-grape-700 transition-colors"
+            >
+              {editMode ? '완료' : '편집'}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* 로딩 */}
@@ -499,53 +508,40 @@ export default function PaymentMethodManager() {
             />
           </div>
 
-          {/* 상세 설정 (접힘) */}
-          <button
-            type="button"
-            onClick={() => setShowDetailSettings(!showDetailSettings)}
-            className="text-sm text-grape-600 hover:text-grape-700 font-medium"
-          >
-            {showDetailSettings ? '상세 설정 접기' : '상세 설정'}
-          </button>
+          <div>
+            <label htmlFor="pm-type" className="block text-xs text-[var(--text-tertiary)] mb-1">유형</label>
+            <select
+              id="pm-type"
+              value={formType}
+              onChange={(e) => setFormType(e.target.value as PaymentMethodType)}
+              className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+            >
+              {TYPE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
 
-          {showDetailSettings && (
-            <>
-              <div>
-                <label htmlFor="pm-type" className="block text-xs text-[var(--text-tertiary)] mb-1">유형</label>
-                <select
-                  id="pm-type"
-                  value={formType}
-                  onChange={(e) => setFormType(e.target.value as PaymentMethodType)}
-                  className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                >
-                  {TYPE_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label htmlFor="pm-target" className="block text-xs text-[var(--text-tertiary)] mb-1">월 실적 목표</label>
-                <div className="relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] text-sm">₩</span>
-                  <input
-                    id="pm-target"
-                    type="number"
-                    inputMode="numeric"
-                    value={formTarget}
-                    onChange={(e) => setFormTarget(e.target.value)}
-                    placeholder="0"
-                    min="0"
-                    className="w-full pl-7 pr-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-                  />
-                </div>
-              </div>
-            </>
-          )}
+          <div>
+            <label htmlFor="pm-target" className="block text-xs text-[var(--text-tertiary)] mb-1">월 실적 목표</label>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] text-sm">₩</span>
+              <input
+                id="pm-target"
+                type="number"
+                inputMode="numeric"
+                value={formTarget}
+                onChange={(e) => setFormTarget(e.target.value)}
+                placeholder="0"
+                min="0"
+                className="w-full pl-7 pr-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+              />
+            </div>
+          </div>
 
           <div className="flex gap-3">
             <button
-              onClick={() => { setShowForm(false); setFormName(''); setFormTarget(''); setShowDetailSettings(false) }}
+              onClick={() => { setShowForm(false); setFormName(''); setFormType('credit_card'); setFormTarget('') }}
               className="flex-1 px-4 py-2.5 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-xl hover:bg-[var(--surface-hover)] transition-colors"
             >
               취소
@@ -561,16 +557,6 @@ export default function PaymentMethodManager() {
         </div>
       )}
 
-      {/* 추가 버튼 (하단) */}
-      {!loading && !showForm && (
-        <button
-          onClick={() => setShowForm(true)}
-          className="w-full flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium text-grape-600 bg-[var(--surface-card)] border border-dashed border-grape-300 rounded-2xl hover:bg-[var(--surface-hover)] transition-colors"
-        >
-          <Plus className="w-4 h-4" />
-          결제수단 추가
-        </button>
-      )}
     </div>
   )
 }

--- a/frontend/src/pages/PaymentMethodManager.tsx
+++ b/frontend/src/pages/PaymentMethodManager.tsx
@@ -261,7 +261,7 @@ export default function PaymentMethodManager() {
       )}
 
       {/* 빈 상태 */}
-      {!loading && methods.length === 0 && (
+      {!loading && methods.length === 0 && !showForm && (
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60">
           <EmptyState
             variant="section"
@@ -272,33 +272,104 @@ export default function PaymentMethodManager() {
         </div>
       )}
 
-      {/* 주 결제수단 + 목록 */}
-      {!loading && methods.length > 0 && !editMode && (
+      {/* 주 결제수단 + 인라인 추가 폼 + 목록 */}
+      {!loading && !editMode && (
         <div className="space-y-4">
-          {/* 주 결제수단 드롭다운 */}
-          <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-5">
-            <label htmlFor="primary-payment" className="block text-sm font-semibold text-[var(--text-primary)] mb-2">
-              주 결제수단
-            </label>
-            <select
-              id="primary-payment"
-              value={defaultMethodId}
-              onChange={(e) => handlePrimaryChange(e.target.value)}
-              className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-            >
-              <option value="">없음</option>
-              {methods.map((m) => (
-                <option key={m.id} value={m.id}>{m.name}</option>
-              ))}
-            </select>
-            {defaultMethodId && (
-              <p className="mt-2 text-xs text-[var(--text-muted)]">
-                입력 시 자동으로 이 결제수단이 선택돼요
-              </p>
-            )}
-          </div>
+          {/* 주 결제수단 드롭다운 — 결제수단 있을 때만 */}
+          {methods.length > 0 && (
+            <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-5">
+              <label htmlFor="primary-payment" className="block text-sm font-semibold text-[var(--text-primary)] mb-2">
+                주 결제수단
+              </label>
+              <select
+                id="primary-payment"
+                value={defaultMethodId}
+                onChange={(e) => handlePrimaryChange(e.target.value)}
+                className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+              >
+                <option value="">없음</option>
+                {methods.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name}</option>
+                ))}
+              </select>
+              {defaultMethodId && (
+                <p className="mt-2 text-xs text-[var(--text-muted)]">
+                  입력 시 자동으로 이 결제수단이 선택돼요
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* 인라인 추가 폼 — 주 결제수단 드롭다운 아래, 목록 위 */}
+          {showForm && (
+            <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-4 space-y-3">
+              <h2 className="text-sm font-semibold text-[var(--text-primary)]">새 결제수단</h2>
+
+              <div>
+                <label htmlFor="pm-name" className="block text-xs text-[var(--text-tertiary)] mb-1">이름 <span className="text-rose-500">*</span></label>
+                <input
+                  id="pm-name"
+                  type="text"
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  placeholder="결제수단 이름"
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus
+                  className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="pm-type" className="block text-xs text-[var(--text-tertiary)] mb-1">유형</label>
+                <select
+                  id="pm-type"
+                  value={formType}
+                  onChange={(e) => setFormType(e.target.value as PaymentMethodType)}
+                  className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                >
+                  {TYPE_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label htmlFor="pm-target" className="block text-xs text-[var(--text-tertiary)] mb-1">월 실적 목표</label>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] text-sm">₩</span>
+                  <input
+                    id="pm-target"
+                    type="number"
+                    inputMode="numeric"
+                    value={formTarget}
+                    onChange={(e) => setFormTarget(e.target.value)}
+                    placeholder="0"
+                    min="0"
+                    className="w-full pl-7 pr-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
+                  />
+                </div>
+              </div>
+
+              <div className="flex gap-3">
+                <button
+                  onClick={() => { setShowForm(false); setFormName(''); setFormType('credit_card'); setFormTarget('') }}
+                  className="flex-1 px-4 py-2.5 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-xl transition-colors"
+                >
+                  취소
+                </button>
+                <button
+                  onClick={handleCreate}
+                  disabled={saving || !formName.trim()}
+                  className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-grape-600 rounded-xl hover:bg-grape-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {saving ? '저장 중...' : '저장'}
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* 내 결제수단 목록 — 일반 모드 */}
+          {methods.length > 0 && (
           <div>
             <h2 className="text-sm font-semibold text-[var(--text-primary)] mb-3">내 결제수단</h2>
             <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 overflow-hidden">
@@ -362,6 +433,7 @@ export default function PaymentMethodManager() {
               </div>
             </div>
           </div>
+          )}
         </div>
       )}
 
@@ -488,72 +560,6 @@ export default function PaymentMethodManager() {
               )}
             </div>
           ))}
-        </div>
-      )}
-
-      {/* 추가 폼 */}
-      {showForm && (
-        <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 p-5 space-y-4">
-          <h2 className="text-sm font-semibold text-[var(--text-primary)]">새 결제수단</h2>
-
-          <div>
-            <label htmlFor="pm-name" className="block text-xs text-[var(--text-tertiary)] mb-1">이름 <span className="text-rose-500">*</span></label>
-            <input
-              id="pm-name"
-              type="text"
-              value={formName}
-              onChange={(e) => setFormName(e.target.value)}
-              placeholder="결제수단 이름"
-              className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-            />
-          </div>
-
-          <div>
-            <label htmlFor="pm-type" className="block text-xs text-[var(--text-tertiary)] mb-1">유형</label>
-            <select
-              id="pm-type"
-              value={formType}
-              onChange={(e) => setFormType(e.target.value as PaymentMethodType)}
-              className="w-full px-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-            >
-              {TYPE_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
-          </div>
-
-          <div>
-            <label htmlFor="pm-target" className="block text-xs text-[var(--text-tertiary)] mb-1">월 실적 목표</label>
-            <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] text-sm">₩</span>
-              <input
-                id="pm-target"
-                type="number"
-                inputMode="numeric"
-                value={formTarget}
-                onChange={(e) => setFormTarget(e.target.value)}
-                placeholder="0"
-                min="0"
-                className="w-full pl-7 pr-3 py-2 border border-[var(--input-border)] rounded-xl text-sm focus:ring-2 focus:ring-grape-500/30 focus:border-grape-500"
-              />
-            </div>
-          </div>
-
-          <div className="flex gap-3">
-            <button
-              onClick={() => { setShowForm(false); setFormName(''); setFormType('credit_card'); setFormTarget('') }}
-              className="flex-1 px-4 py-2.5 text-sm font-medium text-[var(--text-secondary)] bg-[var(--surface-hover)] rounded-xl hover:bg-[var(--surface-hover)] transition-colors"
-            >
-              취소
-            </button>
-            <button
-              onClick={handleCreate}
-              disabled={saving || !formName.trim()}
-              className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-grape-600 rounded-xl hover:bg-grape-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {saving ? '저장 중...' : '저장'}
-            </button>
-          </div>
         </div>
       )}
 

--- a/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
+++ b/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
@@ -344,6 +344,25 @@ describe('PaymentMethodManager', () => {
       // '상세 설정' 토글 버튼 없음
       expect(screen.queryByText('상세 설정')).not.toBeInTheDocument()
     })
+
+    it('폼이 열린 상태에서 + 버튼이 숨겨진다', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: '결제수단 추가' })).toBeInTheDocument()
+      )
+      await user.click(screen.getByRole('button', { name: '결제수단 추가' }))
+      expect(screen.queryByRole('button', { name: '결제수단 추가' })).not.toBeInTheDocument()
+    })
+
+    it('하단 dashed 추가 버튼이 없다', async () => {
+      renderPage()
+      await waitFor(() =>
+        expect(screen.getByTestId('payment-method-1')).toBeInTheDocument()
+      )
+      // 아이콘 버튼이므로 텍스트 "결제수단 추가"는 0개여야 함
+      expect(screen.queryAllByText('결제수단 추가')).toHaveLength(0)
+    })
   })
 
   describe('로딩 스켈레톤', () => {
@@ -390,15 +409,11 @@ describe('PaymentMethodManager', () => {
       expect(screen.getByText('결제수단을 추가하면 지출 입력 시 태깅할 수 있어요')).toBeInTheDocument()
     })
 
-    it('빈 상태에서 결제수단 추가 버튼 클릭 시 추가 폼이 열린다', async () => {
+    it('빈 상태에서 EmptyState 추가 버튼 클릭 시 추가 폼이 열린다', async () => {
       const user = userEvent.setup()
       server.use(
-        http.get('/api/payment-methods', () => {
-          return HttpResponse.json([])
-        }),
-        http.get('/api/payment-methods/stats/monthly', () => {
-          return HttpResponse.json([])
-        })
+        http.get('/api/payment-methods', () => HttpResponse.json([])),
+        http.get('/api/payment-methods/stats/monthly', () => HttpResponse.json([]))
       )
 
       renderPage()
@@ -407,12 +422,10 @@ describe('PaymentMethodManager', () => {
         expect(screen.getByText('등록된 결제수단이 없습니다')).toBeInTheDocument()
       })
 
-      // EmptyState action 버튼은 여러 "결제수단 추가" 버튼 중 첫 번째 (EmptyState 내부)
-      const addButtons = screen.getAllByRole('button', { name: '결제수단 추가' })
-      expect(addButtons.length).toBeGreaterThanOrEqual(1)
-      await user.click(addButtons[0])
+      // EmptyState action 버튼은 텍스트 "결제수단 추가"를 직접 렌더링 (헤더 + 버튼은 아이콘만)
+      const textBtn = screen.getByText('결제수단 추가')
+      await user.click(textBtn)
 
-      // 추가 폼이 열린다
       expect(screen.getByPlaceholderText('결제수단 이름')).toBeInTheDocument()
     })
   })

--- a/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
+++ b/frontend/src/pages/__tests__/PaymentMethodManager.test.tsx
@@ -77,11 +77,20 @@ describe('PaymentMethodManager', () => {
       })
     })
 
-    it('결제수단 추가 버튼을 표시한다', async () => {
+    it('헤더 우상단에 + 버튼을 표시한다', async () => {
       renderPage()
       await waitFor(() => {
-        expect(screen.getByText('결제수단 추가')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: '결제수단 추가' })).toBeInTheDocument()
       })
+    })
+
+    it('편집 모드에서는 + 버튼이 숨겨진다', async () => {
+      const user = userEvent.setup()
+      renderPage()
+      await waitFor(() => expect(screen.getByText('편집')).toBeInTheDocument())
+      await user.click(screen.getByText('편집'))
+      await waitFor(() => expect(screen.getByText('완료')).toBeInTheDocument())
+      expect(screen.queryByRole('button', { name: '결제수단 추가' })).not.toBeInTheDocument()
     })
   })
 
@@ -302,11 +311,10 @@ describe('PaymentMethodManager', () => {
       const user = userEvent.setup()
       renderPage()
 
-      await waitFor(() => {
-        expect(screen.getByText('결제수단 추가')).toBeInTheDocument()
-      })
-
-      await user.click(screen.getByText('결제수단 추가'))
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: '결제수단 추가' })).toBeInTheDocument()
+      )
+      await user.click(screen.getByRole('button', { name: '결제수단 추가' }))
 
       const nameInput = screen.getByPlaceholderText('결제수단 이름')
       expect(nameInput).toBeInTheDocument()
@@ -319,28 +327,22 @@ describe('PaymentMethodManager', () => {
       })
     })
 
-    it('추가 폼에서 이름만 필수이고 타입/목표는 접힘 상태이다', async () => {
+    it('+ 버튼 클릭 시 이름/유형/월목표 3개 필드가 모두 표시된다', async () => {
       const user = userEvent.setup()
       renderPage()
 
-      await waitFor(() => {
-        expect(screen.getByText('결제수단 추가')).toBeInTheDocument()
-      })
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: '결제수단 추가' })).toBeInTheDocument()
+      )
+      await user.click(screen.getByRole('button', { name: '결제수단 추가' }))
 
-      await user.click(screen.getByText('결제수단 추가'))
-
-      // 이름 필드는 보이고
+      // 3개 필드 즉시 표시 (접힘 없음)
       expect(screen.getByPlaceholderText('결제수단 이름')).toBeInTheDocument()
-
-      // 유형/목표 필드는 접힘 (안 보임)
-      expect(screen.queryByLabelText('유형')).not.toBeInTheDocument()
-      expect(screen.queryByLabelText('월 실적 목표')).not.toBeInTheDocument()
-
-      // 상세 설정 클릭 시 펼침
-      await user.click(screen.getByText('상세 설정'))
-
       expect(screen.getByLabelText('유형')).toBeInTheDocument()
       expect(screen.getByLabelText('월 실적 목표')).toBeInTheDocument()
+
+      // '상세 설정' 토글 버튼 없음
+      expect(screen.queryByText('상세 설정')).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## Summary
- 결제수단 추가 버튼을 하단 dashed 버튼 → 헤더 우상단 + 아이콘 버튼으로 이동 (카테고리/정기거래 패턴 통일)
- 추가 폼 위치를 페이지 하단 → 주 결제수단 드롭다운 아래, 목록 위 인라인으로 이동
- showDetailSettings 접힘 로직 제거 → 이름/유형/월목표 3개 필드 항상 표시

## Test plan
- [ ] 헤더 우상단 + 버튼 표시 확인
- [ ] + 클릭 시 드롭다운 아래, 목록 위에 폼 나타남 확인
- [ ] 폼 열린 상태에서 + 버튼 숨겨짐 확인
- [ ] 편집 모드에서 + 버튼 숨겨짐 확인
- [ ] 3개 필드 즉시 표시 확인
- [ ] 취소/저장 동작 확인
- [ ] 빈 상태에서 EmptyState 버튼 클릭 → 폼 표시 확인
- [ ] 다크모드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)