### PR TITLE
fix: 카테고리 순서변경 버그 수정 — 커스텀 sort_order 100 기준 분리

### DIFF
--- a/backend/alembic/versions/a0b1c2d3e4f5_fix_custom_category_sort_order_base.py
+++ b/backend/alembic/versions/a0b1c2d3e4f5_fix_custom_category_sort_order_base.py
@@ -1,0 +1,38 @@
+"""커스텀 카테고리 sort_order 기준값 조정 (100 이상)
+
+시스템 카테고리는 sort_order 1~18로 고정되어 있음.
+기존 커스텀 카테고리 중 sort_order < 100인 항목을 100으로 올려
+sort_order DESC 정렬 시 커스텀이 시스템보다 항상 앞에 오도록 보장.
+
+Revision ID: a0b1c2d3e4f5
+Revises: z9a0b1c2d3e4
+Create Date: 2026-04-27
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a0b1c2d3e4f5"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "z9a0b1c2d3e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # 시스템 카테고리(user_id=NULL, household_id=NULL)를 제외한 커스텀 카테고리만 업데이트
+    conn.execute(
+        sa.text("""
+            UPDATE categories
+            SET sort_order = 100
+            WHERE sort_order < 100
+              AND NOT (user_id IS NULL AND household_id IS NULL)
+        """)
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/b1c2d3e4f5a6_fix_custom_category_sort_order_base.py
+++ b/backend/alembic/versions/b1c2d3e4f5a6_fix_custom_category_sort_order_base.py
@@ -4,8 +4,8 @@
 기존 커스텀 카테고리 중 sort_order < 100인 항목을 100으로 올려
 sort_order DESC 정렬 시 커스텀이 시스템보다 항상 앞에 오도록 보장.
 
-Revision ID: a0b1c2d3e4f5
-Revises: z9a0b1c2d3e4
+Revision ID: b1c2d3e4f5a6
+Revises: 9789df318393
 Create Date: 2026-04-27
 """
 
@@ -15,8 +15,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "a0b1c2d3e4f5"  # pragma: allowlist secret
-down_revision: str | Sequence[str] | None = "z9a0b1c2d3e4"
+revision: str = "b1c2d3e4f5a6"  # pragma: allowlist secret
+down_revision: str | Sequence[str] | None = "9789df318393"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/app/api/categories.py
+++ b/backend/app/api/categories.py
@@ -130,7 +130,8 @@ async def reorder_categories(
     total_custom = len(custom_ids_in_order)
     for idx, cat_id in enumerate(custom_ids_in_order):
         # 커스텀 카테고리는 sort_order 100 이상 유지 (시스템 카테고리 최대값 18과 분리)
-        accessible[cat_id].sort_order = max(100, 100 + total_custom - idx)  # type: ignore[index, assignment]
+        new_order: int = max(100, 100 + total_custom - idx)
+        accessible[cat_id].sort_order = new_order  # type: ignore[index, assignment]
 
     await db.commit()
 

--- a/backend/app/api/categories.py
+++ b/backend/app/api/categories.py
@@ -86,8 +86,8 @@ async def create_category(
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="이미 존재하는 카테고리입니다")
 
-    # 가구 소속이 필수이므로 항상 가계 카테고리로 생성
-    db_category = Category(**category.model_dump(), household_id=household_id, user_id=None)
+    # 가구 소속이 필수이므로 항상 가계 카테고리로 생성, sort_order 100으로 초기화 (시스템 카테고리 최대값 18보다 높음)
+    db_category = Category(**category.model_dump(), household_id=household_id, user_id=None, sort_order=100)
 
     db.add(db_category)
     await db.commit()
@@ -121,12 +121,16 @@ async def reorder_categories(
                 detail=f"카테고리 ID {cat_id}에 접근할 수 없습니다",
             )
 
-    total = len(request.category_ids)
-    for idx, cat_id in enumerate(request.category_ids):
-        cat = accessible[cat_id]  # type: ignore[index]
-        # 시스템 카테고리(user_id=None, household_id=None)는 순서 변경 불가
-        if cat.user_id is not None or cat.household_id is not None:
-            cat.sort_order = total - idx  # type: ignore[assignment]
+    # 커스텀 카테고리만 sort_order 재배정 (시스템은 고정, 100 이상 유지)
+    custom_ids_in_order = [
+        cat_id
+        for cat_id in request.category_ids
+        if accessible[cat_id].user_id is not None or accessible[cat_id].household_id is not None  # type: ignore[index]
+    ]
+    total_custom = len(custom_ids_in_order)
+    for idx, cat_id in enumerate(custom_ids_in_order):
+        # 커스텀 카테고리는 sort_order 100 이상 유지 (시스템 카테고리 최대값 18과 분리)
+        accessible[cat_id].sort_order = max(100, 100 + total_custom - idx)  # type: ignore[index, assignment]
 
     await db.commit()
 

--- a/frontend/src/pages/CategoryManager.tsx
+++ b/frontend/src/pages/CategoryManager.tsx
@@ -36,14 +36,14 @@ function CategoryManagerSkeleton() {
 function MoveButtons({
   name,
   index,
-  total,
+  customCount,
   reordering,
   isSystem,
   onMove,
 }: {
   name: string
   index: number
-  total: number
+  customCount: number
   reordering: boolean
   isSystem: boolean
   onMove: (direction: 'up' | 'down') => void
@@ -62,7 +62,7 @@ function MoveButtons({
       </button>
       <button
         onClick={() => onMove('down')}
-        disabled={index === total - 1 || reordering || isSystem}
+        disabled={index >= customCount - 1 || reordering || isSystem}
         className="p-0.5 text-[var(--text-muted)] hover:text-grape-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
         aria-label={`${name} 아래로 이동`}
       >
@@ -206,6 +206,8 @@ export default function CategoryManager() {
   const handleMove = async (index: number, direction: 'up' | 'down') => {
     const targetIndex = direction === 'up' ? index - 1 : index + 1
     if (targetIndex < 0 || targetIndex >= categories.length) return
+    // 시스템 카테고리 영역으로 이동 불가
+    if (categories[targetIndex].is_system) return
 
     // 낙관적 업데이트
     const newCategories = [...categories]
@@ -377,6 +379,8 @@ export default function CategoryManager() {
         <div className="bg-[var(--surface-card)] rounded-2xl shadow-sm border border-[var(--border-default)]/60 divide-y divide-[var(--border-subtle)]">
           {categories.map((category, index) => {
             const isEditing = editingId === category.id
+            const customCount = categories.filter(c => !c.is_system).length
+            const isFirstSystem = category.is_system && (index === 0 || !categories[index - 1].is_system)
             return (
               <div key={category.id} className={isEditing ? 'bg-[var(--surface-elevated)]' : undefined}>
                 {isEditing ? (
@@ -433,52 +437,59 @@ export default function CategoryManager() {
                   </div>
                 ) : (
                   /* 일반 카드 행 */
-                  <div className="flex items-center gap-3 px-4 py-4">
-                    <MoveButtons
-                      name={category.name}
-                      index={index}
-                      total={categories.length}
-                      reordering={reordering}
-                      isSystem={category.is_system}
-                      onMove={(dir) => handleMove(index, dir)}
-                    />
-                    <span className="text-xl flex-shrink-0 w-8 text-center">{category.emoji}</span>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-1.5">
-                        <span className="font-medium text-[var(--text-primary)]">{category.name}</span>
-                        {category.is_savings && (
-                          <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium text-leaf-600 bg-leaf-500/15 rounded">
-                            저축
-                          </span>
-                        )}
-                      </div>
-                      {category.description && (
-                        <p className="text-xs text-[var(--text-secondary)] mt-0.5">{category.description}</p>
-                      )}
-                    </div>
-                    {category.is_system ? (
-                      <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-[var(--text-tertiary)] bg-[var(--surface-elevated)] rounded-md flex-shrink-0">
-                        <Lock className="w-3 h-3" aria-hidden="true" />
-                        기본
-                      </span>
-                    ) : (
-                      <div className="flex items-center gap-1 flex-shrink-0">
-                        <button
-                          onClick={() => startEdit(category)}
-                          aria-label="수정"
-                          className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-grape-600"
-                        >
-                          <Pencil className="w-4 h-4" />
-                        </button>
-                        <button
-                          onClick={() => { setDeleteTarget(category.id); setEditingId(null) }}
-                          aria-label="삭제"
-                          className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-rose-500"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
+                  <div>
+                    {isFirstSystem && customCount > 0 && (
+                      <div className="px-4 py-2 text-xs font-medium text-[var(--text-tertiary)] bg-[var(--surface-elevated)] border-b border-[var(--border-subtle)]">
+                        기본 제공
                       </div>
                     )}
+                    <div className="flex items-center gap-3 px-4 py-4">
+                      <MoveButtons
+                        name={category.name}
+                        index={index}
+                        customCount={customCount}
+                        reordering={reordering}
+                        isSystem={category.is_system}
+                        onMove={(dir) => handleMove(index, dir)}
+                      />
+                      <span className="text-xl flex-shrink-0 w-8 text-center">{category.emoji}</span>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-1.5">
+                          <span className="font-medium text-[var(--text-primary)]">{category.name}</span>
+                          {category.is_savings && (
+                            <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium text-leaf-600 bg-leaf-500/15 rounded">
+                              저축
+                            </span>
+                          )}
+                        </div>
+                        {category.description && (
+                          <p className="text-xs text-[var(--text-secondary)] mt-0.5">{category.description}</p>
+                        )}
+                      </div>
+                      {category.is_system ? (
+                        <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium text-[var(--text-tertiary)] bg-[var(--surface-elevated)] rounded-md flex-shrink-0">
+                          <Lock className="w-3 h-3" aria-hidden="true" />
+                          기본
+                        </span>
+                      ) : (
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                          <button
+                            onClick={() => startEdit(category)}
+                            aria-label="수정"
+                            className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-grape-600"
+                          >
+                            <Pencil className="w-4 h-4" />
+                          </button>
+                          <button
+                            onClick={() => { setDeleteTarget(category.id); setEditingId(null) }}
+                            aria-label="삭제"
+                            className="p-1.5 rounded-lg hover:bg-[var(--surface-hover)] transition-colors text-[var(--text-muted)] hover:text-rose-500"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </button>
+                        </div>
+                      )}
+                    </div>
                   </div>
                 )}
                 {/* 삭제 인라인 확인 */}


### PR DESCRIPTION
## Summary

- 커스텀 카테고리 sort_order가 시스템 카테고리(1~18)와 겹쳐 순서 변경 시 3~4개씩 점프하고 내려가지 않던 버그 수정
- 커스텀 카테고리 sort_order를 100 이상으로 분리하여 `sort_order DESC` 정렬만으로 커스텀이 항상 시스템보다 앞에 위치하도록 보장
- 시스템 카테고리 직전에 "기본 제공" 구분선 헤더 표시

## Changes

**Backend**
- `reorder` API: 커스텀 카테고리만 sort_order 재배정, `max(100, ...)` 가드로 100 미만 방지
- `create` API: 신규 커스텀 카테고리 sort_order 초기값 0 → 100
- 마이그레이션 추가: 기존 커스텀 카테고리 중 sort_order < 100인 항목 → 100으로 일괄 조정

**Frontend**
- `MoveButtons` DOWN 버튼: 마지막 커스텀 카테고리에서 비활성화 (시스템 영역 진입 차단)
- `handleMove`: 타겟이 시스템 카테고리면 early return 안전 가드 추가
- 시스템 카테고리 첫 항목 앞에 "기본 제공" 구분선 헤더 표시

## Test plan

- [ ] 커스텀 카테고리 UP 클릭 시 1칸씩만 이동하는지 확인
- [ ] 커스텀 카테고리 DOWN 클릭 시 1칸씩 이동, 마지막 커스텀에서 비활성화 확인
- [ ] 시스템 카테고리 아래로 밀려나지 않는지 확인
- [ ] "기본 제공" 구분선이 커스텀↔시스템 경계에 표시되는지 확인
- [ ] 커스텀 카테고리가 없을 때 구분선이 표시되지 않는지 확인
- [ ] 백엔드 테스트 32개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)